### PR TITLE
pwgen: fix inverted "Generate ... less secure passwords" checkbox

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -66,7 +66,7 @@ QString Pass::Generate_b(unsigned int length, const QString &charset) {
     // --secure goes first as it overrides --no-* otherwise
     QStringList args;
     args.append("-1");
-    if (QtPassSettings::isLessRandom())
+    if (!QtPassSettings::isLessRandom())
       args.append("--secure");
     args.append(QtPassSettings::isAvoidCapitals() ? "--no-capitalize"
                                                   : "--capitalize");


### PR DESCRIPTION
Checking the checkbox "Generate easy to memorize but less secure passwords"
(aka `isLessRandom()`)
means _omitting_ "--secure" option to `pwgen`.
Unchecking the checkbox means _passing_ "--secure" option to `pwgen`,
which is meant to be the default for QtPass.

This got broken in
b11e71d331310c27fde3e53a098ba108bc8f0f61 Use new executor in Pass

Fix this by inverting the check once again.