### PR TITLE
Start process only after we finished disabling UI elements etc.

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -257,10 +257,10 @@ void MainWindow::executeWrapper(QString app, QString args, QString input) {
         env << "GNUPGHOME=" + absHome.path();
         process->setEnvironment(env);
     }
-    process->start('"' + app + "\" " + args);
     ui->textBrowser->clear();
     ui->textBrowser->setTextColor(Qt::black);
     enableUiElements(false);
+    process->start('"' + app + "\" " + args);
     if (!input.isEmpty()) {
         process->write(input.toUtf8());
     }


### PR DESCRIPTION
Otherwise we have a race condition, e.g. if the binary does not
exist the error signal might be triggered before we disabled
the UI element.
This would mean that we end up with UI elements being permanently
disabled.

Signed-off-by: Reimar Döffinger <Reimar.Doeffinger@gmx.de>