### PR TITLE
[WIP] Call 'pass git init' on creation of password-store when useGit

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -495,7 +495,7 @@ void Dialog::wizard()
     }
 
     QStringList names = mainWindow->getSecretKeys();
-    //qDebug() << names;
+    qDebug() << names;
     if (QFile(gpg).exists() && names.empty()) {
         KeygenDialog d(this);
         if (!d.exec()) {
@@ -511,11 +511,17 @@ void Dialog::wizard()
             tr("Would you like to create a password-store at %1?").arg(passStore),
             QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
                 QDir().mkdir(passStore);
+
+                if(useGit()) {
+                    mainWindow->executePassGitInit();
+                }
                 mainWindow->userDialog(passStore);
         }
     }
 
     if(!QFile(passStore + ".gpg-id").exists()){
+        qDebug() << ".gpg-id file does not exist";
+
         if (!clean) {
             criticalMessage(tr("Password store not initialised"),
                 tr("The folder %1 doesn't seem to be a password store or is not yet initialised.").arg(passStore));
@@ -528,6 +534,7 @@ void Dialog::wizard()
             passStore = ui->storePath->text();
         }
         if (!QFile(passStore + ".gpg-id").exists()) {
+            qDebug() << ".gpg-id file still does not exist :/";
             // appears not to be store
             // init yes / no ?
             mainWindow->userDialog(passStore);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -68,9 +68,12 @@ MainWindow::~MainWindow()
 QSettings &MainWindow::getSettings() {
     if (!settings) {
         QString portable_ini = QCoreApplication::applicationDirPath() + QDir::separator() + "qtpass.ini";
+        qDebug() << "Settings file: " + portable_ini;
         if (QFile(portable_ini).exists()) {
+            qDebug() << "Settings file exists, loading it in";
             settings.reset(new QSettings(portable_ini, QSettings::IniFormat));
         } else {
+            qDebug() << "Settings file does not exist, use defaults";
             settings.reset(new QSettings("IJHack", "QtPass"));
         }
     }
@@ -543,6 +546,11 @@ void MainWindow::executePass(QString args, QString input) {
     executeWrapper(passExecutable, args, input);
 }
 
+void MainWindow::executePassGitInit() {
+    qDebug() << "Pass git init called";
+    executePass("git init");
+}
+
 /**
  * @brief MainWindow::executeWrapper
  * @param app
@@ -564,8 +572,9 @@ void MainWindow::executeWrapper(QString app, QString args, QString input) {
         item.app = app;
         item.args = args;
         item.input = input;
+
         execQueue->enqueue(item);
-        //qDebug() << item.app + "," + item.args + "," + item.input;
+        qDebug() << item.app + "," + item.args + "," + item.input;
         return;
     }
     wrapperRunning = true;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -47,6 +47,7 @@ public:
     void generateKeyPair(QString, QDialog *);
     void userDialog(QString = "");
     QString generatePassword();
+    void executePassGitInit();
 
 protected:
     void closeEvent(QCloseEvent *event);


### PR DESCRIPTION
Whenever the `~/.password-store` does not exist, the wizard is ran to initialize it.
Depending on either already existing configuration or default configuration, `useGit` can be true.
If so, initialize the directory with git as well, else the `git commit` of the `.gpg-id` file will fail.

TODO:
- [ ] Remove qDebug statements in squash
- [ ] Make `executePassGitInit` configurable with either `pass` or `git+gpg`
- [ ] Seem to have problems with a 'command already running?'

PS. I'm not familiar with either QtPass' codebase, the language, or Qt in general, so all feedback is very welcome.