### PR TITLE
Add support for passwords and directories renaming as requested in #463

### DIFF
--- a/localization/localization_ar_MA.ts
+++ b/localization/localization_ar_MA.ts
@@ -561,13 +561,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +618,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -665,12 +665,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -686,12 +686,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -732,8 +732,34 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -744,7 +770,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>

--- a/localization/localization_ar_MA.ts
+++ b/localization/localization_ar_MA.ts
@@ -665,12 +665,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_ca.ts
+++ b/localization/localization_ca.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Edita</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Suprimeix</translation>
     </message>
@@ -649,7 +649,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Usuaris</translation>
     </message>
@@ -758,12 +758,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Contrasenya</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation>Codi OTP</translation>
     </message>
@@ -811,12 +811,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Fitxer nou</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Fitxer de contrasenyes nou: 
@@ -838,7 +838,33 @@ p, li { white-space: pre-wrap; }
         <translation>Esteu segur que voleu suprimir %1%2</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Suprimir la contrasenya?</translation>
     </message>
@@ -898,7 +924,7 @@ p, li { white-space: pre-wrap; }
         <translation>Afegeix una contrasenya</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Carpeta nova: 

--- a/localization/localization_ca.ts
+++ b/localization/localization_ca.ts
@@ -758,12 +758,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Contrasenya</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation>Codi OTP</translation>
     </message>

--- a/localization/localization_cs_CZ.ts
+++ b/localization/localization_cs_CZ.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Upravit</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -643,7 +643,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Uživatelé</translation>
     </message>
@@ -740,12 +740,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished">Heslo</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -793,12 +793,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nový soubor</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Nový soubor s heslem: 
@@ -820,7 +820,33 @@ p, li { white-space: pre-wrap; }
         <translation>Opravdu chcete smazat %1%2?</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Smazat heslo?</translation>
     </message>
@@ -876,7 +902,7 @@ p, li { white-space: pre-wrap; }
         <translation>Přidat heslo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Nový adresář: 

--- a/localization/localization_cs_CZ.ts
+++ b/localization/localization_cs_CZ.ts
@@ -740,12 +740,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished">Heslo</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -562,13 +562,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Ändern</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
@@ -631,7 +631,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Benutzer</translation>
     </message>
@@ -685,11 +685,37 @@ p, li { white-space: pre-wrap; }
         <translation>Öffnen Sie den Ordner mit dem Dateimanager</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Neuer Ordner:
 (Wird in %1 platziert werden)</translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to connect WebDAV:
@@ -727,18 +753,18 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Passwort ausgeblendet</translation>
     </message>
     <message>
-        <location line="-565"/>
+        <location line="-626"/>
         <source>Content hidden</source>
         <translation>Inhalt ausgeblendet</translation>
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation>OTP-Code</translation>
     </message>
@@ -815,12 +841,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Neue Datei</translation>
     </message>
     <message>
-        <location line="-303"/>
+        <location line="-310"/>
         <source>Delete password?</source>
         <translation>Passwort löschen?</translation>
     </message>

--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -759,12 +759,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation>OTP-Code</translation>
     </message>

--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -561,13 +561,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Ändern</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
@@ -630,7 +630,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Benutzer</translation>
     </message>
@@ -684,11 +684,37 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Neuer Ordner:
 (Wird in %1 platziert werden)</translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to connect WebDAV:
@@ -726,18 +752,18 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Passwort ausgeblendet</translation>
     </message>
     <message>
-        <location line="-565"/>
+        <location line="-626"/>
         <source>Content hidden</source>
         <translation>Inhalt ausgeblendet</translation>
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -810,12 +836,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Neue Datei</translation>
     </message>
     <message>
-        <location line="-303"/>
+        <location line="-310"/>
         <source>Delete password?</source>
         <translation>Passwort löschen?</translation>
     </message>

--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -758,12 +758,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_el_GR.ts
+++ b/localization/localization_el_GR.ts
@@ -543,7 +543,7 @@ Expire-Date: 0
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+189"/>
+        <location filename="../src/mainwindow.cpp" line="+190"/>
         <source>Welcome to QtPass %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,12 +560,12 @@ Expire-Date: 0
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -581,12 +581,12 @@ Expire-Date: 0
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -627,8 +627,34 @@ Expire-Date: 0
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -639,7 +665,7 @@ Expire-Date: 0
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -667,13 +693,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-50"/>
+        <location filename="../src/mainwindow.cpp" line="-57"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -724,7 +750,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_el_GR.ts
+++ b/localization/localization_el_GR.ts
@@ -560,12 +560,12 @@ Expire-Date: 0
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_en_GB.ts
+++ b/localization/localization_en_GB.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -660,7 +660,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Users</translation>
     </message>
@@ -769,12 +769,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation>OTP Code</translation>
     </message>
@@ -822,12 +822,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>New file</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>New password file: 
@@ -849,7 +849,33 @@ p, li { white-space: pre-wrap; }
         <translation>Are you sure you want to delete %1%2</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Delete password?</translation>
     </message>
@@ -909,7 +935,7 @@ p, li { white-space: pre-wrap; }
         <translation>Add password</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>New Folder: 

--- a/localization/localization_en_GB.ts
+++ b/localization/localization_en_GB.ts
@@ -769,12 +769,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation>OTP Code</translation>
     </message>

--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -660,7 +660,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Users</translation>
     </message>
@@ -769,12 +769,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation>OTP Code</translation>
     </message>
@@ -822,12 +822,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>New file</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>New password file: 
@@ -849,7 +849,33 @@ p, li { white-space: pre-wrap; }
         <translation>Are you sure you want to delete %1%2</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Delete password?</translation>
     </message>
@@ -909,7 +935,7 @@ p, li { white-space: pre-wrap; }
         <translation>Add password</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>New Folder: 

--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -769,12 +769,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation>OTP Code</translation>
     </message>

--- a/localization/localization_es_ES.ts
+++ b/localization/localization_es_ES.ts
@@ -554,13 +554,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
@@ -623,7 +623,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Usuarios</translation>
     </message>
@@ -688,6 +688,32 @@ p, li { white-space: pre-wrap; }
         <translation>Está seguro que quiere borrar %1%2?</translation>
     </message>
     <message>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Failed to connect WebDAV:
 </source>
         <translation type="vanished">No se pudo conectar WebDAV:</translation>
@@ -715,18 +741,18 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Contraseña oculta</translation>
     </message>
     <message>
-        <location line="-262"/>
+        <location line="-626"/>
         <source>Content hidden</source>
         <translation>Contenido oculto</translation>
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,7 +790,7 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">QProcess::Error desconocido</translation>
     </message>
     <message>
-        <location line="+518"/>
+        <location line="+525"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -779,7 +805,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="-58"/>
+        <location filename="../src/mainwindow.cpp" line="-65"/>
         <source>Add folder</source>
         <translation>Añadir carpeta</translation>
     </message>
@@ -810,12 +836,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nuevo fichero</translation>
     </message>
     <message>
-        <location line="-303"/>
+        <location line="-310"/>
         <source>Delete password?</source>
         <translation>Borrar contraseña?</translation>
     </message>

--- a/localization/localization_es_ES.ts
+++ b/localization/localization_es_ES.ts
@@ -747,12 +747,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -740,12 +740,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Editer</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -643,7 +643,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Utilisateurs</translation>
     </message>
@@ -740,12 +740,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -793,12 +793,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nouveau fichier</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Enregistrement d&apos;un nouveau mot de passe :
@@ -820,7 +820,33 @@ p, li { white-space: pre-wrap; }
         <translation>Êtes-vous sûr de vouloir supprimer %1%2?</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Supprimer le mot de passe ?</translation>
     </message>
@@ -876,7 +902,7 @@ p, li { white-space: pre-wrap; }
         <translation>Ajouter un mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Nouveau dossier :

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -758,12 +758,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Editer</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -648,7 +648,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Utilisateurs</translation>
     </message>
@@ -758,12 +758,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -811,12 +811,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nouveau fichier</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -837,9 +837,35 @@ p, li { white-space: pre-wrap; }
         <translation>Êtes-vous certain de vouloir supprimer %1%2?</translation>
     </message>
     <message>
-        <location line="+303"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -849,7 +875,7 @@ p, li { white-space: pre-wrap; }
 (Placé dans %1)</translation>
     </message>
     <message>
-        <location line="-304"/>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Supprimer le mot de passe ?</translation>
     </message>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -740,12 +740,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Editer</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -643,7 +643,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Utilisateurs</translation>
     </message>
@@ -740,12 +740,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -793,12 +793,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nouveau fichier</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Enregistrement d&apos;un nouveau mot de passe :
@@ -820,7 +820,33 @@ p, li { white-space: pre-wrap; }
         <translation>Êtes-vous sûr de vouloir supprimer %1%2?</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Supprimer le mot de passe ?</translation>
     </message>
@@ -876,7 +902,7 @@ p, li { white-space: pre-wrap; }
         <translation>Ajouter un mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Nouveau dossier :

--- a/localization/localization_gl_ES.ts
+++ b/localization/localization_gl_ES.ts
@@ -780,12 +780,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_gl_ES.ts
+++ b/localization/localization_gl_ES.ts
@@ -628,13 +628,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -685,7 +685,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -780,12 +780,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,12 +825,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -871,8 +871,34 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -883,7 +909,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>

--- a/localization/localization_he_IL.ts
+++ b/localization/localization_he_IL.ts
@@ -561,13 +561,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +618,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -665,12 +665,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -686,12 +686,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -732,8 +732,34 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -744,7 +770,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>

--- a/localization/localization_he_IL.ts
+++ b/localization/localization_he_IL.ts
@@ -665,12 +665,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_hu_HU.ts
+++ b/localization/localization_hu_HU.ts
@@ -561,13 +561,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +618,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,12 +673,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+206"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -718,12 +718,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -764,8 +764,34 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -776,7 +802,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>

--- a/localization/localization_hu_HU.ts
+++ b/localization/localization_hu_HU.ts
@@ -673,12 +673,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+206"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_it_IT.ts
+++ b/localization/localization_it_IT.ts
@@ -575,13 +575,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -651,7 +651,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Utenti</translation>
     </message>
@@ -780,12 +780,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation>Codice OTP</translation>
     </message>
@@ -833,12 +833,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nuovo file</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Nuovo file password:
@@ -860,7 +860,33 @@ p, li { white-space: pre-wrap; }
         <translation>Sei sicuro di voler eliminare %1%2</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Eliminare password?</translation>
     </message>
@@ -920,7 +946,7 @@ p, li { white-space: pre-wrap; }
         <translation>Aggiungi password</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Nuova cartella:

--- a/localization/localization_it_IT.ts
+++ b/localization/localization_it_IT.ts
@@ -780,12 +780,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation>Codice OTP</translation>
     </message>

--- a/localization/localization_lb_LU.ts
+++ b/localization/localization_lb_LU.ts
@@ -561,13 +561,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +618,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -665,12 +665,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -686,12 +686,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -732,8 +732,34 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -744,7 +770,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>

--- a/localization/localization_lb_LU.ts
+++ b/localization/localization_lb_LU.ts
@@ -665,12 +665,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_nl.ts
+++ b/localization/localization_nl.ts
@@ -762,12 +762,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation>OTP Code</translation>
     </message>

--- a/localization/localization_nl.ts
+++ b/localization/localization_nl.ts
@@ -574,13 +574,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Bewerken</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
@@ -659,7 +659,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Gebruikers</translation>
     </message>
@@ -762,12 +762,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation>OTP Code</translation>
     </message>
@@ -815,12 +815,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Nieuw bestand</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Nieuw wachtwoordbestand:
@@ -842,7 +842,33 @@ p, li { white-space: pre-wrap; }
         <translation>Weet je zeker dat je %1%2 wil verwijderen</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>Verwijder wachtwoord?</translation>
     </message>
@@ -902,7 +928,7 @@ p, li { white-space: pre-wrap; }
         <translation>Voeg wachtwoord toe</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Nieuwe map: 

--- a/localization/localization_pl_PL.ts
+++ b/localization/localization_pl_PL.ts
@@ -543,7 +543,7 @@ Expire-Date: 0
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+189"/>
+        <location filename="../src/mainwindow.cpp" line="+190"/>
         <source>Welcome to QtPass %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,12 +560,12 @@ Expire-Date: 0
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -581,12 +581,12 @@ Expire-Date: 0
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -627,8 +627,34 @@ Expire-Date: 0
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+22"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/mainwindow.ui"/>
-        <location filename="../src/mainwindow.cpp" line="+1"/>
+        <location filename="../src/mainwindow.cpp" line="-119"/>
         <source>Add folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -639,7 +665,7 @@ Expire-Date: 0
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation type="unfinished"></translation>
@@ -667,13 +693,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-50"/>
+        <location filename="../src/mainwindow.cpp" line="-57"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -724,7 +750,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_pl_PL.ts
+++ b/localization/localization_pl_PL.ts
@@ -560,12 +560,12 @@ Expire-Date: 0
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_pt_PT.ts
+++ b/localization/localization_pt_PT.ts
@@ -727,12 +727,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_pt_PT.ts
+++ b/localization/localization_pt_PT.ts
@@ -554,13 +554,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Remover</translation>
     </message>
@@ -623,7 +623,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Utilizadores</translation>
     </message>
@@ -727,12 +727,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -780,12 +780,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Novo ficheiro</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>Novo ficheiro de password:
@@ -807,7 +807,33 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">De certeza que deseja remover %1%2?</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete folder?</source>
         <translation>Remover pasta?</translation>
     </message>
@@ -863,7 +889,7 @@ p, li { white-space: pre-wrap; }
         <translation>Adicionar password</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Nova pasta: (Será colocada em %1 )</translation>

--- a/localization/localization_ru_RU.ts
+++ b/localization/localization_ru_RU.ts
@@ -602,13 +602,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Изменить</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -644,7 +644,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Пользователи</translation>
     </message>
@@ -718,7 +718,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+66"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Новая папка:
@@ -737,18 +737,18 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Добавить папку</translation>
     </message>
     <message>
-        <location line="-565"/>
+        <location line="-572"/>
         <source>Content hidden</source>
         <translation>Содержимое скрыто</translation>
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -810,6 +810,32 @@ p, li { white-space: pre-wrap; }
         <translation>Удалить папку?</translation>
     </message>
     <message>
+        <location line="+267"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to delete %1%2?</source>
         <translation type="obsolete">Вы в самом деле хотите удалить %1? {1%2??}</translation>
     </message>
@@ -818,7 +844,7 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Генерирую ключевую пару GPG</translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="-247"/>
         <source>Profile changed to %1</source>
         <translation>Профиль изменён на %1</translation>
     </message>
@@ -868,12 +894,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="-49"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Новый файл</translation>
     </message>
     <message>
-        <location line="-303"/>
+        <location line="-310"/>
         <source>Delete password?</source>
         <translation>Удалить пароль?</translation>
     </message>

--- a/localization/localization_ru_RU.ts
+++ b/localization/localization_ru_RU.ts
@@ -743,12 +743,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -555,13 +555,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>Ändra</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>Ta bort</translation>
     </message>
@@ -624,7 +624,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>Användare</translation>
     </message>
@@ -694,9 +694,35 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Vill du verkligen ta bort %%21?</translation>
     </message>
     <message>
-        <location line="+303"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -727,13 +753,13 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Gömt lösenord</translation>
     </message>
     <message>
-        <location line="-565"/>
+        <location line="-626"/>
         <source>Content hidden</source>
         <translation>Gömt innehåll</translation>
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation type="unfinished">Lösenord</translation>
     </message>
@@ -742,7 +768,7 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Urklippet ej rensat</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-659"/>
         <source>Password and Content hidden</source>
         <translation>Gömt lösenord och innehåll</translation>
     </message>
@@ -787,12 +813,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>Ny fil</translation>
     </message>
     <message>
-        <location line="-303"/>
+        <location line="-310"/>
         <source>Delete password?</source>
         <translation>Ta bort lösenord?</translation>
     </message>

--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -759,7 +759,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation type="unfinished">Lösenord</translation>
     </message>
@@ -768,7 +768,7 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Urklippet ej rensat</translation>
     </message>
     <message>
-        <location line="-659"/>
+        <location line="-657"/>
         <source>Password and Content hidden</source>
         <translation>Gömt lösenord och innehåll</translation>
     </message>

--- a/localization/localization_zh_CN.ts
+++ b/localization/localization_zh_CN.ts
@@ -573,13 +573,13 @@ Expire-Date: 0
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+906"/>
+        <location filename="../src/mainwindow.cpp" line="+907"/>
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="+12"/>
+        <location filename="../src/mainwindow.cpp" line="+19"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -642,7 +642,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location/>
-        <location filename="../src/mainwindow.cpp" line="-18"/>
+        <location filename="../src/mainwindow.cpp" line="-25"/>
         <source>Users</source>
         <translation>用户</translation>
     </message>
@@ -739,12 +739,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+651"/>
+        <location line="+702"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
-        <location line="-627"/>
+        <location line="-678"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -792,12 +792,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+97"/>
-        <location line="+351"/>
+        <location line="+358"/>
         <source>New file</source>
         <translation>新密码</translation>
     </message>
     <message>
-        <location line="-350"/>
+        <location line="-357"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
         <translation>新建密码：
@@ -819,7 +819,33 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">确定删除 %1%2?</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="+266"/>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rename password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+33"/>
+        <source>Rename file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>Rename Folder To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Rename File To: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-365"/>
         <source>Delete password?</source>
         <translation>删除密码？</translation>
     </message>
@@ -875,7 +901,7 @@ p, li { white-space: pre-wrap; }
         <translation>新密码</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="+57"/>
+        <location filename="../src/mainwindow.cpp" line="+64"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>新建文件夹：

--- a/localization/localization_zh_CN.ts
+++ b/localization/localization_zh_CN.ts
@@ -739,12 +739,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location line="+4"/>
-        <location line="+702"/>
+        <location line="+700"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
-        <location line="-678"/>
+        <location line="-676"/>
         <source>OTP Code</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -27,7 +27,6 @@
 #include <QMessageBox>
 #include <QShortcut>
 #include <QTimer>
-#include<QDebug>
 
 /**
  * @brief MainWindow::MainWindow handles all of the main functionality and also

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -27,6 +27,7 @@
 #include <QMessageBox>
 #include <QShortcut>
 #include <QTimer>
+#include<QDebug>
 
 /**
  * @brief MainWindow::MainWindow handles all of the main functionality and also
@@ -915,6 +916,13 @@ void MainWindow::showContextMenu(const QPoint &pos) {
     // SLOT(copyPasswordToClipboard()));
     // }
     contextMenu.addSeparator();
+    if (fileOrFolder.isDir()) {
+      QAction *renameFolder = contextMenu.addAction(tr("Rename folder"));
+      connect(renameFolder, &QAction::triggered, this, &MainWindow::renameFolder);
+    } else if (fileOrFolder.isFile()) {
+      QAction *renamePassword = contextMenu.addAction(tr("Rename password"));
+      connect(renamePassword, &QAction::triggered, this, &MainWindow::renamePassword);
+    }
     QAction *deleteItem = contextMenu.addAction(tr("Delete"));
     connect(deleteItem, &QAction::triggered, this, &MainWindow::onDelete);
   }
@@ -966,6 +974,27 @@ void MainWindow::addFolder() {
 }
 
 /**
+ * @brief MainWindow::renameFolder rename an existing folder
+ */
+void MainWindow::renameFolder() {
+  bool ok;
+  QString srcDir = QDir::cleanPath(Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel));
+  QString srcDirName = QDir(srcDir).dirName();
+  QString newName =
+      QInputDialog::getText(this, tr("Rename file"),
+                            tr("Rename Folder To: "),
+                            QLineEdit::Normal,
+                            srcDirName,
+                            &ok);
+  if (!ok || newName.isEmpty())
+    return;
+  QString destDir = srcDir;
+  destDir.replace(srcDir.lastIndexOf(srcDirName), srcDirName.length(), newName);
+  QtPassSettings::getPass()->Move(srcDir, destDir);
+}
+
+
+/**
  * @brief MainWindow::editPassword read password and open edit window via
  * MainWindow::onEdit()
  */
@@ -975,6 +1004,29 @@ void MainWindow::editPassword(const QString &file) {
       onUpdate(true);
     setPassword(file, false);
   }
+}
+
+/**
+ * @brief MainWindow::renamePassword rename or move an existing password
+ */
+void MainWindow::renamePassword() {
+  bool ok;
+  QString file = getFile(ui->treeView->currentIndex(), false);
+  QString fileName = QFileInfo(file).baseName();
+  QString newName =
+      QInputDialog::getText(this, tr("Rename file"),
+                            tr("Rename File To: "),
+                            QLineEdit::Normal,
+                            fileName,
+                            &ok);
+  if (!ok || newName.isEmpty())
+    return;
+  qDebug() << fileName;
+  qDebug() << newName;
+  QString newFile = file;
+  newFile.replace(file.lastIndexOf(fileName), fileName.length(), newName);
+  qDebug() << newFile;
+  QtPassSettings::getPass()->Move(file, newFile);
 }
 
 /**

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1007,7 +1007,7 @@ void MainWindow::editPassword(const QString &file) {
 }
 
 /**
- * @brief MainWindow::renamePassword rename or move an existing password
+ * @brief MainWindow::renamePassword rename an existing password
  */
 void MainWindow::renamePassword() {
   bool ok;
@@ -1021,11 +1021,9 @@ void MainWindow::renamePassword() {
                             &ok);
   if (!ok || newName.isEmpty())
     return;
-  qDebug() << fileName;
-  qDebug() << newName;
   QString newFile = file;
   newFile.replace(file.lastIndexOf(fileName), fileName.length(), newName);
-  qDebug() << newFile;
+  newFile.replace(QRegExp("\\.gpg$"), "");
   QtPassSettings::getPass()->Move(file, newFile);
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -105,7 +105,9 @@ private slots:
   void showContextMenu(const QPoint &pos);
   void showBrowserContextMenu(const QPoint &pos);
   void openFolder();
+  void renameFolder();
   void editPassword(const QString &);
+  void renamePassword();
   void focusInput();
   void copyPasswordFromTreeview();
   void passwordFromFileToClipboard(const QString &text);

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,7 +5,7 @@ QT        += core gui
 TARGET 	   = qtpass
 
 CONFIG += c++11 staticlib
-#CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
+CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 
 SOURCES   += mainwindow.cpp \
              configdialog.cpp \

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,7 +5,7 @@ QT        += core gui
 TARGET 	   = qtpass
 
 CONFIG += c++11 staticlib
-CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
+#CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 
 SOURCES   += mainwindow.cpp \
              configdialog.cpp \


### PR DESCRIPTION
Added support for renaming passwords and directories as requested in #463 and #446 
Right-clicking an entry shows a new "rename" action in the context menu.
The action opens a dialog which lets you modify the actual entry name.
The renaming is performed via the Pass::Move() method.