### PR TITLE
Fix High Dpi Support. Works now under Windows and KDE/Plasma.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -39,7 +39,6 @@
  * @return
  */
 int main(int argc, char *argv[]) {
-  qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QString text = "";
   for (int i = 1; i < argc; ++i) {


### PR DESCRIPTION
Commit 4a530820 was incomplete...

Qts scaling environment variables shall never be changed by application.
That way the user hasn't any chance to fix things himself. With setting
QT_AUTO_SCREEN_SCALE_FACTOR to 1 QtPass does not work under KDE/Plasma
and cannot even be fixed by setting Qts scaling environment variables.