### PR TITLE
For config check, check that the selected binary is available.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,8 +131,9 @@ QString Util::findBinaryInPath(QString binary) {
 bool Util::checkConfig() {
   return !QFile(QDir(QtPassSettings::getPassStore()).filePath(".gpg-id"))
               .exists() ||
-         (!QtPassSettings::getPassExecutable().startsWith("wsl ") &&
-          !QFile(QtPassSettings::getPassExecutable()).exists() &&
+         (QtPassSettings::isUsePass() ?
+          !QtPassSettings::getPassExecutable().startsWith("wsl ") &&
+          !QFile(QtPassSettings::getPassExecutable()).exists() :
           !QtPassSettings::getGpgExecutable().startsWith("wsl ") &&
           !QFile(QtPassSettings::getGpgExecutable()).exists());
 }


### PR DESCRIPTION
pass being available is irrelevant if QtPass was configured to
use gpg for example.