### PR TITLE
Main window entry details improvements

### DIFF
--- a/src/filecontent.cpp
+++ b/src/filecontent.cpp
@@ -1,11 +1,15 @@
 #include "filecontent.h"
 
+static bool isLineHidden(const QString &line) {
+	return line.startsWith("otpauth://", Qt::CaseInsensitive);
+}
+
 FileContent FileContent::parse(const QString &fileContent,
                                const QStringList &templateFields,
                                bool allFields) {
   QStringList lines = fileContent.split("\n");
   QString password = lines.takeFirst();
-  QStringList remainingData;
+  QStringList remainingData, remainingDataDisplay;
   NamedValues namedValues;
   for (const QString &line : lines) {
     if (line.contains(":")) {
@@ -20,9 +24,13 @@ FileContent FileContent::parse(const QString &fileContent,
         continue;
       }
     }
+
     remainingData.append(line);
+    if (!isLineHidden(line))
+      remainingDataDisplay.append(line);
   }
-  return FileContent(password, namedValues, remainingData.join("\n"));
+  return FileContent(password, namedValues, remainingData.join("\n"),
+                     remainingDataDisplay.join("\n"));
 }
 
 QString FileContent::getPassword() const { return this->password; }
@@ -31,11 +39,16 @@ NamedValues FileContent::getNamedValues() const { return this->namedValues; }
 
 QString FileContent::getRemainingData() const { return this->remainingData; }
 
+QString FileContent::getRemainingDataForDisplay() const {
+  return this->remainingDataDisplay;
+}
+
 FileContent::FileContent(const QString &password,
                          const NamedValues &namedValues,
-                         const QString &remainingData)
+                         const QString &remainingData,
+                         const QString &remainingDataDisplay)
     : password(password), namedValues(namedValues),
-      remainingData(remainingData) {}
+      remainingData(remainingData), remainingDataDisplay(remainingDataDisplay) {}
 
 NamedValues::NamedValues() : QList() {}
 

--- a/src/filecontent.h
+++ b/src/filecontent.h
@@ -28,8 +28,8 @@ public:
    * @brief parse parses the given fileContent in a FileContent object.
    * The password is accessible through getPassword.
    * The named value pairs (name: value) are parsed and depeding on the
-   * templateFields and allFields parameters accessible through getNamedValues
-   * or getRemainingData.
+   * templateFields and allFields parameters accessible through getNamedValues,
+   * getRemainingData or getRemainingDataForDisplay.
    *
    * @param fileContent the file content to parse.
    *
@@ -61,13 +61,19 @@ public:
    */
   QString getRemainingData() const;
 
+  /**
+   * @like getRemainingData but without data that should not be displayed
+   * (like a TOTP secret).
+   */
+  QString getRemainingDataForDisplay() const;
+
 private:
   FileContent(const QString &password, const NamedValues &namedValues,
-              const QString &remainingData);
+              const QString &remainingData, const QString &remainingDataDisplay);
 
   QString password;
   NamedValues namedValues;
-  QString remainingData;
+  QString remainingData, remainingDataDisplay;
 };
 
 #endif // FILECONTENT_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -399,7 +399,8 @@ void MainWindow::passShowHandler(const QString &p_output) {
       ui->verticalLayoutPassword->setSpacing(0);
     else
       ui->verticalLayoutPassword->setSpacing(6);
-    output = fileContent.getRemainingData();
+
+    output = fileContent.getRemainingDataForDisplay();
   }
 
   if (QtPassSettings::isUseAutoclearPanel()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -203,10 +203,6 @@ void MainWindow::cleanKeygenDialog() {
   this->keygen = nullptr;
 }
 
-void MainWindow::setTextTextBrowser(const QString &text) {
-  ui->textBrowser->setText(text);
-}
-
 void MainWindow::flashText(const QString &text, const bool isError,
                            const bool isHtml) {
   if (isError)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -406,6 +406,7 @@ void MainWindow::passShowHandler(const QString &p_output) {
     clearPanelTimer.start();
   }
 
+  emit passShowHandlerFinished(output);
   setUiElementsEnabled(true);
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -49,7 +49,6 @@ public:
   void userDialog(QString = "");
   void config();
 
-  void setTextTextBrowser(const QString &text);
   void setUiElementsEnabled(bool state);
   void flashText(const QString &text, const bool isError,
                  const bool isHtml = false);
@@ -66,7 +65,6 @@ protected:
   bool eventFilter(QObject *obj, QEvent *event);
 
 signals:
-  void uiEnabled(bool state);
   void passShowHandlerFinished(QString output);
   void passGitInitNeeded();
   void generateGPGKeyPair(QString batch);

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -121,6 +121,9 @@ void QtPass::setMainWindow(MainWindow *mW) {
   connectPassSignalHandlers(QtPassSettings::getRealPass());
   connectPassSignalHandlers(QtPassSettings::getImitatePass());
 
+  connect(m_mainWindow, &MainWindow::passShowHandlerFinished, this,
+          &QtPass::passShowHandlerFinished);
+
   // only for ipass
   connect(QtPassSettings::getImitatePass(), &ImitatePass::startReencryptPath,
           m_mainWindow, &MainWindow::startReencryptPath);
@@ -144,13 +147,10 @@ void QtPass::setMainWindow(MainWindow *mW) {
 void QtPass::connectPassSignalHandlers(Pass *pass) {
   connect(pass, &Pass::error, this, &QtPass::processError);
   connect(pass, &Pass::processErrorExit, this, &QtPass::processErrorExit);
-
   connect(pass, &Pass::critical, m_mainWindow, &MainWindow::critical);
   connect(pass, &Pass::startingExecuteWrapper, m_mainWindow,
           &MainWindow::executeWrapperStarted);
   connect(pass, &Pass::statusMsg, m_mainWindow, &MainWindow::showStatusMessage);
-  connect(m_mainWindow, &MainWindow::passShowHandlerFinished, this,
-          &QtPass::passShowHandlerFinished);
   connect(pass, &Pass::finishedShow, m_mainWindow,
           &MainWindow::passShowHandler);
   connect(pass, &Pass::finishedOtpGenerate, m_mainWindow,


### PR DESCRIPTION
This PR contains two main window entry details improvements:
1) Make password entry non-template details actually display upon selecting the entry in the main
QtPass window (fixes a regression introduced by commit 3cb140ca697367),

2) Don't show a TOTP secret when selecting a password entry since it isn't a proper way to utilize a
OTP and also it isn't safe.

Also included here is a commit that removes an unused signal and an unused function from
MainWindow class.
