### PR TITLE
Fix nested template argument list compile error

### DIFF
--- a/src/simpletransaction.h
+++ b/src/simpletransaction.h
@@ -8,7 +8,7 @@ class simpleTransaction {
 
   int transactionDepth;
   Enums::PROCESS lastInTransaction;
-  std::queue<std::pair<Enums::PROCESS, Enums::PROCESS>> transactionQueue;
+  std::queue<std::pair<Enums::PROCESS, Enums::PROCESS> > transactionQueue;
 
 public:
   simpleTransaction()


### PR DESCRIPTION
Fixes this compilation error:

In file included from ../../../src/imitatepass.h:5:0,
                 from ../../../src/qtpasssettings.h:5,
                 from ../../../src/storemodel.h:10,
                 from ../../../src/util.h:4,
                 from tst_util.cpp:1:
../../../src/simpletransaction.h:11:54: error: ‘>>’ should be ‘> >’ within a nested template argument list
   std::queue<std::pair<Enums::PROCESS, Enums::PROCESS>> transactionQueue;
