### PR TITLE
Mention qt5-default package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Installation
 On most systems all you need is:
 `qmake && make && make install`
 
-On MacOsX:
+On Mac OS X:
 `qmake && make && macdeployqt QtPass.app`
 * Currently seems to only work with MacGPG2
 
 On some systems there are issues with qt4 and qt5 being installed at the same time.
-An easy fix is regenerating the Makefile with: `make clean && rm Makefile && qmake -qt5` or if qmake is ambiguous: `qmake-qt5`
+An easy fix is regenerating the Makefile with: `make clean && rm Makefile && qmake -qt5` or if qmake is ambiguous: `qmake-qt5`. On Debian (and derivatives such as Ubuntu), the `qt5-default` package will install the required build tools.
 
 Further reading
 ---------------


### PR DESCRIPTION
Explicitly reference qt5-default package for installing build tools.