### PR TITLE
Honor PREFIX during tests install

### DIFF
--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -3,5 +3,5 @@
 CONFIG += testcase qt warn_on depend_includepath testcase
 QT += testlib widgets
 
-target.path = $$[QT_INSTALL_TESTS]/qtpass/$$TARGET
+target.path = $$PREFIX$$[QT_INSTALL_TESTS]/qtpass/$$TARGET
 INSTALLS += target


### PR DESCRIPTION
Hi.

It tries to install tests without taking into account PREFIX.
This patch fixes it.