### PR TITLE
New scroll bar on large files

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -383,7 +383,35 @@
            <bool>false</bool>
           </property>
           <property name="styleSheet">
-           <string notr="true">background: transparent</string>
+           <string notr="true">
+             background: transparent
+             setStyleSheet(QString::fromUtf8(QScrollBar:vertical {              
+              border: 1px solid #999999;
+              background:white;
+              width:10px;    
+              margin: 0px 0px 0px 0px;
+             }
+             QScrollBar::handle:vertical {
+              background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+              stop: 0 rgb(32, 47, 130), stop: 0.5 rgb(32, 47, 130), stop:1 rgb(32, 47, 130));
+              min-height: 0px;
+             }
+             QScrollBar::add-line:vertical {
+              background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+              stop: 0 rgb(32, 47, 130), stop: 0.5 rgb(32, 47, 130),  stop:1 rgb(32, 47, 130));
+              height: 0px;
+              subcontrol-position: bottom;
+              subcontrol-origin: margin;
+             }
+             QScrollBar::sub-line:vertical {
+              background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+              stop: 0  rgb(32, 47, 130), stop: 0.5 rgb(32, 47, 130),  stop:1 rgb(32, 47, 130));
+              height: 0 px;
+              subcontrol-position: top;
+              subcontrol-origin: margin;
+             }
+            ));
+           </string>
           </property>
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
Changed the style of the scroll bar when the text file containing the password is larger than usual.
I have never used Qt and I am on Linux KDE so I don't know if the change is global.

![newscroll](https://user-images.githubusercontent.com/2753657/34852863-be1c563e-f728-11e7-98f9-771cb7004926.png) ![oldscroll](https://user-images.githubusercontent.com/2753657/34852897-e78d98b6-f728-11e7-90e1-38599cd48725.png)

