### PR TITLE
Lookup validity field to check if keys are valid

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1380,7 +1380,7 @@ QList<UserInfo> MainWindow::listKeys(QString keystring, bool secret) {
       current_user = UserInfo();
       current_user.key_id = props[4];
       current_user.name = props[9].toUtf8();
-      current_user.validity = props[8][0].toLatin1();
+      current_user.validity = props[1][0].toLatin1();
       current_user.created.setTime_t(props[5].toInt());
       current_user.expiry.setTime_t(props[6].toInt());
     } else if (current_user.name.isEmpty() && props[0] == "uid") {

--- a/usersdialog.cpp
+++ b/usersdialog.cpp
@@ -65,7 +65,7 @@ void UsersDialog::populateList(const QString &filter) {
          it != userList->end(); ++it) {
       UserInfo &user(*it);
       if (filter.isEmpty() || nameFilter.exactMatch(user.name)) {
-        if (user.validity == '-' && !ui->checkBox->isChecked())
+        if (!user.isValid() && !ui->checkBox->isChecked())
           continue;
         if (user.expiry.toTime_t() > 0 &&
             user.expiry.daysTo(QDateTime::currentDateTime()) > 0 &&
@@ -89,12 +89,15 @@ void UsersDialog::populateList(const QString &filter) {
           font.setFamily(font.defaultFamily());
           font.setBold(true);
           item->setFont(font);
-        } else if (user.validity == '-') {
+        } else if (!user.isValid()) {
           item->setBackground(QColor(164, 0, 0));
           item->setForeground(Qt::white);
         } else if (user.expiry.toTime_t() > 0 &&
                    user.expiry.daysTo(QDateTime::currentDateTime()) > 0) {
           item->setForeground(QColor(164, 0, 0));
+        } else if (!user.fullyValid()) {
+          item->setBackground(QColor(164, 80, 0));
+          item->setForeground(Qt::white);
         }
 
         ui->listWidget->addItem(item);

--- a/usersdialog.h
+++ b/usersdialog.h
@@ -20,6 +20,11 @@ class QListWidgetItem;
 struct UserInfo {
   UserInfo() : validity('-'), have_secret(false), enabled(false) {}
 
+  // see http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
+  bool fullyValid() { return validity == 'f' || validity == 'u'; }
+  bool marginallyValid() { return validity == 'm'; }
+  bool isValid() { return fullyValid() || marginallyValid(); }
+
   QString name;
   QString key_id;
   char validity;


### PR DESCRIPTION
Currently, the code checks the Ownertrust field [1] to look if a key should be considered as valid. However, the Ownertrust field should not be deemed to represent the level of confidence that a key is valid. Rather, it represents how much the user trusts in the owner of the key to understand correctly how key signing works and to strictly check fingerprints before signing keys. Ownertrust is used as input by the trust models to compute the validity of keys, which is printed by GnuPG in the Validity field.

This commit changes the code to check the Validity field instead of the Ownertrust field.

Keys which are at least marginally valid are also included in the user list dialog, however keys which are not fully valid are printed with dark orange background.

[1] http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS