### PR TITLE
Use --secure for pwgen and add more configurable options

### DIFF
--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -669,9 +669,13 @@ void ConfigDialog::setPwgenPath(QString pwgen) {
  * @brief ConfigDialog::on_checkBoxUsPwgen_clicked
  */
 void ConfigDialog::on_checkBoxUsePwgen_clicked() {
-  ui->checkBoxUseSymbols->setEnabled(ui->checkBoxUsePwgen->isChecked());
-  ui->lineEditPasswordChars->setEnabled(!ui->checkBoxUsePwgen->isChecked());
-  ui->labelPasswordChars->setEnabled(!ui->checkBoxUsePwgen->isChecked());
+  bool usePwgen = ui->checkBoxUsePwgen->isChecked();
+  ui->checkBoxAvoidCapitals->setEnabled(usePwgen);
+  ui->checkBoxAvoidNumbers->setEnabled(usePwgen);
+  ui->checkBoxLessRandom->setEnabled(usePwgen);
+  ui->checkBoxUseSymbols->setEnabled(usePwgen);
+  ui->lineEditPasswordChars->setEnabled(!usePwgen);
+  ui->labelPasswordChars->setEnabled(!usePwgen);
 }
 
 /**
@@ -683,6 +687,18 @@ void ConfigDialog::usePwgen(bool usePwgen) {
     usePwgen = false;
   ui->checkBoxUsePwgen->setChecked(usePwgen);
   on_checkBoxUsePwgen_clicked();
+}
+
+void ConfigDialog::avoidCapitals(bool avoidCapitals) {
+  ui->checkBoxAvoidCapitals->setChecked(avoidCapitals);
+}
+
+void ConfigDialog::avoidNumbers(bool avoidNumbers) {
+  ui->checkBoxAvoidNumbers->setChecked(avoidNumbers);
+}
+
+void ConfigDialog::lessRandom(bool lessRandom) {
+  ui->checkBoxLessRandom->setChecked(lessRandom);
 }
 
 /**
@@ -710,6 +726,11 @@ void ConfigDialog::setPasswordChars(QString pwChars) {
  * @return
  */
 bool ConfigDialog::usePwgen() { return ui->checkBoxUsePwgen->isChecked(); }
+
+bool ConfigDialog::avoidCapitals() { return ui->checkBoxAvoidCapitals->isChecked(); }
+bool ConfigDialog::avoidNumbers() { return ui->checkBoxAvoidNumbers->isChecked(); }
+bool ConfigDialog::lessRandom() { return ui->checkBoxLessRandom->isChecked(); }
+
 
 /**
  * @brief ConfigDialog::useSymbols

--- a/configdialog.h
+++ b/configdialog.h
@@ -60,10 +60,16 @@ class ConfigDialog : public QDialog {
   QString getPwgenPath();
   void setPwgenPath(QString);
   void usePwgen(bool usePwgen);
+  void avoidCapitals(bool avoidCapitals);
+  void avoidNumbers(bool avoidNumbers);
+  void lessRandom(bool lessRandom);
   void useSymbols(bool useSymbols);
   void setPasswordLength(int pwLen);
   void setPasswordChars(QString);
   bool usePwgen();
+  bool avoidCapitals();
+  bool avoidNumbers();
+  bool lessRandom();
   bool useSymbols();
   int getPasswordLength();
   QString getPasswordChars();

--- a/configdialog.ui
+++ b/configdialog.ui
@@ -280,11 +280,11 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_10">
+          <layout class="QFormLayout" name="formLayout">
            <property name="topMargin">
             <number>0</number>
            </property>
-           <item>
+           <item row="0" column="0">
             <widget class="QCheckBox" name="checkBoxUsePwgen">
              <property name="enabled">
               <bool>true</bool>
@@ -294,13 +294,34 @@
              </property>
             </widget>
            </item>
-           <item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="checkBoxAvoidCapitals">
+             <property name="text">
+              <string>Exclude capital letters</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
             <widget class="QCheckBox" name="checkBoxUseSymbols">
              <property name="enabled">
               <bool>true</bool>
              </property>
              <property name="text">
               <string>Include special symbols </string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QCheckBox" name="checkBoxLessRandom">
+             <property name="text">
+              <string>Generate easy to memorize but less secure passwords</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="checkBoxAvoidNumbers">
+             <property name="text">
+              <string>Exclude numbers</string>
              </property>
             </widget>
            </item>
@@ -826,8 +847,8 @@ email</string>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>484</x>
-     <y>204</y>
+     <x>556</x>
+     <y>518</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -842,8 +863,8 @@ email</string>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>484</x>
-     <y>204</y>
+     <x>556</x>
+     <y>518</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -260,6 +260,9 @@ bool MainWindow::checkConfig() {
 
   useGit = (settings.value("useGit") == "true");
   usePwgen = (settings.value("usePwgen") == "true");
+  avoidCapitals = settings.value("avoidCapitals").toBool();
+  avoidNumbers = settings.value("avoidNumbers").toBool();
+  lessRandom = settings.value("lessRandom").toBool();
   useSymbols = (settings.value("useSymbols") == "true");
   passwordLength = settings.value("passwordLength").toInt();
   passwordChars = settings.value("passwordChars").toString();
@@ -431,6 +434,9 @@ void MainWindow::config() {
   d->useGit(useGit);
   d->setPwgenPath(pwgenExecutable);
   d->usePwgen(usePwgen);
+  d->avoidCapitals(avoidCapitals);
+  d->avoidNumbers(avoidNumbers);
+  d->lessRandom(lessRandom);
   d->useSymbols(useSymbols);
   d->setPasswordLength(passwordLength);
   d->setPasswordChars(passwordChars);
@@ -464,6 +470,9 @@ void MainWindow::config() {
       useGit = d->useGit();
       pwgenExecutable = d->getPwgenPath();
       usePwgen = d->usePwgen();
+      avoidCapitals = d->avoidCapitals();
+      avoidNumbers = d->avoidNumbers();
+      lessRandom = d->lessRandom();
       useSymbols = d->useSymbols();
       passwordLength = d->getPasswordLength();
       passwordChars = d->getPasswordChars();
@@ -507,6 +516,9 @@ void MainWindow::config() {
       settings.setValue("useGit", useGit ? "true" : "false");
       settings.setValue("pwgenExecutable", pwgenExecutable);
       settings.setValue("usePwgen", usePwgen ? "true" : "false");
+      settings.setValue("avoidCapitals", avoidCapitals ? "true" : "false");
+      settings.setValue("avoidNumbers", avoidNumbers ? "true" : "false");
+      settings.setValue("lessRandom", lessRandom ? "true" : "false");
       settings.setValue("useSymbols", useSymbols ? "true" : "false");
       settings.setValue("passwordLength", passwordLength);
       settings.setValue("passwordChars", passwordChars);
@@ -1752,7 +1764,12 @@ QString MainWindow::generatePassword() {
   QString passwd;
   if (usePwgen) {
     waitFor(2);
-    QString args = (useSymbols ? "--symbols -1 " : "-1 ") +
+    // --secure goes first as it overrides --no-* otherwise
+    QString args = QString("-1 ") +
+                   (lessRandom    ? ""                 : "--secure ") +
+                   (avoidCapitals ? "--no-capitalize " : "--capitalize ") +
+                   (avoidNumbers  ? "--no-numerals "   : "--numerals ") +
+                   (useSymbols    ? "--symbols "       : "") +
                    QString::number(passwordLength);
     currentAction = PWGEN;
     executeWrapper(pwgenExecutable, args);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -141,6 +141,9 @@ class MainWindow : public QMainWindow {
   bool startMinimized;
   bool useGit;
   bool usePwgen;
+  bool avoidCapitals;
+  bool avoidNumbers;
+  bool lessRandom;
   bool useSymbols;
   int passwordLength;
   QString passwordChars;


### PR DESCRIPTION
Enable --secure option for pwgen by default as it allows it
to generate more random passwords.

Also, add the following options to pwgen together with corresponding checkboxes:
 * --capitalize
 * --numerals
 * --secure

All these options are enabled by default, as
 * we're a password manager, so no need to memorize passwords,
   so we should make them more secure by default;
 * most websites accept passwords, generated using these options
   (unlike --symbols option)

Convert horizontal layout for options into form layout
to accommodate more checkboxes.