### PR TITLE
Issue 86 clear panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ qtpass.xcodeproj/xcuserdata/*
 qtpass.xcworkspace/xcuserdata/*
 .DS_Store
 .qmake.stash
-
+*.o

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ qtpass.xcworkspace/xcuserdata/*
 .DS_Store
 .qmake.stash
 *.o
+moc_*.cpp
+qrc_*.cpp
+ui_*.h

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -256,6 +256,20 @@ void Dialog::on_checkBoxClipboard_clicked()
 }
 
 /**
+ * @brief Dialog::on_checkBoxAutoclearPanel_clicked
+ */
+void Dialog::on_checkBoxAutoclearPanel_clicked()
+{
+    if (ui->checkBoxAutoclearPanel->isChecked()) {
+        ui->spinBoxAutoclearPanelSeconds->setEnabled(true);
+        ui->labelPanelSeconds->setEnabled(true);
+    } else {
+        ui->spinBoxAutoclearPanelSeconds->setEnabled(false);
+        ui->labelPanelSeconds->setEnabled(false);
+    }
+}
+
+/**
  * @brief Dialog::useClipboard
  */
 void Dialog::useClipboard(bool useClipboard)
@@ -281,6 +295,25 @@ void Dialog::useAutoclear(bool useAutoclear)
 void Dialog::setAutoclear(int seconds)
 {
     ui->spinBoxAutoclearSeconds->setValue(seconds);
+}
+
+/**
+ * @brief Dialog::useAutoclearPanel
+ * @param useAutoclearPanel
+ */
+void Dialog::useAutoclearPanel(bool useAutoclearPanel)
+{
+    ui->checkBoxAutoclearPanel->setChecked(useAutoclearPanel);
+    on_checkBoxAutoclearPanel_clicked();
+}
+
+/**
+ * @brief Dialog::setAutoclearPanel
+ * @param seconds
+ */
+void Dialog::setAutoclearPanel(int seconds)
+{
+    ui->spinBoxAutoclearPanelSeconds->setValue(seconds);
 }
 
 /**
@@ -316,6 +349,24 @@ int Dialog::getAutoclear()
 void Dialog::on_checkBoxAutoclear_clicked()
 {
     on_checkBoxClipboard_clicked();
+}
+
+/**
+ * @brief Dialog::useAutoclearPanel
+ * @return
+ */
+bool Dialog::useAutoclearPanel()
+{
+    return ui->checkBoxAutoclearPanel->isChecked();
+}
+
+/**
+ * @brief Dialog::getAutoclearPanel
+ * @return
+ */
+int Dialog::getAutoclearPanel()
+{
+    return ui->spinBoxAutoclearPanelSeconds->value();
 }
 
 /**

--- a/dialog.h
+++ b/dialog.h
@@ -30,6 +30,8 @@ public:
     void useClipboard(bool);
     void useAutoclear(bool);
     void setAutoclear(int);
+    void useAutoclearPanel(bool);
+    void setAutoclearPanel(int);
     void hidePassword(bool);
     void hideContent(bool);
     void addGPGId(bool);
@@ -42,6 +44,8 @@ public:
     bool useClipboard();
     bool useAutoclear();
     int getAutoclear();
+    bool useAutoclearPanel();
+    int getAutoclearPanel();
     bool hidePassword();
     bool hideContent();
     bool addGPGId();
@@ -79,6 +83,7 @@ private slots:
     void on_toolButtonStore_clicked();
     void on_checkBoxClipboard_clicked();
     void on_checkBoxAutoclear_clicked();
+    void on_checkBoxAutoclearPanel_clicked();
     void on_addButton_clicked();
     void on_deleteButton_clicked();
     void on_checkBoxUseTrayIcon_clicked();

--- a/dialog.ui
+++ b/dialog.ui
@@ -273,6 +273,34 @@
            </item>
           </layout>
          </item>
+         <item row="1" column="2">
+          <widget class="QCheckBox" name="checkBoxAutoclearPanel">
+           <property name="text">
+            <string>Autoclear panel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QSpinBox" name="spinBoxAutoclearPanelSeconds">
+             <property name="minimum">
+              <number>5</number>
+             </property>
+             <property name="value">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="labelPanelSeconds">
+             <property name="text">
+              <string>Seconds</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item row="1" column="0">
           <widget class="QCheckBox" name="checkBoxHidePassword">
            <property name="text">
@@ -519,6 +547,8 @@
   <tabstop>checkBoxClipboard</tabstop>
   <tabstop>checkBoxAutoclear</tabstop>
   <tabstop>spinBoxAutoclearSeconds</tabstop>
+  <tabstop>checkBoxAutoclearPanel</tabstop>
+  <tabstop>spinBoxAutoclearPanelSeconds</tabstop>
   <tabstop>checkBoxHidePassword</tabstop>
   <tabstop>checkBoxHideContent</tabstop>
   <tabstop>checkBoxUseGit</tabstop>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -166,6 +166,8 @@ bool MainWindow::checkConfig() {
     useClipboard = (settings.value("useClipboard") == "true");
     useAutoclear = (settings.value("useAutoclear") == "true");
     autoclearSeconds = settings.value("autoclearSeconds").toInt();
+    useAutoclearPanel = (settings.value("useAutoclearPanel") == "true");
+    autoclearPanelSeconds = settings.value("autoclearPanelSeconds").toInt();
     hidePassword = (settings.value("hidePassword") == "true");
     hideContent = (settings.value("hideContent") == "true");
     addGPGId = (settings.value("addGPGId") != "false");
@@ -227,6 +229,7 @@ bool MainWindow::checkConfig() {
         if (freshStart && startMinimized) {
             // since we are still in constructor, can't directly hide
             QTimer::singleShot(10*autoclearSeconds, this, SLOT(hide()));
+            QTimer::singleShot(10*autoclearPanelSeconds, this, SLOT(hide()));
         }
     } else if (!useTrayIcon && tray != NULL) {
         destroyTrayIcon();
@@ -239,6 +242,9 @@ bool MainWindow::checkConfig() {
         qDebug() << "assuming fresh install";
         if (autoclearSeconds < 5) {
             autoclearSeconds = 10;
+        }
+        if (autoclearPanelSeconds < 5) {
+            autoclearPanelSeconds = 10;
         }
         passwordLength = 16;
         passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890~!@#$%^&*()_-+={}[]|:;<>,.?";
@@ -350,6 +356,8 @@ void MainWindow::config() {
     d->useClipboard(useClipboard);
     d->useAutoclear(useAutoclear);
     d->setAutoclear(autoclearSeconds);
+    d->useAutoclearPanel(useAutoclearPanel);
+    d->setAutoclearPanel(autoclearPanelSeconds);
     d->hidePassword(hidePassword);
     d->hideContent(hideContent);
     d->addGPGId(addGPGId);
@@ -376,6 +384,8 @@ void MainWindow::config() {
             useClipboard = d->useClipboard();
             useAutoclear = d->useAutoclear();
             autoclearSeconds = d->getAutoclear();
+            useAutoclearPanel = d->useAutoclearPanel();
+            autoclearPanelSeconds = d->getAutoclearPanel();
             hidePassword = d->hidePassword();
             hideContent = d->hideContent();
             addGPGId = d->addGPGId();
@@ -401,6 +411,8 @@ void MainWindow::config() {
             settings.setValue("useClipboard", useClipboard ? "true" : "false");
             settings.setValue("useAutoclear", useAutoclear ? "true" : "false");
             settings.setValue("autoclearSeconds", autoclearSeconds);
+            settings.setValue("useAutoclearPanel", useAutoclearPanel ? "true" : "false");
+            settings.setValue("autoclearPanelSeconds", autoclearPanelSeconds);
             settings.setValue("hidePassword", hidePassword ? "true" : "false");
             settings.setValue("hideContent", hideContent ? "true" : "false");
             settings.setValue("addGPGId", addGPGId ? "true" : "false");
@@ -616,6 +628,9 @@ void MainWindow::readyRead(bool finished = false) {
                       clippedPass = tokens[0];
                       QTimer::singleShot(1000*autoclearSeconds, this, SLOT(clearClipboard()));
                 }
+                if (useAutoclearPanel) {
+                      QTimer::singleShot(1000*autoclearPanelSeconds, this, SLOT(clearPanel()));
+                }
                 if (hidePassword) {
                     //tokens.pop_front();
                     tokens[0] = "***" + tr("Password hidden") + "***";
@@ -665,6 +680,15 @@ void MainWindow::clearClipboard()
     } else {
         ui->statusBar->showMessage(tr("Clipboard not cleared"), 3000);
     }
+}
+
+/**
+ * @brief MainWindow::clearPanel
+ */
+void MainWindow::clearPanel()
+{
+    QString output = "***" + tr("Password and Content hidden") + "***";
+    ui->textBrowser->setHtml(output);
 }
 
 /**

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -61,6 +61,7 @@ private slots:
     void processFinished(int, QProcess::ExitStatus);
     void processError(QProcess::ProcessError);
     void clearClipboard();
+    void clearPanel();
     void on_lineEdit_textChanged(const QString &arg1);
     void on_lineEdit_returnPressed();
     void on_clearButton_clicked();
@@ -85,10 +86,12 @@ private:
     bool usePass;
     bool useClipboard;
     bool useAutoclear;
+    bool useAutoclearPanel;
     bool hidePassword;
     bool hideContent;
     bool addGPGId;
     int autoclearSeconds;
+    int autoclearPanelSeconds;
     QString passStore;
     QString passExecutable;
     QString gitExecutable;


### PR DESCRIPTION
Implemented a "Autoclear panel" checkbox and corresponding duration control in the Config tab.

![qtpass_config](https://cloud.githubusercontent.com/assets/548140/9103224/387c9356-3bc1-11e5-9dd7-411e1838b116.png)

Then, when the duration has passed, the content panel is cleared, like so:

![qtpass_cleared](https://cloud.githubusercontent.com/assets/548140/9103263/c73c25ac-3bc1-11e5-8e29-e49fe2840ebf.png)

I also updated .gitignore for the artifacts generated from building on ubuntu (I was just running `qmake && make` in the qtpass root and then running the binary generated like `./qtpass` if there's a better, cleaner way let me know.