### PR TITLE
Increase maximum password length to 255

### DIFF
--- a/configdialog.ui
+++ b/configdialog.ui
@@ -262,6 +262,9 @@
                <property name="minimum">
                 <number>8</number>
                </property>
+               <property name="maximum">
+                <number>255</number>
+               </property>
                <property name="value">
                 <number>16</number>
                </property>


### PR DESCRIPTION
QSpinBox has a default maximum of 99 thus making it impossible to
generate longer passwords.

http://doc.qt.io/qt-5/qspinbox.html#maximum-prop