### PR TITLE
Refactoring of qpushbuttonwithclipboard and timers

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -97,7 +97,7 @@ MainWindow::MainWindow(QWidget *parent)
   connect(actionAddFolder, SIGNAL(triggered()), this, SLOT(addFolder()));
   qsrand(static_cast<uint>(QTime::currentTime().msec()));
 
-#if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
   ui->lineEdit->setClearButtonEnabled(true);
 #endif
 }
@@ -1460,25 +1460,6 @@ void MainWindow::clearTemplateWidgets() {
 }
 
 /**
- * @brief Mainwindow::copyTextByButtonClick - copy the text to the clipboard
- * @param checked
- *  no use, we need it, because of QPushButtonWithClipboard::clicked function
- */
-void MainWindow::copyTextByButtonClick(bool checked) {
-  if (checked) {
-    qDebug() << "checked";
-  }
-  QPushButtonWithClipboard *button =
-      dynamic_cast<QPushButtonWithClipboard *>(sender());
-  if (button == NULL) {
-    return;
-  }
-  button->changeIconPushed();
-  QString textToCopy = button->getTextToCopy();
-  copyTextToClipboard(textToCopy);
-}
-
-/**
  * @brief MainWindow::copyTextToClipboard copies text to your clipboard
  * @param text
  */
@@ -1512,7 +1493,8 @@ void MainWindow::addToGridLayout(int position, const QString &field,
   if (QtPassSettings::getClipBoardType() != Enums::CLIPBOARD_NEVER) {
     QPushButtonWithClipboard *fieldLabel =
         new QPushButtonWithClipboard(trimmedValue, this);
-    connect(fieldLabel, SIGNAL(clicked()), this, SLOT(copyTextByButtonClick()));
+    connect(fieldLabel, SIGNAL(clicked(QString)), this,
+            SLOT(copyTextToClipboard(QString)));
 
     fieldLabel->setStyleSheet("border-style: none ; background: transparent;");
     // fieldLabel->setContentsMargins(0,5,5,0);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -73,7 +73,11 @@ MainWindow::MainWindow(QWidget *parent)
   ui->statusBar->showMessage(tr("Welcome to QtPass %1").arg(VERSION), 2000);
   freshStart = true;
   startupPhase = true;
-  autoclearTimer = NULL;
+  clearPanelTimer.setSingleShot(true);
+  connect(&clearPanelTimer, SIGNAL(timeout()), this, SLOT(clearPanel()));
+  clearClipboardTimer.setSingleShot(true);
+  connect(&clearClipboardTimer, SIGNAL(timeout()), this,
+          SLOT(clearClipboard()));
   pwdConfig.selected = 0;
   if (!checkConfig()) {
     // no working config
@@ -353,6 +357,10 @@ bool MainWindow::checkConfig() {
   }
   pass->updateEnv();
 
+  clearPanelTimer.setInterval(1000 *
+                              QtPassSettings::getAutoclearPanelSeconds());
+  clearClipboardTimer.setInterval(1000 * QtPassSettings::getAutoclearSeconds());
+
   if (!QtPassSettings::isUseGit() ||
       (QtPassSettings::getGitExecutable().isEmpty() &&
        QtPassSettings::getPassExecutable().isEmpty())) {
@@ -483,6 +491,11 @@ void MainWindow::config() {
       if (freshStart && Util::checkConfig())
         config();
       pass->updateEnv();
+      clearPanelTimer.setInterval(1000 *
+                                  QtPassSettings::getAutoclearPanelSeconds());
+      clearClipboardTimer.setInterval(1000 *
+                                      QtPassSettings::getAutoclearSeconds());
+
       if (!QtPassSettings::isUseGit() ||
           (QtPassSettings::getGitExecutable().isEmpty() &&
            QtPassSettings::getPassExecutable().isEmpty())) {
@@ -632,12 +645,7 @@ void MainWindow::executeWrapperStarted() {
   ui->textBrowser->clear();
   ui->textBrowser->setTextColor(Qt::black);
   enableUiElements(false);
-  if (autoclearTimer != NULL) {
-    autoclearTimer->stop();
-    //    TODO(bezet): why dynamic allocation?
-    delete autoclearTimer;
-    autoclearTimer = NULL;
-  }
+  clearPanelTimer.stop();
 }
 
 /**
@@ -664,8 +672,7 @@ void MainWindow::readyRead(bool finished = false) {
         if (QtPassSettings::getClipBoardType() == Enums::CLIPBOARD_ALWAYS)
           copyTextToClipboard(tokens[0]);
         if (QtPassSettings::isUseAutoclearPanel()) {
-          QTimer::singleShot(1000 * QtPassSettings::getAutoclearPanelSeconds(),
-                             this, SLOT(clearPanel(true)));
+          clearPanelTimer.start();
         }
         if (QtPassSettings::isHidePassword() &&
             !QtPassSettings::isUseTemplate()) {
@@ -716,14 +723,7 @@ void MainWindow::readyRead(bool finished = false) {
         addToGridLayout(0, tr("Password"), password);
       }
       if (QtPassSettings::isUseAutoclearPanel()) {
-        autoclearPass = output;
-        autoclearTimer = new QTimer(this);
-        autoclearTimer->setSingleShot(true);
-        autoclearTimer->setInterval(1000 *
-                                    QtPassSettings::getAutoclearPanelSeconds());
-        connect(autoclearTimer, SIGNAL(timeout()), this,
-                SLOT(clearPanel(true)));
-        autoclearTimer->start();
+        clearPanelTimer.start();
       }
     }
     output.replace(QRegExp("<"), "&lt;");
@@ -789,6 +789,12 @@ void MainWindow::clearPanel(bool notify = true) {
     ui->textBrowser->setHtml("");
   }
 }
+
+/**
+ * @brief MainWindow::clearPanel because slots needs the same amout of params as
+ * signals
+ */
+void MainWindow::clearPanel() { clearPanel(true); }
 
 /**
  * @brief MainWindow::processFinished process is finished, if there is another
@@ -1469,8 +1475,7 @@ void MainWindow::copyTextToClipboard(const QString &text) {
   clippedText = text;
   ui->statusBar->showMessage(tr("Copied to clipboard"), 2000);
   if (QtPassSettings::isUseAutoclear()) {
-    QTimer::singleShot(1000 * QtPassSettings::getAutoclearSeconds(), this,
-                       SLOT(clearClipboard()));
+    clearClipboardTimer.start();
   }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -83,7 +83,6 @@ public:
   QString generatePassword(int length, Enums::characterSet selection);
   void config();
   void executePassGitInit();
-  void copyTextToClipboard(const QString &text);
 
   /**
    * @brief MainWindow::pwdConfig instance of passwordConfiguration.
@@ -124,7 +123,7 @@ private slots:
   void addFolder();
   void editPassword();
   void focusInput();
-  void copyTextByButtonClick(bool checked = false);
+  void copyTextToClipboard(const QString &text);
 
   void executeWrapperStarted();
   void showStatusMessage(QString msg, int timeout);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -110,6 +110,7 @@ private slots:
   void processError(QProcess::ProcessError);
   void clearClipboard();
   void clearPanel(bool notify);
+  void clearPanel();
   void on_lineEdit_textChanged(const QString &arg1);
   void on_lineEdit_returnPressed();
   void on_addButton_clicked();
@@ -144,8 +145,8 @@ private:
   QTreeView *treeView;
   QProcess fusedav;
   QString clippedText;
-  QString autoclearPass;
-  QTimer *autoclearTimer;
+  QTimer clearPanelTimer;
+  QTimer clearClipboardTimer;
   actionType currentAction;
   QString lastDecrypt;
   QQueue<execQueueItem> *execQueue;

--- a/qpushbuttonwithclipboard.cpp
+++ b/qpushbuttonwithclipboard.cpp
@@ -14,16 +14,17 @@
  */
 QPushButtonWithClipboard::QPushButtonWithClipboard(const QString &textToCopy,
                                                    MainWindow *parent)
-    : QPushButton(*new QIcon(QIcon::fromTheme("edit-copy",
-                                              QIcon(":/icons/edit-copy.svg"))),
-                  "", parent) {
-  this->textToCopy = textToCopy;
-  this->parent = parent;
+    : QPushButton(parent), textToCopy(textToCopy),
+      iconEdit(QIcon::fromTheme("edit-copy", QIcon(":/icons/edit-copy.svg"))),
+      iconEditPushed(
+          QIcon::fromTheme("document-new", QIcon(":/icons/document-new.svg"))) {
+  setIcon(iconEdit);
+  connect(this, SIGNAL(clicked(bool)), this, SLOT(buttonClicked(bool)));
 }
 
 /**
- * @brief QPushButtonWithClipboard::getTextToCopy returns the text of associated
- * text field
+ * @brief QPushButtonWithClipboard::getTextToCopy returns the text of
+ * associated text field
  * @return QString textToCopy
  */
 QString QPushButtonWithClipboard::getTextToCopy() const { return textToCopy; }
@@ -37,13 +38,14 @@ void QPushButtonWithClipboard::setTextToCopy(const QString &value) {
   textToCopy = value;
 }
 
-void QPushButtonWithClipboard::changeIconPushed() {
-  this->setIcon(*new QIcon(
-      QIcon::fromTheme("document-new", QIcon(":/icons/document-new.svg"))));
+/**
+ * @brief QPushButtonWithClipboard::buttonClicked handles clicked event by
+ * emitting clicked(QString) with string provided to constructor
+ */
+void QPushButtonWithClipboard::buttonClicked(bool) {
+  setIcon(iconEditPushed);
   QTimer::singleShot(500, this, SLOT(changeIconDefault()));
+  emit clicked(textToCopy);
 }
 
-void QPushButtonWithClipboard::changeIconDefault() {
-  this->setIcon(*new QIcon(
-      QIcon::fromTheme("edit-copy", QIcon(":/icons/edit-copy.svg"))));
-}
+void QPushButtonWithClipboard::changeIconDefault() { this->setIcon(iconEdit); }

--- a/qpushbuttonwithclipboard.cpp
+++ b/qpushbuttonwithclipboard.cpp
@@ -1,6 +1,5 @@
 #include "qpushbuttonwithclipboard.h"
-#include <QDebug>
-#include <QLabel>
+#include <QTimer>
 
 /**
  * @brief QPushButtonWithClipboard::QPushButtonWithClipboard
@@ -13,7 +12,7 @@
  *  the parent window
  */
 QPushButtonWithClipboard::QPushButtonWithClipboard(const QString &textToCopy,
-                                                   MainWindow *parent)
+                                                   QWidget *parent)
     : QPushButton(parent), textToCopy(textToCopy),
       iconEdit(QIcon::fromTheme("edit-copy", QIcon(":/icons/edit-copy.svg"))),
       iconEditPushed(

--- a/qpushbuttonwithclipboard.h
+++ b/qpushbuttonwithclipboard.h
@@ -1,7 +1,6 @@
 #ifndef QPUSHBUTTONWITHCLIPBOARD_H_
 #define QPUSHBUTTONWITHCLIPBOARD_H_
 
-#include "mainwindow.h"
 #include <QPushButton>
 #include <QWidget>
 
@@ -10,7 +9,7 @@ class QPushButtonWithClipboard : public QPushButton {
 
 public:
   explicit QPushButtonWithClipboard(const QString &textToCopy = "",
-                                    MainWindow *parent = 0);
+                                    QWidget *parent = 0);
 
   QString getTextToCopy() const;
   void setTextToCopy(const QString &value);

--- a/qpushbuttonwithclipboard.h
+++ b/qpushbuttonwithclipboard.h
@@ -14,14 +14,18 @@ public:
 
   QString getTextToCopy() const;
   void setTextToCopy(const QString &value);
-  void changeIconPushed();
+
+signals:
+  void clicked(QString);
 
 private slots:
   void changeIconDefault();
+  void buttonClicked(bool);
 
 private:
   QString textToCopy;
-  MainWindow *parent;
+  QIcon iconEdit;
+  QIcon iconEditPushed;
 };
 
 #endif // QPUSHBUTTONWITHCLIPBOARD_H_


### PR DESCRIPTION
Fixed memleaks in qpushbuttowithclipboard and refactored a bit to remove dependency from MainWindow. Only signal-based comunication right now.
Also fixed panel timer, which apparently was not working, as well as added member timer for clipboard clearing(there was an issue, that when clicked "copy pass" multiple times, clipboard was cleared multiple times, thus the last copied pass was not kept there as long as expected).