### PR TITLE
Code coverage measurement

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ build_script:
   - cmd: cd tests
   - qmake
   - mingw32-make
-  - cmd: auto\util\release\tst_util.exe
+  - mingw32-make check
 artifacts:
   - path: Output\qtpass-*.exe
   - path: src\release\qtpass.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,11 +5,11 @@ install:
 build_script:
   - qmake qtpass.pro CONFIG+=static
   - mingw32-make
+  - mingw32-make check
 #after_build:
   - cmd: copy README.md src\release\README.txt
   - cmd: copy LICENSE src\release\LICENSE.txt
   - iscc qtpass.iss
-  - mingw32-make check
 artifacts:
   - path: Output\qtpass-*.exe
   - path: src\release\qtpass.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,6 @@ build_script:
   - cmd: copy README.md src\release\README.txt
   - cmd: copy LICENSE src\release\LICENSE.txt
   - iscc qtpass.iss
-  - cmd: cd tests
-  - qmake
-  - mingw32-make
   - mingw32-make check
 artifacts:
   - path: Output\qtpass-*.exe

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,4 @@
 coverage:
     ignore:
         - tests/*
+        - src/qrc_*.cpp

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+    ignore:
+        - tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,12 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then npm install -g appdmg; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -qq update; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -qq install qt58base qt58tools qt58svg; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install --user codecov; fi
 before_script:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source /opt/qt58/bin/qt58-env.sh; fi
 script:
 - qmake -v
-- qmake -Wall qtpass.pro
+- qmake CONFIG+=debug -Wall qtpass.pro
 - make -j$(nproc)
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then macdeployqt src/QtPass.app; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed 's/FAQ\.md/https:\/\/qtpass.org\/docs\/md_FAQ.html/' < README.md > README.faq; fi
@@ -43,13 +44,8 @@ script:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pandoc --standalone --from=markdown_github --to=rtf --output=README.rtf README.clean; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then appdmg appdmg.json qtpass-$(grep ^VERSION  qtpass.pri | cut -d " " -f 6).dmg; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export VERSION=$(grep ^VERSION  qtpass.pri | cut -d " " -f 6); fi
-- export QT_QPA_PLATFORM=offscreen
-- cd tests
-- qmake
-- make
-- if [ "$TRAVIS_OS_NAME" != "osx" ]; then ./auto/util/tst_util; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./auto/util/tst_util.app/Contents/MacOS/tst_util; fi
-- cd -
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then make -j$(nproc) check ; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then make -j$(nproc) codecov TESTARGS="--platform offscreen"; fi
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,19 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -qq update; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -qq install qt58base qt58tools qt58svg; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install --user codecov; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then gem install coveralls-lcov ; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -qq install lcov; fi
 before_script:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source /opt/qt58/bin/qt58-env.sh; fi
-script:
 - qmake -v
-- qmake CONFIG+=debug -Wall qtpass.pro
+script:
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then qmake CONFIG+=coverage -Wall qtpass.pro; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then make -j$(nproc); fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then make -j$(nproc) coveralls TESTARGS="--platform offscreen"; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then make distclean; fi
+- qmake -Wall qtpass.pro
 - make -j$(nproc)
+- make check TESTARGS="--platform offscreen"
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then macdeployqt src/QtPass.app; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed 's/FAQ\.md/https:\/\/qtpass.org\/docs\/md_FAQ.html/' < README.md > README.faq; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed 's/CONTRIBUTING\.md/https:\/\/qtpass.org\/docs\/md_CONTRIBUTING.html/' < README.faq > README.contrib; fi
@@ -44,8 +51,6 @@ script:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pandoc --standalone --from=markdown_github --to=rtf --output=README.rtf README.clean; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then appdmg appdmg.json qtpass-$(grep ^VERSION  qtpass.pri | cut -d " " -f 6).dmg; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export VERSION=$(grep ^VERSION  qtpass.pri | cut -d " " -f 6); fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then make -j$(nproc) check ; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then make -j$(nproc) codecov TESTARGS="--platform offscreen"; fi
 notifications:
   irc:
     channels:

--- a/qtpass.pri
+++ b/qtpass.pri
@@ -1,2 +1,13 @@
 VERSION    = 1.2.0-pre
 
+TEMPLATE = subdirs
+
+CONFIG(debug, debug|release) {
+	DESTDIR = debug 
+	OBJECTS_DIR = debug 
+	MOC_DIR = debug
+	QMAKE_CXXFLAGS += --coverage
+	QMAKE_LFLAGS += --coverage
+	QMAKE_DISTCLEAN += -r $$OBJECTS_DIR
+}
+

--- a/qtpass.pri
+++ b/qtpass.pri
@@ -2,12 +2,6 @@ VERSION    = 1.2.0-pre
 
 TEMPLATE = subdirs
 
-CONFIG(debug, debug|release) {
-	DESTDIR = debug 
-	OBJECTS_DIR = debug 
-	MOC_DIR = debug
-	QMAKE_CXXFLAGS += --coverage
+CONFIG(coverage) {
 	QMAKE_LFLAGS += --coverage
-	QMAKE_DISTCLEAN += -r $$OBJECTS_DIR
 }
-

--- a/qtpass.pro
+++ b/qtpass.pro
@@ -1,9 +1,10 @@
-TEMPLATE = subdirs
+!include(qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 
 SUBDIRS += src
 
 CONFIG(debug, debug|release) {
     SUBDIRS += tests
+    tests.depends = src
 }
 
 OTHER_FILES += LICENSE \
@@ -12,3 +13,24 @@ OTHER_FILES += LICENSE \
 
 RESOURCES += resources.qrc
 
+# add Makefile target to generate code coverage
+coverage.target = coverage
+coverage.commands = @echo "Coverage DONE!" $$escape_expand(\\n\\t)
+coverage.commands += cd src/debug && gcov "*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
+coverage.commands += $$escape_expand(\\n)
+
+coverage.depends = check
+
+# add Makefile target to generate code coverage using codecov
+codecov.target = codecov
+codecov.commands = @echo "Starting Codecov!" $$escape_expand(\\n\\t)
+coverage.commands += cd src/ && gcov "*.cpp *.h debug/*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
+codecov.commands += codecov $$escape_expand(\\n\\t)
+codecov.commands += $$escape_expand(\\n)
+
+codecov.depends = check
+
+CONFIG(debug, debug|release) {
+    QMAKE_EXTRA_TARGETS += coverage codecov
+    QMAKE_CLEAN += 'src/debug/*.gc??' 'src/*.gcov'
+}

--- a/qtpass.pro
+++ b/qtpass.pro
@@ -13,22 +13,40 @@ OTHER_FILES += LICENSE \
 
 RESOURCES += resources.qrc
 
-# add Makefile target to generate code coverage
-coverage.target = coverage
-coverage.commands += cd src/debug && gcov "*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
-coverage.commands += $$escape_expand(\\n)
-
-coverage.depends = check
+# add Makefile target to generate code coverage using gcov
+gcov.target = gcov
+gcov.commands += cd src/debug && gcov "*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
+gcov.commands += $$escape_expand(\\n)
+gcov.depends = check
 
 # add Makefile target to generate code coverage using codecov
 codecov.target = codecov
-codecov.commands += cd src/ && gcov "*.cpp *.h debug/*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
+codecov.commands += cd src/ && gcov -o debug *.cpp *.h debug/*.gcda 1>/dev/null $$escape_expand(\\n\\t)
 codecov.commands += codecov -X gcov $$escape_expand(\\n\\t)
 codecov.commands += $$escape_expand(\\n)
-
 codecov.depends = check
 
+LCOV_OUTPUT_DIR = src/$$OBJECTS_DIR/lcov/
+# add Makefile target to generate code coverage using lcov
+lcov_initial.target = lcov_initial
+#lcov_initial.commands =  $$escape_expand(\\n\\t)
+lcov_initial.commands += rm -rf $$LCOV_OUTPUT_DIR $$escape_expand(\\n\\t)
+lcov_initial.commands +=  mkdir $$LCOV_OUTPUT_DIR $$escape_expand(\\n\\t)
+lcov_initial.commands += lcov --quiet --initial --capture --base-directory ./src --directory ./src/debug/ -o $${LCOV_OUTPUT_DIR}/.lcov.base1 $$escape_expand(\\n\\t)
+lcov_initial.commands += $$escape_expand(\\n)
+lcov_initial.depends += sub-src
+
+lcov.target = lcov
+lcov.commands += lcov -q -c -b ./src -d ./src/debug/ -o $${LCOV_OUTPUT_DIR}/.lcov.run1 $$escape_expand(\\n\\t)
+lcov.commands += lcov -q -e $${LCOV_OUTPUT_DIR}/.lcov.base1 -o $${LCOV_OUTPUT_DIR}/.lcov.base $$PWD/src/* $$escape_expand(\\n\\t)
+lcov.commands += lcov -q -e $${LCOV_OUTPUT_DIR}/.lcov.run1 -o $${LCOV_OUTPUT_DIR}/.lcov.run $$PWD/src/* $$escape_expand(\\n\\t)
+lcov.commands += lcov -q -a $${LCOV_OUTPUT_DIR}/.lcov.base -a $${LCOV_OUTPUT_DIR}/.lcov.run -o $${LCOV_OUTPUT_DIR}/.lcov.total $$escape_expand(\\n\\t)
+lcov.commands += genhtml --demangle-cpp -o $${LCOV_OUTPUT_DIR}/ $${LCOV_OUTPUT_DIR}/.lcov.total $$escape_expand(\\n\\t)
+lcov.commands += @echo -e "xdg-open file:///$${PWD}/$${LCOV_OUTPUT_DIR}/index.html"
+lcov.commands += $$escape_expand(\\n)
+lcov.depends = lcov_initial check
+
 CONFIG(debug, debug|release) {
-    QMAKE_EXTRA_TARGETS += coverage codecov
+    QMAKE_EXTRA_TARGETS += gcov codecov lcov lcov_initial
     QMAKE_CLEAN += 'src/debug/*.gc??' 'src/*.gcov'
 }

--- a/qtpass.pro
+++ b/qtpass.pro
@@ -1,11 +1,7 @@
 !include(qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 
-SUBDIRS += src
-
-CONFIG(debug, debug|release) {
-    SUBDIRS += tests
-    tests.depends = src
-}
+SUBDIRS += src tests
+tests.depends = src
 
 OTHER_FILES += LICENSE \
                README.md \
@@ -15,14 +11,13 @@ RESOURCES += resources.qrc
 
 # add Makefile target to generate code coverage using gcov
 gcov.target = gcov
-gcov.commands += cd src/debug && gcov "*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
+gcov.commands += cd src/$$OBJECTS_DIR && gcov "*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
 gcov.commands += $$escape_expand(\\n)
 gcov.depends = check
 
 # add Makefile target to generate code coverage using codecov
 codecov.target = codecov
-codecov.commands += cd src/ && gcov -o debug *.cpp *.h debug/*.gcda 1>/dev/null $$escape_expand(\\n\\t)
-codecov.commands += codecov -X gcov $$escape_expand(\\n\\t)
+codecov.commands += cd src/ && codecov $$escape_expand(\\n\\t)
 codecov.commands += $$escape_expand(\\n)
 codecov.depends = check
 
@@ -32,21 +27,31 @@ lcov_initial.target = lcov_initial
 #lcov_initial.commands =  $$escape_expand(\\n\\t)
 lcov_initial.commands += rm -rf $$LCOV_OUTPUT_DIR $$escape_expand(\\n\\t)
 lcov_initial.commands +=  mkdir $$LCOV_OUTPUT_DIR $$escape_expand(\\n\\t)
-lcov_initial.commands += lcov --quiet --initial --capture --base-directory ./src --directory ./src/debug/ -o $${LCOV_OUTPUT_DIR}/.lcov.base1 $$escape_expand(\\n\\t)
+lcov_initial.commands += lcov --quiet --initial --capture --base-directory ./src --directory ./src/$$OBJECTS_DIR/ -o $${LCOV_OUTPUT_DIR}/.lcov.base1 $$escape_expand(\\n\\t)
 lcov_initial.commands += $$escape_expand(\\n)
 lcov_initial.depends += sub-src
 
+lcov_prepare.target = lcov_prepare
+lcov_prepare.commands += lcov -q -c -b ./src -d ./src/$$OBJECTS_DIR/ -o $${LCOV_OUTPUT_DIR}/.lcov.run1 $$escape_expand(\\n\\t)
+lcov_prepare.commands += lcov -q -e $${LCOV_OUTPUT_DIR}/.lcov.base1 -o $${LCOV_OUTPUT_DIR}/.lcov.base $$PWD/src/* $$escape_expand(\\n\\t)
+lcov_prepare.commands += lcov -q -e $${LCOV_OUTPUT_DIR}/.lcov.run1 -o $${LCOV_OUTPUT_DIR}/.lcov.run $$PWD/src/* $$escape_expand(\\n\\t)
+lcov_prepare.commands += lcov -q -a $${LCOV_OUTPUT_DIR}/.lcov.base -a $${LCOV_OUTPUT_DIR}/.lcov.run -o $${LCOV_OUTPUT_DIR}/.lcov.total $$escape_expand(\\n\\t)
+lcov_prepare.commands += $$escape_expand(\\n)
+lcov_prepare.depends = lcov_initial check
+
 lcov.target = lcov
-lcov.commands += lcov -q -c -b ./src -d ./src/debug/ -o $${LCOV_OUTPUT_DIR}/.lcov.run1 $$escape_expand(\\n\\t)
-lcov.commands += lcov -q -e $${LCOV_OUTPUT_DIR}/.lcov.base1 -o $${LCOV_OUTPUT_DIR}/.lcov.base $$PWD/src/* $$escape_expand(\\n\\t)
-lcov.commands += lcov -q -e $${LCOV_OUTPUT_DIR}/.lcov.run1 -o $${LCOV_OUTPUT_DIR}/.lcov.run $$PWD/src/* $$escape_expand(\\n\\t)
-lcov.commands += lcov -q -a $${LCOV_OUTPUT_DIR}/.lcov.base -a $${LCOV_OUTPUT_DIR}/.lcov.run -o $${LCOV_OUTPUT_DIR}/.lcov.total $$escape_expand(\\n\\t)
 lcov.commands += genhtml --demangle-cpp -o $${LCOV_OUTPUT_DIR}/ $${LCOV_OUTPUT_DIR}/.lcov.total $$escape_expand(\\n\\t)
 lcov.commands += @echo -e "xdg-open file:///$${PWD}/$${LCOV_OUTPUT_DIR}/index.html"
 lcov.commands += $$escape_expand(\\n)
-lcov.depends = lcov_initial check
+lcov.depends = lcov_prepare
 
-CONFIG(debug, debug|release) {
-    QMAKE_EXTRA_TARGETS += gcov codecov lcov lcov_initial
-    QMAKE_CLEAN += 'src/debug/*.gc??' 'src/*.gcov'
+coveralls.target = coveralls
+coveralls.commands += coveralls-lcov $${LCOV_OUTPUT_DIR}/.lcov.total $$escape_expand(\\n\\t)
+coveralls.commands += $$escape_expand(\\n)
+coveralls.depends = lcov_prepare
+
+CONFIG(coverage) {
+    QMAKE_EXTRA_TARGETS += gcov codecov lcov_initial lcov_prepare lcov coveralls
+    QMAKE_CLEAN += src/$$OBJECTS_DIR/*.gc?? src/*.gcov
+	QMAKE_DISTCLEAN += -r src/$$OBJECTS_DIR/lcov/
 }

--- a/qtpass.pro
+++ b/qtpass.pro
@@ -15,7 +15,6 @@ RESOURCES += resources.qrc
 
 # add Makefile target to generate code coverage
 coverage.target = coverage
-coverage.commands = @echo "Coverage DONE!" $$escape_expand(\\n\\t)
 coverage.commands += cd src/debug && gcov "*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
 coverage.commands += $$escape_expand(\\n)
 
@@ -23,9 +22,8 @@ coverage.depends = check
 
 # add Makefile target to generate code coverage using codecov
 codecov.target = codecov
-codecov.commands = @echo "Starting Codecov!" $$escape_expand(\\n\\t)
-coverage.commands += cd src/ && gcov "*.cpp *.h debug/*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
-codecov.commands += codecov $$escape_expand(\\n\\t)
+codecov.commands += cd src/ && gcov "*.cpp *.h debug/*.gcda" 1>/dev/null $$escape_expand(\\n\\t)
+codecov.commands += codecov -X gcov $$escape_expand(\\n\\t)
 codecov.commands += $$escape_expand(\\n)
 
 codecov.depends = check

--- a/src/src.pro
+++ b/src/src.pro
@@ -12,6 +12,10 @@ CONFIG(debug, debug|release) {
     QMAKE_LFLAGS += -O0
 }
 
+CONFIG(coverage) {
+	QMAKE_CXXFLAGS += --coverage
+}
+
 macx {
     TARGET = QtPass
     QMAKE_MAC_SDK = macosx

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,4 +1,4 @@
-!include(../qtpass.pri) { error("Couldn't find the auto.pri file!") }
+!include(../qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 
 TEMPLATE   = app
 QT        += core gui
@@ -8,9 +8,8 @@ CONFIG += c++11
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 CONFIG(debug, debug|release) {
-    QMAKE_CXXFLAGS += -g -c -Wall -coverage -O0
-    QMAKE_LFLAGS += -coverage -O0
-    SUBDIRS += tests
+    QMAKE_CXXFLAGS += -g -c -Wall -O0
+    QMAKE_LFLAGS += -O0
 }
 
 macx {

--- a/tests/auto/auto.pri
+++ b/tests/auto/auto.pri
@@ -1,3 +1,5 @@
 !include(../tests.pri) { error("Couldn't find the tests.pri file!") }
 
+TEMPLATE = app
+
 !contains(TARGET, ^tst_.*):TARGET = $$join(TARGET,,"tst_")

--- a/tests/auto/util/util.pro
+++ b/tests/auto/util/util.pro
@@ -1,14 +1,15 @@
 !include(../auto.pri) { error("Couldn't find the auto.pri file!") }
 
 SOURCES += tst_util.cpp \
-           util.cpp \
-           qtpasssettings.cpp \
-           settingsconstants.cpp \
-           pass.cpp \
-           realpass.cpp \
-           imitatepass.cpp \
-           executor.cpp \
-           simpletransaction.cpp
+
+OBJECTS +=      ../../../src/$$OBJECTS_DIR/util.o \
+                ../../../src/$$OBJECTS_DIR/qtpasssettings.o \
+                ../../../src/$$OBJECTS_DIR/settingsconstants.o \
+                ../../../src/$$OBJECTS_DIR/pass.o \
+                ../../../src/$$OBJECTS_DIR/realpass.o \
+                ../../../src/$$OBJECTS_DIR/imitatepass.o \
+                ../../../src/$$OBJECTS_DIR/executor.o \
+                ../../../src/$$OBJECTS_DIR/simpletransaction.o
 
 HEADERS   += util.h \
              qtpasssettings.h \
@@ -18,6 +19,8 @@ HEADERS   += util.h \
              imitatepass.h \
              executor.h \
              simpletransaction.h
+
+OBJ_PATH += ../../../src/$$OBJECTS_DIR
 
 VPATH += ../../../src
 INCLUDEPATH += ../../../src

--- a/tests/auto/util/util.pro
+++ b/tests/auto/util/util.pro
@@ -2,14 +2,14 @@
 
 SOURCES += tst_util.cpp \
 
-OBJECTS +=      ../../../src/$$OBJECTS_DIR/util.o \
-                ../../../src/$$OBJECTS_DIR/qtpasssettings.o \
-                ../../../src/$$OBJECTS_DIR/settingsconstants.o \
-                ../../../src/$$OBJECTS_DIR/pass.o \
-                ../../../src/$$OBJECTS_DIR/realpass.o \
-                ../../../src/$$OBJECTS_DIR/imitatepass.o \
-                ../../../src/$$OBJECTS_DIR/executor.o \
-                ../../../src/$$OBJECTS_DIR/simpletransaction.o
+OBJECTS +=      ../../../src/$(OBJECTS_DIR)/util.o \
+                ../../../src/$(OBJECTS_DIR)/qtpasssettings.o \
+                ../../../src/$(OBJECTS_DIR)/settingsconstants.o \
+                ../../../src/$(OBJECTS_DIR)/pass.o \
+                ../../../src/$(OBJECTS_DIR)/realpass.o \
+                ../../../src/$(OBJECTS_DIR)/imitatepass.o \
+                ../../../src/$(OBJECTS_DIR)/executor.o \
+                ../../../src/$(OBJECTS_DIR)/simpletransaction.o
 
 HEADERS   += util.h \
              qtpasssettings.h \
@@ -20,7 +20,7 @@ HEADERS   += util.h \
              executor.h \
              simpletransaction.h
 
-OBJ_PATH += ../../../src/$$OBJECTS_DIR
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
 
 VPATH += ../../../src
 INCLUDEPATH += ../../../src

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -1,8 +1,7 @@
-TEMPLATE = app
+!include(../qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 
 CONFIG += testcase qt warn_on depend_includepath testcase
 QT += testlib widgets
 
 target.path = $$[QT_INSTALL_TESTS]/qtpass/$$TARGET
 INSTALLS += target
-

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,5 +1,5 @@
-QT += widgets testlib
+!include(tests.pri) { error("Couldn't find the tests.pri file!") }
+
 CONFIG += no_docs_target
-TEMPLATE = subdirs
 SUBDIRS += auto
 exists(manual): SUBDIRS += manual


### PR DESCRIPTION
We now have an ability to measure code coverage(stunning 2% right now ;)).  This closes #298.

While the commit may seem a bit complicated at first, everything boils down to compilation with `--coverage`. Basically this have to be a new 'flavour' of build as coverage measurements is built into application as a shared library, so it's unusable for end-users. Due to the way `make/qmake` works, enabling/disabling coverage requires `make distclean` before changing flavour(ie. from release to coverage) so that all object files are rebuild(alternatively one can run `make clean` and `qmake -r`, which will update `Makefiles`).
There are 4 frontends for displaying code coverage added as make targets. Those are: `gcov, lcov, codecov and coveralls`. First two create code-coverage report locally, either as text-files(`gcov`, files are located in `src/` with `.gcov` extension) or html report(`lcov`, located in `src/lcov`). The other two uploads code coverage to external services(respectively [codecov](https://codecov.io/) and [coveralls](https://coveralls.io/)). Please note that `codecov` does not include files with no coverage(due to the bug in gcov), so the total coverage percentage is quite misleading.
In order to be able to see current code coverage:
1. Start with clean repo
`$ make distclean`
2. Reconfigure qmake to create coverage build
`$ qmake CONFIG+=coverage qtpro.pro`
3. Build, run tests and create coverage report
`$ make lcov`
4. View report :)

Also from now, all tests can be run with `make check`.

Travis creates code-coverage report using linux build, as I don't know how to install required stuff(lcov, coveralls-lcov(this is ruby gem)) on osx. Build steps shall be the same.