### PR TITLE
Fixes and improvments for config dialog

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -107,6 +107,12 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
     useSelection(QtPassSettings::isUseSelection());
   }
 
+  if (Util::checkConfig()) {
+    // Show Programs tab, which is likely
+    // what the user needs to fix now.
+    ui->tabWidget->setCurrentIndex(1);
+  }
+
   connect(ui->profileTable, &QTableWidget::itemChanged, this,
           &ConfigDialog::onProfileTableItemChanged);
   connect(this, &ConfigDialog::accepted, this, &ConfigDialog::on_accepted);

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -224,6 +224,20 @@ void ConfigDialog::on_accepted() {
   QtPassSettings::setVersion(VERSION);
 }
 
+void ConfigDialog::on_autodetectButton_clicked()
+{
+    QString pass = Util::findBinaryInPath("pass");
+    if (!pass.isEmpty()) ui->passPath->setText(pass);
+    usePass(!pass.isEmpty());
+    QString gpg = Util::findBinaryInPath("gpg2");
+    if (gpg.isEmpty()) gpg = Util::findBinaryInPath("gpg");
+    if (!gpg.isEmpty()) ui->gpgPath->setText(gpg);
+    QString git = Util::findBinaryInPath("git");
+    if (!git.isEmpty()) ui->gitPath->setText(git);
+    QString pwgen = Util::findBinaryInPath("pwgen");
+    if (!pwgen.isEmpty()) ui->pwgenPath->setText(pwgen);
+}
+
 /**
  * @brief ConfigDialog::on_radioButtonNative_clicked wrapper for
  * ConfigDialog::setGroupBoxState()

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -48,6 +48,7 @@ protected:
 
 private slots:
   void on_accepted();
+  void on_autodetectButton_clicked();
   void on_radioButtonNative_clicked();
   void on_radioButtonPass_clicked();
   void on_toolButtonGit_clicked();

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -767,6 +767,30 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="autodetectButton">
+           <property name="text">
+            <string>Autodetect</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -351,9 +351,11 @@ void MainWindow::on_treeView_doubleClicked(const QModelIndex &index) {
  * @brief MainWindow::deselect clear the selection, password and copy buffer
  */
 void MainWindow::deselect() {
-  currentDir = "/";
+  currentDir = "";
   m_qtPass->clearClipboard();
   ui->passwordName->setText("");
+  ui->actionDelete->setEnabled(false);
+  ui->actionEdit->setEnabled(false);
   clearPanel(false);
 }
 
@@ -626,7 +628,7 @@ void MainWindow::onDelete() {
 
   QString dirMessage = tr(" and the whole content?");
   if (isDir) {
-    QDirIterator it(model.rootPath() + "/" + file,
+    QDirIterator it(model.rootPath() + QDir::separator() + file,
                     QDirIterator::Subdirectories);
     bool okDir = true;
     while (it.hasNext() && okDir) {

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -263,8 +263,8 @@ QString QtPassSettings::getPassStore(const QString &defaultValue) {
   }
 
   // ensure path ends in /
-  if (!returnValue.endsWith("/")) {
-    returnValue += "/";
+  if (!returnValue.endsWith("/") && !returnValue.endsWith(QDir::separator())) {
+    returnValue += QDir::separator();
   }
 
   return returnValue;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -136,7 +136,7 @@ bool Util::checkConfig() {
 QString Util::getDir(const QModelIndex &index, bool forPass,
                      const QFileSystemModel &model,
                      const StoreModel &storeModel) {
-  QString abspath = QDir(QtPassSettings::getPassStore()).absolutePath() + '/';
+  QString abspath = QDir(QtPassSettings::getPassStore()).absolutePath() + QDir::separator();
   if (!index.isValid())
     return forPass ? "" : abspath;
   QFileInfo info = model.fileInfo(storeModel.mapToSource(index));
@@ -145,7 +145,7 @@ QString Util::getDir(const QModelIndex &index, bool forPass,
   if (forPass) {
     filePath = QDir(abspath).relativeFilePath(filePath);
   }
-  filePath += '/';
+  filePath += QDir::separator();
   return filePath;
 }
 


### PR DESCRIPTION
- Fix endless append of / at end of password store path on Windows
- When the user is told to fix the binaries configuration, send the straight to the proper tab to fix it
- Add an autodetect button for the programs, so that if the user forgot to install dependencies onfirst start they don't have to fill everything in manually once they did.