### PR TITLE
Add Makefile with commands to make a binary release zip file.

### DIFF
--- a/release-zip.mak
+++ b/release-zip.mak
@@ -1,0 +1,10 @@
+# Note: this assumes Qt with release and debug config was used
+
+VERSION=v0.1-testing
+
+qtpass-${VERSION}-win.zip: qtpass.exe LICENSE README.md
+	7z a -mx=9 $@ $^
+
+qtpass.exe: release/qtpass.exe
+	strip $^
+	if [ -n "$(SIGNKEY)" ] ; then osslsigncode sign -ts http://www.startssl.com/timestamp -certs $(SIGNKEY).crt -key $(SIGNKEY).key -in $^ -out $@ ; chmod +x $@ ; else cp $^ $@ ; fi


### PR DESCRIPTION
Windows-only for now since I never figured out a good way to make binary release of Linux GUI programs.
It also has optional support for code-signing which I use for the moment.
Support for signing via GPG in addition or instead might make sense as well.