### PR TITLE
Allow ssh links

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -888,7 +888,7 @@ void MainWindow::readyRead(bool finished = false) {
     }
   }
 
-  output.replace(QRegExp("((?:https?|ftp)://\\S+)"), "<a href=\"\\1\">\\1</a>");
+  output.replace(QRegExp("((?:https?|ftp|ssh)://\\S+)"), "<a href=\"\\1\">\\1</a>");
   output.replace(QRegExp("\n"), "<br />");
   if (!ui->textBrowser->toPlainText().isEmpty())
     output = ui->textBrowser->toHtml() + output;


### PR DESCRIPTION
In most Linux desktops, it is allowed to use ssh links (ssh://user@server) but QtPass only allow http and ftp links.

Tested on KDE Plasma 5.