### PR TITLE
Restore directories-first order of passwords tree view on non-Mac platforms

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -69,9 +69,7 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   model.fetchMore(rootDir);
 
   proxyModel.setModelAndStore(&model, passStore);
-  // proxyModel.sort(0, Qt::AscendingOrder);
   selectionModel.reset(new QItemSelectionModel(&proxyModel));
-  // model.sort(0, Qt::AscendingOrder);
 
   ui->treeView->setModel(&proxyModel);
   ui->treeView->setRootIndex(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -65,7 +65,6 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 
   QString passStore = QtPassSettings::getPassStore(Util::findPasswordStore());
 
-  proxyModel.setSourceModel(&model);
   proxyModel.setModelAndStore(&model, passStore);
   // proxyModel.sort(0, Qt::AscendingOrder);
   selectionModel.reset(new QItemSelectionModel(&proxyModel));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -65,15 +65,17 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 
   QString passStore = QtPassSettings::getPassStore(Util::findPasswordStore());
 
+  QModelIndex rootDir = model.setRootPath(passStore);
+  model.fetchMore(rootDir);
+
   proxyModel.setModelAndStore(&model, passStore);
   // proxyModel.sort(0, Qt::AscendingOrder);
   selectionModel.reset(new QItemSelectionModel(&proxyModel));
-  model.fetchMore(model.setRootPath(passStore));
   // model.sort(0, Qt::AscendingOrder);
 
   ui->treeView->setModel(&proxyModel);
   ui->treeView->setRootIndex(
-      proxyModel.mapFromSource(model.setRootPath(passStore)));
+      proxyModel.mapFromSource(rootDir));
   ui->treeView->setColumnHidden(1, true);
   ui->treeView->setColumnHidden(2, true);
   ui->treeView->setColumnHidden(3, true);

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -80,6 +80,7 @@ bool StoreModel::ShowThis(const QModelIndex index) const {
  */
 void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
                                   QString passStore) {
+  setSourceModel(sourceModel);
   fs = sourceModel;
   store = std::move(passStore);
 }

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -256,3 +256,19 @@ bool StoreModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
   }
   return true;
 }
+
+bool StoreModel::lessThan(const QModelIndex &source_left,
+                          const QModelIndex &source_right) const {
+/* matches logic in QFileSystemModelSorter::compareNodes() */
+#ifndef Q_OS_MAC
+  if (fs && (source_left.column() == 0 || source_left.column() == 1)) {
+    bool leftD = fs->isDir(source_left);
+    bool rightD = fs->isDir(source_right);
+
+    if (leftD ^ rightD)
+      return leftD;
+  }
+#endif
+
+  return QSortFilterProxyModel::lessThan(source_left, source_right);
+}

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -23,6 +23,8 @@ public:
   bool ShowThis(const QModelIndex) const;
   void setModelAndStore(QFileSystemModel *sourceModel, QString passStore);
   QVariant data(const QModelIndex &index, int role) const;
+  bool lessThan(const QModelIndex &source_left,
+                const QModelIndex &source_right) const override;
 
   // QAbstractItemModel interface
 public:


### PR DESCRIPTION
Since commit b4dc9e6 ("Auto update CHANGELOG and sorting of treeview")
directories are no longer listed first in the tree view of passwords.

This is because a simple sort of the tree view widget (as enabled by the
aforementioned commit) does its work by sorting the backing
StoreModel (QSortFilterProxyModel), which in turn does just a simple
lexicographical order sort on the path of each its item.

Before that commit the sort was done by QFileSystemModel via
QFileSystemModelSorter, which always places its directories first on
non-Mac platforms.

Unfortunately, QFileSystemModelSorter is an internal Qt helper class, so we
can't just use it directly, we need to open-code a bit of logic from
QFileSystemModelSorter::compareNodes() into StoreModel::lessThan() to
restore the old behavior.

This PR also contains 3 small improvements around the modified code (in
separate commits).
