### PR TITLE
Get PREFIX variable from environment

### DIFF
--- a/qtpass.pro
+++ b/qtpass.pro
@@ -94,7 +94,7 @@ OTHER_FILES += LICENSE \
 isEmpty(PREFIX) {
  PREFIX = /usr/local/bin
 }
-target.path = $$PREFIX/
+target.path = $$(PREFIX)/
 
 INSTALLS    += target
 


### PR DESCRIPTION
The parentheses are needed to get the variable from the environment