### PR TITLE
Fix bug that prints "Unknown error" to the terminal

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,9 @@ int main(int argc, char *argv[])
     //qDebug() << name;
     SingleApplication app(argc, argv, name + "QtPass");
     if (app.isRunning()) {
-        app.sendMessage(text);
+        if (text.length() > 0) {
+            app.sendMessage(text);
+        }
         return 0;
     }
 #else


### PR DESCRIPTION
Then I try to start qtpass I get the message in the terminal "Unknown error" and the program closes, but this patch fixes that problem.
A workaround for this bug is to add a argument to the execution of qtpass, like "qtpass test". You can still use arguments to search in qtpass then starting the program.