### PR TITLE
Minor fix for file names and git push

### DIFF
--- a/imitatepass.cpp
+++ b/imitatepass.cpp
@@ -55,8 +55,7 @@ void ImitatePass::GitPush() {
  * @brief ImitatePass::Show shows content of file
  */
 void ImitatePass::Show(QString file) {
-  //  TODO(bezet): apparently not yet needed
-  //  file += ".gpg";
+  file = QtPassSettings::getPassStore() + file + ".gpg";
   QStringList args = {"-d",      "--quiet",     "--yes", "--no-encrypt-to",
                       "--batch", "--use-agent", file};
   executeWrapper(PASS_SHOW, QtPassSettings::getGpgExecutable(), args);
@@ -68,6 +67,7 @@ void ImitatePass::Show(QString file) {
  * @returns process exitCode
  */
 int ImitatePass::Show_b(QString file) {
+  file = QtPassSettings::getPassStore() + file + ".gpg";
   QStringList args = {"-d",      "--quiet",     "--yes", "--no-encrypt-to",
                       "--batch", "--use-agent", file};
   return exec.executeBlocking(QtPassSettings::getGpgExecutable(), args);
@@ -81,8 +81,7 @@ int ImitatePass::Show_b(QString file) {
  * @param overwrite whether to overwrite existing file
  */
 void ImitatePass::Insert(QString file, QString newValue, bool overwrite) {
-  file += ".gpg";
-  //  TODO(bezet): getRecipientString is in MainWindow for now - fix this ;)
+  file = QtPassSettings::getPassStore() + file + ".gpg";
   QStringList recipients = Pass::getRecipientList(file);
   if (recipients.isEmpty()) {
     //  TODO(bezet): probably throw here
@@ -122,6 +121,9 @@ void ImitatePass::GitCommit(const QString &file, const QString &msg) {
  * @brief ImitatePass::Remove git init wrapper
  */
 void ImitatePass::Remove(QString file, bool isDir) {
+  file = QtPassSettings::getPassStore() + file;
+  if (!isDir)
+    file += ".gpg";
   if (QtPassSettings::isUseGit()) {
     executeWrapper(GIT_RM, QtPassSettings::getGitExecutable(),
                    {"rm", (isDir ? "-rf" : "-f"), file});

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1253,7 +1253,7 @@ void MainWindow::on_profileBox_currentIndexChanged(QString name) {
   QtPassSettings::setPassStore(QtPassSettings::getProfiles()[name]);
   ui->statusBar->showMessage(tr("Profile changed to %1").arg(name), 2000);
 
-  pass->resetPasswordStoreDir();
+  pass->updateEnv();
 
   ui->treeView->setRootIndex(proxyModel.mapFromSource(
       model.setRootPath(QtPassSettings::getPassStore())));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -533,9 +533,11 @@ void MainWindow::on_updateButton_clicked(bool block) {
  * @brief MainWindow::on_pushButton_clicked do a git push
  */
 void MainWindow::on_pushButton_clicked() {
-  ui->statusBar->showMessage(tr("Updating password-store"), 2000);
-  currentAction = GIT;
-  pass->GitPush();
+  if (QtPassSettings::isUseGit() && QtPassSettings::isAutoPush()) {
+    ui->statusBar->showMessage(tr("Updating password-store"), 2000);
+    currentAction = GIT;
+    pass->GitPush();
+  }
 }
 
 /**
@@ -988,8 +990,7 @@ void MainWindow::setPassword(QString file, bool overwrite, bool isNew = false) {
   currentAction = EDIT;
   pass->Insert(file, newValue, overwrite);
 
-  if (QtPassSettings::isUseGit() && QtPassSettings::isAutoPush())
-    on_pushButton_clicked();
+  on_pushButton_clicked();
 }
 
 /**
@@ -1054,9 +1055,8 @@ void MainWindow::on_deleteButton_clicked() {
 
   currentAction = REMOVE;
   pass->Remove(file, isDir);
-  //  TODO(bezet): hide inside interface?
-  if (QtPassSettings::isUseGit() && QtPassSettings::isAutoPush())
-    on_pushButton_clicked();
+
+  on_pushButton_clicked();
 
   lastDecrypt = "";
 }
@@ -1147,8 +1147,7 @@ void MainWindow::on_usersButton_clicked() {
 
   pass->Init(dir, users);
 
-  if (QtPassSettings::isAutoPush())
-    on_pushButton_clicked();
+  on_pushButton_clicked();
 }
 
 /**

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -586,9 +586,7 @@ void MainWindow::on_treeView_clicked(const QModelIndex &index) {
   currentDir = getDir(ui->treeView->currentIndex(), false);
   lastDecrypt = "Could not decrypt";
   clippedText = "";
-  QString file = getFile(index, QtPassSettings::isUsePass());
-  QFileInfo fileinfo =
-      model.fileInfo(proxyModel.mapToSource(ui->treeView->currentIndex()));
+  QString file = getFile(index, true);
   ui->passwordName->setText(getFile(index, true));
   if (!file.isEmpty() && !cleared) {
     currentAction = GPG;
@@ -611,7 +609,7 @@ void MainWindow::on_treeView_doubleClicked(const QModelIndex &index) {
   QString file = "";
 
   if (fileOrFolder.isFile()) {
-    QString file = getFile(index, QtPassSettings::isUsePass());
+    QString file = getFile(index, true);
     if (file.isEmpty()) {
       QMessageBox::critical(
           this, tr("Can not edit"),
@@ -1016,8 +1014,7 @@ void MainWindow::on_addButton_clicked() {
   //    return;
   //  }
   bool ok;
-  QString dir =
-      getDir(ui->treeView->currentIndex(), QtPassSettings::isUsePass());
+  QString dir = getDir(ui->treeView->currentIndex(), true);
   QString file = QInputDialog::getText(
       this, tr("New file"),
       tr("New password file: \n(Will be placed in %1 )")
@@ -1041,9 +1038,9 @@ void MainWindow::on_deleteButton_clicked() {
   bool isDir = false;
 
   if (fileOrFolder.isFile()) {
-    file = getFile(ui->treeView->currentIndex(), QtPassSettings::isUsePass());
+    file = getFile(ui->treeView->currentIndex(), true);
   } else {
-    file = getDir(ui->treeView->currentIndex(), QtPassSettings::isUsePass());
+    file = getDir(ui->treeView->currentIndex(), true);
     isDir = true;
   }
 
@@ -1068,8 +1065,7 @@ void MainWindow::on_deleteButton_clicked() {
  * @brief MainWindow::on_editButton_clicked try and edit (selected) password.
  */
 void MainWindow::on_editButton_clicked() {
-  QString file =
-      getFile(ui->treeView->currentIndex(), QtPassSettings::isUsePass());
+  QString file = getFile(ui->treeView->currentIndex(), true);
   if (file.isEmpty()) {
     QMessageBox::critical(
         this, tr("Can not edit"),
@@ -1447,8 +1443,7 @@ void MainWindow::editPassword() {
   // TODO(annejan) move to editbutton stuff possibly?
   currentDir = getDir(ui->treeView->currentIndex(), false);
   lastDecrypt = "Could not decrypt";
-  QString file =
-      getFile(ui->treeView->currentIndex(), QtPassSettings::isUsePass());
+  QString file = getFile(ui->treeView->currentIndex(), true);
   if (!file.isEmpty()) {
     currentAction = GPG;
     if (pass->Show_b(file) == 0)

--- a/pass.cpp
+++ b/pass.cpp
@@ -153,25 +153,6 @@ void Pass::updateEnv() {
 }
 
 /**
- * @brief Pass::resetPasswordStoreDir   probably temporary helper
- */
-void Pass::resetPasswordStoreDir() {
-  // dbg()<< env;
-  QStringList store = env.filter("PASSWORD_STORE_DIR");
-  // put PASSWORD_STORE_DIR in env
-  if (store.isEmpty()) {
-    // dbg()<< "Added
-    // PASSWORD_STORE_DIR";
-    env.append("PASSWORD_STORE_DIR=" + QtPassSettings::getPassStore());
-  } else {
-    // dbg()<< "Update
-    // PASSWORD_STORE_DIR";
-    env.replaceInStrings(store.first(), "PASSWORD_STORE_DIR=" +
-                                            QtPassSettings::getPassStore());
-  }
-}
-
-/**
  * @brief Pass::getRecipientList return list of gpg-id's to encrypt for
  * @param for_file which file (folder) would you like recepients for
  * @return recepients gpg-id contents

--- a/pass.h
+++ b/pass.h
@@ -50,7 +50,6 @@ public:
 
   void GenerateGPGKeys(QString batch);
   QList<UserInfo> listKeys(QString keystring = "", bool secret = false);
-  void resetPasswordStoreDir();
   void updateEnv();
   //  TODO(bezet): those are probably temporarly here
   static QStringList getRecipientList(QString for_file);


### PR DESCRIPTION
Fix for refactoring bug, was adding file with extra '.gpg' suffix. This also clarifies a bit Pass interface, when passing filename it requires to be in pass format(ie. password-store relative path and no '.gpg' suffix). It is resolved internally(for native tools).
Fix for pushing to git, when "Auto push" is checked but "Use git" is not.