### PR TITLE
Two UI Tweaks

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -897,6 +897,7 @@ void MainWindow::enableUiElements(bool state) {
   ui->updateButton->setEnabled(state);
   ui->treeView->setEnabled(state);
   ui->lineEdit->setEnabled(state);
+  ui->lineEdit->installEventFilter(this);
   ui->addButton->setEnabled(state);
   ui->usersButton->setEnabled(state);
   ui->configButton->setEnabled(state);
@@ -989,6 +990,7 @@ void MainWindow::on_lineEdit_textChanged(const QString &arg1) {
  * @brief MainWindow::on_lineEdit_returnPressed
  */
 void MainWindow::on_lineEdit_returnPressed() {
+    qDebug() << "on_lineEdit_returnPressed";
   selectFirstFile();
   on_treeView_clicked(ui->treeView->currentIndex());
 }
@@ -1594,6 +1596,18 @@ void MainWindow::closeEvent(QCloseEvent *event) {
   }
 }
 
+bool MainWindow::eventFilter(QObject *obj, QEvent *event)
+{
+    if (obj == ui->lineEdit && event->type() == QEvent::KeyPress)
+    {
+        QKeyEvent *key = static_cast<QKeyEvent *>(event);
+        if(key->key() == Qt::Key_Down) {
+            ui->treeView->setFocus();
+        }
+    }
+    return QObject::eventFilter(obj, event);
+}
+
 void MainWindow::keyPressEvent(QKeyEvent * event) {
     switch (event->key()) {
     case Qt::Key_Delete:
@@ -1601,7 +1615,7 @@ void MainWindow::keyPressEvent(QKeyEvent * event) {
         break;
     case Qt::Key_Return:
     case Qt::Key_Enter:
-        on_editButton_clicked();
+        on_treeView_clicked(ui->treeView->currentIndex());
         break;
      case Qt::Key_Escape:
         ui->lineEdit->clear();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -106,6 +106,20 @@ QSettings &MainWindow::getSettings() {
   return *settings;
 }
 
+void MainWindow::changeEvent(QEvent *event)
+{   
+    QWidget::changeEvent(event);
+    if (event->type() == QEvent::ActivationChange)
+    {
+        if(this->isActiveWindow())
+        {
+            ui->lineEdit->selectAll();
+            ui->lineEdit->setFocus();
+        }
+    }
+}
+
+
 void MainWindow::mountWebDav() {
 #ifdef Q_OS_WIN
   char dst[20] = {0};

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -59,6 +59,7 @@ class MainWindow : public QMainWindow {
  protected:
   void closeEvent(QCloseEvent *event);
   void keyPressEvent(QKeyEvent * event);
+  void changeEvent(QEvent *event);
 
 
  private slots:

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -60,6 +60,7 @@ class MainWindow : public QMainWindow {
   void closeEvent(QCloseEvent *event);
   void keyPressEvent(QKeyEvent * event);
   void changeEvent(QEvent *event);
+  bool eventFilter(QObject *obj, QEvent *event);
 
 
  private slots:


### PR DESCRIPTION
These two changes probably aren't worth merging as is, but I thought someone might want to add config options for them and add them. I also know very little c++ and even less about QT, so the merges might be a horrible way of going about them.

1) When the window is activated, focus the search box. I generally leave QTPass open, and then just switch to it when I need a password. When I switch I always want to search for the password to copy. So for me it's really nice if search is always focused when I activate the window, and I can immediately start typing.

2) Usually when I've searched for a password it's the top item and I can just hit enter to grab it, but sometimes it's not and I need to navigate to another password. I set it up so the down arrow will move to the tree view below, but this can probably be solved more cleanly by simply adding the treeView to the tabstops after lineEdit.