### PR TITLE
Modified the clipboard logic to allow for on-demand copy to clipboard.

### DIFF
--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -22,6 +22,12 @@ ConfigDialog::ConfigDialog(MainWindow *parent) :
     ui->profileTable->verticalHeader()->hide();
     ui->profileTable->horizontalHeader()->setStretchLastSection(true);
     ui->label->setText(ui->label->text() + VERSION);
+    ui->comboBoxClipboard->clear();
+
+    ui->comboBoxClipboard->addItem(tr("No Clipboard"));
+    ui->comboBoxClipboard->addItem(tr("Always copy to clipboard"));
+    ui->comboBoxClipboard->addItem(tr("On-demand copy to clipboard"));
+    ui->comboBoxClipboard->setCurrentIndex(0);
 }
 
 /**
@@ -234,11 +240,11 @@ void ConfigDialog::on_toolButtonStore_clicked()
 }
 
 /**
- * @brief ConfigDialog::on_checkBoxClipboard_clicked
+ * @brief ConfigDialog::on_comboBoxClipboard_activated
  */
-void ConfigDialog::on_checkBoxClipboard_clicked()
+void ConfigDialog::on_comboBoxClipboard_activated()
 {
-    if (ui->checkBoxClipboard->isChecked()) {
+    if (ui->comboBoxClipboard->currentIndex() > 0) {
         ui->checkBoxAutoclear->setEnabled(true);
         ui->checkBoxHidePassword->setEnabled(true);
         ui->checkBoxHideContent->setEnabled(true);
@@ -275,10 +281,10 @@ void ConfigDialog::on_checkBoxAutoclearPanel_clicked()
 /**
  * @brief ConfigDialog::useClipboard
  */
-void ConfigDialog::useClipboard(bool useClipboard)
+void ConfigDialog::useClipboard(MainWindow::clipBoardType useClipboard)
 {
-    ui->checkBoxClipboard->setChecked(useClipboard);
-    on_checkBoxClipboard_clicked();
+    ui->comboBoxClipboard->setCurrentIndex((int)useClipboard);
+    on_comboBoxClipboard_activated();
 }
 
 /**
@@ -323,9 +329,9 @@ void ConfigDialog::setAutoclearPanel(int seconds)
  * @brief ConfigDialog::useClipboard
  * @return
  */
-bool ConfigDialog::useClipboard()
+MainWindow::clipBoardType ConfigDialog::useClipboard()
 {
-    return ui->checkBoxClipboard->isChecked();
+    return static_cast<MainWindow::clipBoardType>(ui->comboBoxClipboard->currentIndex());
 }
 
 /**
@@ -351,7 +357,7 @@ int ConfigDialog::getAutoclear()
  */
 void ConfigDialog::on_checkBoxAutoclear_clicked()
 {
-    on_checkBoxClipboard_clicked();
+    on_comboBoxClipboard_activated();
 }
 
 /**

--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -283,7 +283,7 @@ void ConfigDialog::on_checkBoxAutoclearPanel_clicked()
  */
 void ConfigDialog::useClipboard(MainWindow::clipBoardType useClipboard)
 {
-    ui->comboBoxClipboard->setCurrentIndex((int)useClipboard);
+    ui->comboBoxClipboard->setCurrentIndex(static_cast<int>(useClipboard));
     on_comboBoxClipboard_activated();
 }
 

--- a/configdialog.h
+++ b/configdialog.h
@@ -27,7 +27,7 @@ public:
     void setStorePath(QString);
     void setProfiles(QHash<QString, QString>, QString);
     void usePass(bool);
-    void useClipboard(bool);
+    void useClipboard(MainWindow::clipBoardType);
     void useAutoclear(bool);
     void setAutoclear(int);
     void useAutoclearPanel(bool);
@@ -41,7 +41,7 @@ public:
     QString getStorePath();
     QHash<QString,QString> getProfiles();
     bool usePass();
-    bool useClipboard();
+    MainWindow::clipBoardType useClipboard();
     bool useAutoclear();
     int getAutoclear();
     bool useAutoclearPanel();
@@ -91,7 +91,7 @@ private slots:
     void on_toolButtonPwgen_clicked();
     void on_toolButtonPass_clicked();
     void on_toolButtonStore_clicked();
-    void on_checkBoxClipboard_clicked();
+    void on_comboBoxClipboard_activated();
     void on_checkBoxAutoclear_clicked();
     void on_checkBoxAutoclearPanel_clicked();
     void on_addButton_clicked();

--- a/configdialog.ui
+++ b/configdialog.ui
@@ -245,13 +245,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="checkBoxClipboard">
-           <property name="text">
-            <string>Use clipboard</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="3">
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
@@ -403,6 +396,9 @@
             <string>Automatically pull</string>
            </property>
           </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QComboBox" name="comboBoxClipboard"/>
          </item>
         </layout>
        </item>
@@ -589,7 +585,6 @@ url</string>
   <tabstop>toolButtonPwgen</tabstop>
   <tabstop>passPath</tabstop>
   <tabstop>toolButtonPass</tabstop>
-  <tabstop>checkBoxClipboard</tabstop>
   <tabstop>checkBoxAutoclear</tabstop>
   <tabstop>spinBoxAutoclearSeconds</tabstop>
   <tabstop>checkBoxAutoclearPanel</tabstop>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -53,7 +53,6 @@ MainWindow::MainWindow(QWidget *parent) :
     QtPass = NULL;
     autoclearTimer = NULL;
     QTimer::singleShot(10, this, SLOT(focusInput()));
-
 }
 
 void MainWindow::focusInput() {
@@ -175,7 +174,8 @@ bool MainWindow::checkConfig() {
     usePass = (settings.value("usePass") == "true");
 
     useClipboard = CLIPBOARD_NEVER;
-    if (settings.value("useClipboard") == "true" || settings.value("useClipboard") == "1") {
+    if (settings.value("useClipboard") == "true" || 
+        settings.value("useClipboard") == "1") {
         useClipboard = CLIPBOARD_ALWAYS;
     } else if (settings.value("useClipboard") == "2") {
         useClipboard = CLIPBOARD_ON_DEMAND;
@@ -450,9 +450,15 @@ void MainWindow::config() {
             settings.setValue("passStore", passStore);
             settings.setValue("usePass", usePass ? "true" : "false");
             switch (useClipboard) {
-                case CLIPBOARD_ALWAYS: settings.setValue("useClipboard", "true"); break;
-                case CLIPBOARD_ON_DEMAND: settings.setValue("useClipboard", "2"); break;
-                default: settings.setValue("useClipboard", "false"); break;
+                case CLIPBOARD_ALWAYS: 
+                    settings.setValue("useClipboard", "true"); 
+                    break;
+                case CLIPBOARD_ON_DEMAND:
+                    settings.setValue("useClipboard", "2");
+                    break;
+                default:
+                    settings.setValue("useClipboard", "false");
+                    break;
             }
             settings.setValue("useAutoclear", useAutoclear ? "true" : "false");
             settings.setValue("autoclearSeconds", autoclearSeconds);
@@ -680,12 +686,14 @@ void MainWindow::readyRead(bool finished = false) {
         if (finished && currentAction == GPG) {
             lastDecrypt = output;
             QStringList tokens =  output.split("\n");
-            
+
             if (useClipboard != CLIPBOARD_NEVER && !output.isEmpty()) {
                 setClippedPassword(tokens[0]);
                 if (useClipboard == CLIPBOARD_ALWAYS) copyPasswordToClipboard();
                 if (useAutoclearPanel) {
-                      QTimer::singleShot(1000*autoclearPanelSeconds, this, SLOT(clearPanel()));
+                      QTimer::singleShot(1000*autoclearPanelSeconds, \
+                        this, \
+                        SLOT(clearPanel()));
                 }
                 if (hidePassword && !useTemplate) {
                     tokens[0] = "***" + tr("Password hidden") + "***";
@@ -1625,7 +1633,7 @@ void MainWindow::showContextMenu(const QPoint& pos)
     }
 
     contextMenu.exec(globalPos);
- }
+}
 
 /**
  * @brief MainWindow::showContextMenu
@@ -1634,12 +1642,15 @@ void MainWindow::showContextMenu(const QPoint& pos)
 void MainWindow::showBrowserContextMenu(const QPoint& pos)
 {
     QMenu *contextMenu = ui->textBrowser->createStandardContextMenu(pos);
-    
+
     if (useClipboard != CLIPBOARD_NEVER) {
         contextMenu->addSeparator();
         QAction* copyItem = contextMenu->addAction(tr("Copy Password"));
         if (getClippedPassword().length() == 0) copyItem->setEnabled(false);
-        connect(copyItem, SIGNAL(triggered()), this, SLOT(copyPasswordToClipboard()));
+        connect(copyItem, \
+            SIGNAL(triggered()), \
+            this, \
+            SLOT(copyPasswordToClipboard()));
     }
     QPoint globalPos = ui->textBrowser->viewport()->mapToGlobal(pos);
 
@@ -1769,7 +1780,9 @@ void MainWindow::copyPasswordToClipboard()
         clip->setText(clippedPass);
         ui->statusBar->showMessage(tr("Password copied to clipboard"), 3000);
         if (useAutoclear) {
-            QTimer::singleShot(1000*autoclearSeconds, this, SLOT(clearClipboard()));
+            QTimer::singleShot(1000*autoclearSeconds, \
+                this, \
+                SLOT(clearClipboard()));
         }
     }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -48,6 +48,8 @@ MainWindow::MainWindow(QWidget *parent) :
         // no working config
         QApplication::quit();
     }
+    ui->copyPasswordButton->setEnabled(false);
+    setClippedPassword("");
     QtPass = NULL;
     autoclearTimer = NULL;
     QTimer::singleShot(10, this, SLOT(focusInput()));
@@ -172,7 +174,12 @@ bool MainWindow::checkConfig() {
 
     usePass = (settings.value("usePass") == "true");
 
-    useClipboard = (settings.value("useClipboard") == "true");
+    useClipboard = CLIPBOARD_NEVER;
+    if (settings.value("useClipboard") == "true" || settings.value("useClipboard") == "1") {
+        useClipboard = CLIPBOARD_ALWAYS;
+    } else if (settings.value("useClipboard") == "2") {
+        useClipboard = CLIPBOARD_ON_DEMAND;
+    }
     useAutoclear = (settings.value("useAutoclear") == "true");
     autoclearSeconds = settings.value("autoclearSeconds").toInt();
     useAutoclearPanel = (settings.value("useAutoclearPanel") == "true");
@@ -323,6 +330,9 @@ bool MainWindow::checkConfig() {
         this, SLOT(showContextMenu(const QPoint&)));
 
     ui->textBrowser->setOpenExternalLinks(true);
+    ui->textBrowser->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(ui->textBrowser, SIGNAL(customContextMenuRequested(const QPoint&)),
+        this, SLOT(showBrowserContextMenu(const QPoint&)));
 
     updateProfileBox();
 
@@ -439,7 +449,11 @@ void MainWindow::config() {
             settings.setValue("gpgExecutable", gpgExecutable);
             settings.setValue("passStore", passStore);
             settings.setValue("usePass", usePass ? "true" : "false");
-            settings.setValue("useClipboard", useClipboard ? "true" : "false");
+            switch (useClipboard) {
+                case CLIPBOARD_ALWAYS: settings.setValue("useClipboard", "true"); break;
+                case CLIPBOARD_ON_DEMAND: settings.setValue("useClipboard", "2"); break;
+                default: settings.setValue("useClipboard", "false"); break;
+            }
             settings.setValue("useAutoclear", useAutoclear ? "true" : "false");
             settings.setValue("autoclearSeconds", autoclearSeconds);
             settings.setValue("useAutoclearPanel", useAutoclearPanel ? "true" : "false");
@@ -572,6 +586,7 @@ void MainWindow::on_treeView_clicked(const QModelIndex &index)
 {
     currentDir = getDir(ui->treeView->currentIndex(), false);
     lastDecrypt = "Could not decrypt";
+    setClippedPassword("");
     QString file = getFile(index, usePass);
     if (!file.isEmpty()){
         currentAction = GPG;
@@ -665,13 +680,12 @@ void MainWindow::readyRead(bool finished = false) {
         if (finished && currentAction == GPG) {
             lastDecrypt = output;
             QStringList tokens =  output.split("\n");
-            if (useClipboard && !output.isEmpty()) {
-                QClipboard *clip = QApplication::clipboard();
-                clip->setText(tokens[0]);
-                ui->statusBar->showMessage(tr("Password copied to clipboard"), 3000);
-                if (useAutoclear) {
-                      clippedPass = tokens[0];
-                      QTimer::singleShot(1000*autoclearSeconds, this, SLOT(clearClipboard()));
+            
+            if (useClipboard != CLIPBOARD_NEVER && !output.isEmpty()) {
+                setClippedPassword(tokens[0]);
+                if (useClipboard == CLIPBOARD_ALWAYS) copyPasswordToClipboard();
+                if (useAutoclearPanel) {
+                      QTimer::singleShot(1000*autoclearPanelSeconds, this, SLOT(clearPanel()));
                 }
                 if (hidePassword && !useTemplate) {
                     tokens[0] = "***" + tr("Password hidden") + "***";
@@ -771,9 +785,8 @@ void MainWindow::readyRead(bool finished = false) {
 void MainWindow::clearClipboard()
 {
     QClipboard *clipboard = QApplication::clipboard();
-    if (clipboard->text() == clippedPass) {
+    if (clipboard->text() == getClippedPassword()) {
         clipboard->clear();
-        clippedPass = "";
         ui->statusBar->showMessage(tr("Clipboard cleared"), 3000);
     } else {
         ui->statusBar->showMessage(tr("Clipboard not cleared"), 3000);
@@ -1560,6 +1573,11 @@ void MainWindow::closeEvent(QCloseEvent *event)
     }
 }
 
+void MainWindow::on_copyPasswordButton_clicked()
+{
+    copyPasswordToClipboard();
+}
+
 /**
  * @brief MainWindow::showContextMenu
  * @param pos
@@ -1595,12 +1613,38 @@ void MainWindow::showContextMenu(const QPoint& pos)
         connect(edit, SIGNAL(triggered()), this, SLOT(editPassword()));
     }
     if (selected) {
+        //if (useClipboard != CLIPBOARD_NEVER) {
+        //    contextMenu.addSeparator();
+        //    QAction* copyItem = contextMenu.addAction(tr("Copy Password"));
+        //    if (getClippedPassword().length() == 0) copyItem->setEnabled(false);
+        //    connect(copyItem, SIGNAL(triggered()), this, SLOT(copyPasswordToClipboard()));
+        //}
+        contextMenu.addSeparator();
         QAction* deleteItem = contextMenu.addAction(tr("Delete"));
         connect(deleteItem, SIGNAL(triggered()), this, SLOT(on_deleteButton_clicked()));
     }
 
     contextMenu.exec(globalPos);
  }
+
+/**
+ * @brief MainWindow::showContextMenu
+ * @param pos
+ */
+void MainWindow::showBrowserContextMenu(const QPoint& pos)
+{
+    QMenu *contextMenu = ui->textBrowser->createStandardContextMenu(pos);
+    
+    if (useClipboard != CLIPBOARD_NEVER) {
+        contextMenu->addSeparator();
+        QAction* copyItem = contextMenu->addAction(tr("Copy Password"));
+        if (getClippedPassword().length() == 0) copyItem->setEnabled(false);
+        connect(copyItem, SIGNAL(triggered()), this, SLOT(copyPasswordToClipboard()));
+    }
+    QPoint globalPos = ui->textBrowser->viewport()->mapToGlobal(pos);
+
+    contextMenu->exec(globalPos);
+}
 
 /**
  * @brief MainWindow::addFolder
@@ -1712,4 +1756,38 @@ void MainWindow::clearTemplateWidgets()
         delete item;
     }
     ui->verticalLayoutPassword->setSpacing(0);
+}
+
+/*
+ * @brief Mainwindow::copyPasswordToClipboard - copy the clipped password (if not "") to the clipboard
+ * @return
+ */
+void MainWindow::copyPasswordToClipboard()
+{
+    if (clippedPass.length() > 0) {
+        QClipboard *clip = QApplication::clipboard();
+        clip->setText(clippedPass);
+        ui->statusBar->showMessage(tr("Password copied to clipboard"), 3000);
+        if (useAutoclear) {
+            QTimer::singleShot(1000*autoclearSeconds, this, SLOT(clearClipboard()));
+        }
+    }
+}
+
+/**
+ * @brief Mainwindow::setClippedPassword - set the stored clipped password
+ * @return none
+ */
+void MainWindow::setClippedPassword(const QString & pass)
+{
+    clippedPass = pass;
+    if (clippedPass.length() == 0) {
+        ui->copyPasswordButton->setEnabled(false);
+    } else {
+        ui->copyPasswordButton->setEnabled(true);
+    }
+}
+
+const QString &MainWindow::getClippedPassword() {
+    return clippedPass;
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -35,8 +35,9 @@ class MainWindow : public QMainWindow
 enum actionType { GPG, GIT, EDIT, DELETE, GPG_INTERNAL, PWGEN };
 
 public:
-
-    enum clipBoardType { CLIPBOARD_NEVER=0, CLIPBOARD_ALWAYS=1, CLIPBOARD_ON_DEMAND=2 };
+    enum clipBoardType { CLIPBOARD_NEVER = 0, 
+                        CLIPBOARD_ALWAYS = 1,
+                        CLIPBOARD_ON_DEMAND = 2 };
 
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -35,6 +35,9 @@ class MainWindow : public QMainWindow
 enum actionType { GPG, GIT, EDIT, DELETE, GPG_INTERNAL, PWGEN };
 
 public:
+
+    enum clipBoardType { CLIPBOARD_NEVER=0, CLIPBOARD_ALWAYS=1, CLIPBOARD_ON_DEMAND=2 };
+
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
     void setPassExecutable(QString);
@@ -73,10 +76,13 @@ private slots:
     void on_usersButton_clicked();
     void messageAvailable(QString message);
     void on_profileBox_currentIndexChanged(QString);
+    void on_copyPasswordButton_clicked();
     void showContextMenu(const QPoint& pos);
+    void showBrowserContextMenu(const QPoint& pos);
     void addFolder();
     void editPassword();
     void focusInput();
+    void copyPasswordToClipboard();
 
 private:
     QApplication *QtPass;
@@ -87,7 +93,7 @@ private:
     QScopedPointer<QItemSelectionModel> selectionModel;
     QScopedPointer<QProcess> process;
     bool usePass;
-    bool useClipboard;
+    clipBoardType useClipboard;
     bool useAutoclear;
     bool useAutoclearPanel;
     bool hidePassword;
@@ -155,6 +161,8 @@ private:
     bool removeDir(const QString & dirName);
     void waitFor(int);
     void clearTemplateWidgets();
+    void setClippedPassword(const QString & pass);
+    const QString &getClippedPassword();
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -86,6 +86,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QToolButton" name="copyPasswordButton">
+         <property name="toolTip">
+          <string>Copy Password</string>
+         </property>
+         <property name="text">
+          <string>Password</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Sometimes I want secondary information from a entry (URL, notes, ...) and don't always want the password being pushed to the clipboard.  So I added a new state to the clipboard handling, copy on-demand.

For the UI I changed the clipboard config entry to be a combobox instead of a checkbox.  It has 3 states:
 * Never copy to the clipboard
 * Always copy to the clipboard
 * On-demand copy to the clipboard

Added a 'Password' button to the main window which copies the password to the clipboard when pressed.
The button is disabled when there is no password loaded or passwords are set to never copy to the clipboard.

Added a context menu entry to the text browser to copy the password to the clipboard.

Moved some of the clipboard code around to make it more flexible.  Clippedpass is always set when the password could be copied.