### PR TITLE
Fix missing app ID and icon on Wayland.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -92,6 +92,10 @@ int main(int argc, char *argv[]) {
                    &MainWindow::messageAvailable);
 #endif
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
+  QGuiApplication::setDesktopFileName("qtpass.desktop");
+#endif
+
   w.show();
 
   return SingleApplication::exec();


### PR DESCRIPTION
X11/Wayland needs to know the name of the .desktop file to show a dock
icon and application name. X11 has various means of guessing the
filename (often WM_NAME). Wayland is a bit more strict, and requires
that either the filename match the AppId or the .desktop filename be
specified.

By specifying the .desktop filename QT will set the AppId automatically (from the `Exec` field I believe):
```
$ WAYLAND_DEBUG=1 ./result/bin/qtpass |& grep 'xdg_toplevel@[0-9]\+\.set_app_id'
[4110074.755]  -> xdg_toplevel@23.set_app_id("qtpass")
```

Tested on a Gnome 3.32 Wayland session. To run using XWayland, set `QT_QPA_PLATFORM=xcb`. To run using Wayland set `QT_QPA_PLATFORM=wayland`.