### PR TITLE
Add missing finishedShow() signal connection in PasswordDialog constructor (fixes the "Edit password" function)

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -58,6 +58,8 @@ PasswordDialog::PasswordDialog(const QString &file, const bool &isNew,
   setLength(m_passConfig.length);
   setPasswordCharTemplate(m_passConfig.selected);
 
+  connect(QtPassSettings::getPass(), &Pass::finishedShow, this,
+          &PasswordDialog::setPass);
   connect(QtPassSettings::getPass(), &Pass::processErrorExit, this,
           &PasswordDialog::close);
   connect(this, &PasswordDialog::accepted, this, &PasswordDialog::on_accepted);


### PR DESCRIPTION
Commit 990b89c0ee6231 ("Removed unused headers from mainwindow.cpp. Disable UseTrayIcon if it's not available for the OS.")
moved Pass finishedShow() signal connection for a PasswordDialog from
MainWindow::setPassword() to the (first) PasswordDialog constructor.

However PasswordDialog has actually two constructors, and the second one
needs to make this connection, too, otherwise the "Edit password" function
does not load the edited entry data.

See:
https://github.com/IJHack/QtPass/issues/423
https://github.com/IJHack/QtPass/issues/465
https://github.com/IJHack/QtPass/issues/470
