### PR TITLE
Support for editing .gpg-id via GUI with public keyring list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TODO
 2. ~~multi-lingual~~
 3. ~~filtering and autocomplete~~
 4. ~~edit, insert~~
-5. gpg-id management (per-folder)
+5. ~~gpg-id management (per-folder)~~
 
 Instalation
 -----------

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -13,11 +13,13 @@ namespace Ui {
 class MainWindow;
 }
 
+struct UserInfo;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
 
-enum actionType { GPG, GIT, EDIT, DELETE };
+enum actionType { GPG, GIT, EDIT, DELETE, GPG_INTERNAL };
 
 public:
     explicit MainWindow(QWidget *parent = 0);
@@ -43,6 +45,7 @@ private slots:
     void on_addButton_clicked();
     void on_deleteButton_clicked();
     void on_editButton_clicked();
+    void on_usersButton_clicked();
     void messageAvailable(QString message);
 
 private:
@@ -78,6 +81,8 @@ private:
     void setPassword(QString, bool);
     void normalizePassStore();
     QSettings &getSettings();
+    QList<UserInfo> listKeys(QString keystring = "");
+    QString getRecipientString(QString for_file, QString separator = " ");
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -77,6 +77,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QToolButton" name="usersButton">
+            <property name="text">
+             <string>U</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item row="2" column="1">

--- a/qtpass.pro
+++ b/qtpass.pro
@@ -21,16 +21,19 @@ SOURCES   += main.cpp\
              dialog.cpp \
              storemodel.cpp \
              singleapplication.cpp \
-    util.cpp
+             util.cpp \
+             usersdialog.cpp
 
 HEADERS   += mainwindow.h \
              dialog.h \
              storemodel.h \
              singleapplication.h \
-    util.h
+             util.h \
+             usersdialog.h
 
 FORMS     += mainwindow.ui \
-             dialog.ui
+             dialog.ui \
+             usersdialog.ui
 
 TRANSLATIONS    +=  localization/localization_nl_NL.ts \
                     localization/localization_de_DE.ts \

--- a/usersdialog.cpp
+++ b/usersdialog.cpp
@@ -1,0 +1,41 @@
+#include "usersdialog.h"
+#include "ui_usersdialog.h"
+
+UsersDialog::UsersDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::UsersDialog)
+{
+    ui->setupUi(this);
+    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(ui->listWidget, SIGNAL(itemChanged(QListWidgetItem *)), this, SLOT(itemChange(QListWidgetItem *)));
+}
+
+UsersDialog::~UsersDialog()
+{
+    delete ui;
+}
+
+Q_DECLARE_METATYPE(UserInfo *)
+
+void UsersDialog::itemChange(QListWidgetItem *item)
+{
+    if (!item) return;
+    UserInfo *info = item->data(Qt::UserRole).value<UserInfo *>();
+    if (!info) return;
+    info->enabled = item->checkState() == Qt::Checked;
+}
+
+void UsersDialog::setUsers(QList<UserInfo> *users)
+{
+    ui->listWidget->clear();
+    if (users) {
+        for (QList<UserInfo>::iterator it = users->begin(); it != users->end(); ++it) {
+            UserInfo &user(*it);
+            QListWidgetItem *item = new QListWidgetItem(user.name + "\n" + user.key_id, ui->listWidget);
+            item->setCheckState(user.enabled ? Qt::Checked : Qt::Unchecked);
+            item->setData(Qt::UserRole, QVariant::fromValue(&user));
+            ui->listWidget->addItem(item);
+        }
+    }
+}

--- a/usersdialog.h
+++ b/usersdialog.h
@@ -1,0 +1,38 @@
+#ifndef USERSDIALOG_H
+#define USERSDIALOG_H
+
+//#include <QAbstractListModel>
+#include <QDialog>
+#include <QList>
+#include <QStandardItemModel>
+
+namespace Ui {
+class UsersDialog;
+}
+
+class QListWidgetItem;
+
+struct UserInfo {
+    UserInfo() : enabled(false) {}
+    QString name;
+    QString key_id;
+    bool enabled;
+};
+
+class UsersDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit UsersDialog(QWidget *parent = 0);
+    ~UsersDialog();
+    void setUsers(QList<UserInfo> *);
+
+private slots:
+    void itemChange(QListWidgetItem *);
+
+private:
+    Ui::UsersDialog *ui;
+};
+
+#endif // USERSDIALOG_H

--- a/usersdialog.ui
+++ b/usersdialog.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UsersDialog</class>
+ <widget class="QDialog" name="UsersDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>599</width>
+    <height>583</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Read access users</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Select which users should be able to decrypt passwords stored in this folder.
+Note: Existing files will not be modified and retain the old permissions until you edit them.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidget">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This is not really a pull request since it does nothing useful.
But i don't know a better idea to make sure people are aware, and give a chance to comment early on.
I've been working a bit on making a user-interface to edit the .gpg-id file.
What I managed so far is creating a dialog with a list of all public keys and checkboxes for them.
The next step would be to read in an existing .gpg-id, set checkboxes according to that, add extra entries if a public key for a user is not available and after the dialog exits writing a new .gpg-id file.
There is a bit of a user-interface issue though, as the current UI makes it look as it is editable per-file, plus I'd prefer to not add code to change all existing files.