### PR TITLE
Fix build issues with MSVC2015 on Windows

### DIFF
--- a/qtpass.pro
+++ b/qtpass.pro
@@ -48,7 +48,7 @@ FORMS     += mainwindow.ui \
              keygendialog.ui \
              passworddialog.ui
 
-QMAKE_CXXFLAGS_WARN_ON += -Wno-unknown-pragmas
+clang|gcc:QMAKE_CXXFLAGS_WARN_ON += -Wno-unknown-pragmas
 
 nosingleapp {
     QMAKE_CXXFLAGS += -DSINGLE_APP=0
@@ -112,7 +112,8 @@ win32 {
     static {
         QMAKE_LFLAGS += -static-libgcc -static-libstdc++
     }
-    QMAKE_LFLAGS += -Wl,--dynamicbase -Wl,--nxcompat
+    gcc:QMAKE_LFLAGS += -Wl,--dynamicbase -Wl,--nxcompat
+    msvc:QMAKE_LFLAGS += /DYNAMICBASE /NXCOMPAT
     LIBS    += -lmpr
 } else:macx {
     ICON = artwork/icon.icns

--- a/util.cpp
+++ b/util.cpp
@@ -6,8 +6,9 @@
 #include <QDir>
 #ifdef Q_OS_WIN
 #include <windows.h>
-#endif
+#else
 #include <sys/time.h>
+#endif
 QProcessEnvironment Util::_env;
 bool Util::_envInitialised;
 


### PR DESCRIPTION
Remove/Replace invalid compiler and linker flags
Do not include sys/time.h on Windows