### PR TITLE
Fixed path of resources.qrc

### DIFF
--- a/qtpass.pro
+++ b/qtpass.pro
@@ -25,5 +25,5 @@ DISTFILES += \
     settingsToDelete.txt
 
 RESOURCES += \
-    src/resources.qrc
+    resources.qrc
 


### PR DESCRIPTION
Depending on version and configuration of qmake, it would result in an error that it could not find 'src/resources.qrc'.

With this change, this should be fixed.