### PR TITLE
Use key fingerprint as ID instead of “long” ID.

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -127,7 +127,7 @@ void Pass::GenerateGPGKeys(QString batch) {
  */
 QList<UserInfo> Pass::listKeys(QStringList keystrings, bool secret) {
   QList<UserInfo> users;
-  QStringList args = {"--no-tty", "--with-colons"};
+  QStringList args = {"--no-tty", "--with-colons", "--with-fingerprint"};
   args.append(secret ? "--list-secret-keys" : "--list-keys");
 
   foreach (QString keystring, keystrings) {
@@ -156,6 +156,8 @@ QList<UserInfo> Pass::listKeys(QStringList keystrings, bool secret) {
       current_user.expiry.setTime_t(props[6].toUInt());
     } else if (current_user.name.isEmpty() && props[0] == "uid") {
       current_user.name = props[9];
+    } else if ((props[0] == "fpr") && props[9].endsWith(current_user.key_id)) {
+      current_user.key_id = props[9];
     }
   }
   if (!current_user.key_id.isEmpty())


### PR DESCRIPTION
It is generally assumed that for applications demanding good security, the full key fingerprint should be used instead of just the 64-bit or, let alone, 32-bit key ID.

This PR uses the key fingerprint from GPG to replace the key ID. It works by waiting for an `fpr` record in the key list and, if it looks like belonging to the key at hand by comparing the end of the fingerprint to the previously found ID, replacing the `key_id` field with it (it should normally be the next line after the `pub` or `sec` record).

As a bonus, this increases compatibility with other frontends, like gopass-pw, which use the fingerprint and would cause unwanted updates of `.gpg-id`.