### PR TITLE
Don't call QtPass::setup() from QtPass class constructor (should fix #466)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,8 +44,7 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 #endif
   ui->setupUi(this);
 
-  m_qtPass = new QtPass();
-  m_qtPass->setMainWindow(this);
+  m_qtPass = new QtPass(this);
 
   // register shortcut ctrl/cmd + Q to close the main window
   new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this, SLOT(close()));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -118,6 +118,10 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   QTimer::singleShot(10, this, SLOT(focusInput()));
 
   ui->lineEdit->setText(searchText);
+
+  if (!m_qtPass->init())
+    // no working config so this should just quit
+    QApplication::quit();
 }
 
 MainWindow::~MainWindow() { delete m_qtPass; }

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -25,12 +25,6 @@
 QtPass::QtPass(MainWindow *mainWindow) : m_mainWindow(mainWindow),
                                          clippedText(QString()),
                                          freshStart(true) {
-  if (!setup()) {
-    // no working config so this should quit without config anything
-    QApplication::quit();
-    {}
-  }
-
   setClipboardTimer();
   clearClipboardTimer.setSingleShot(true);
   connect(&clearClipboardTimer, SIGNAL(timeout()), this,
@@ -59,10 +53,10 @@ QtPass::~QtPass() {
 }
 
 /**
- * @brief QtPass::setup make sure we are ready to go as soon as
+ * @brief QtPass::init make sure we are ready to go as soon as
  * possible
  */
-bool QtPass::setup() {
+bool QtPass::init() {
   QString passStore = QtPassSettings::getPassStore(Util::findPasswordStore());
   QtPassSettings::setPassStore(passStore);
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -22,7 +22,9 @@
 #include "debughelper.h"
 #endif
 
-QtPass::QtPass() : clippedText(QString()), freshStart(true) {
+QtPass::QtPass(MainWindow *mainWindow) : m_mainWindow(mainWindow),
+                                         clippedText(QString()),
+                                         freshStart(true) {
   if (!setup()) {
     // no working config so this should quit without config anything
     QApplication::quit();
@@ -36,6 +38,8 @@ QtPass::QtPass() : clippedText(QString()), freshStart(true) {
 
   QObject::connect(qApp, &QApplication::aboutToQuit, this,
                    &QtPass::clearClipboard);
+
+  setMainWindow();
 }
 
 /**
@@ -111,8 +115,7 @@ bool QtPass::setup() {
   return true;
 }
 
-void QtPass::setMainWindow(MainWindow *mW) {
-  m_mainWindow = mW;
+void QtPass::setMainWindow(void) {
   m_mainWindow->restoreWindow();
 
   fusedav.setParent(m_mainWindow);

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -14,6 +14,7 @@ public:
   QtPass(MainWindow *mainWindow);
   ~QtPass();
 
+  bool init();
   void setClippedText(const QString &, const QString &p_output = QString());
   void clearClippedText();
   void setClipboardTimer();
@@ -30,7 +31,6 @@ private:
   bool freshStart;
 
   void setMainWindow();
-  bool setup();
   void connectPassSignalHandlers(Pass *pass);
   void mountWebDav();
 

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -11,10 +11,9 @@ class QtPass : public QObject {
   Q_OBJECT
 
 public:
-  QtPass();
+  QtPass(MainWindow *mainWindow);
   ~QtPass();
 
-  void setMainWindow(MainWindow *mW);
   void setClippedText(const QString &, const QString &p_output = QString());
   void clearClippedText();
   void setClipboardTimer();
@@ -30,6 +29,7 @@ private:
   QString clippedText;
   bool freshStart;
 
+  void setMainWindow();
   bool setup();
   void connectPassSignalHandlers(Pass *pass);
   void mountWebDav();


### PR DESCRIPTION
QtPass::setup() cannot be called from this class constructor as it
possibly calls back MainWindow::config() method.
QtPass constructor is in turn called from the MainWindow one so the
MainWindow object might not be fully constructed yet.

It looks like this was introduced in commit bc19f9e.

Rename QtPass::setup() to QtPass::init() and call it explicitly at the end
of the MainWindow constructor.

Should fix #466, but the whole thing
really needs a refactoring to establish a clear QtPass -> MainWindow (or
MainWindow -> QtPass) relationship and to make sure there aren't any
circular dependencies there (and other similar bugs).
