### PR TITLE
qrand always generating the same sequence of passwords

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -51,6 +51,7 @@ MainWindow::MainWindow(QWidget *parent)
   setClippedPassword("");
   QtPass = NULL;
   QTimer::singleShot(10, this, SLOT(focusInput()));
+  qsrand(QDateTime::currentDateTime().toTime_t());
 }
 
 void MainWindow::focusInput() {


### PR DESCRIPTION
qrand fallback when not using pwgen would always generate the same
sequence of passwords because qsrand was never called.