### PR TITLE
Don't base pass-otp availability decision on hardcoded /usr/lib

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -567,9 +567,7 @@ bool ConfigDialog::isPassOtpAvailable() {
 #elif defined(__APPLE__)
   return false;
 #else
-  QFileInfo file("/usr/lib/password-store/extensions/otp.bash");
-
-  return file.exists();
+  return true;
 #endif
 }
 


### PR DESCRIPTION
`/usr/lib` does not exist in various Linux distributions, nor does it work if you have installed your qtpass to a custom prefix such as `/usr/local` or into your home directory.

Disable this check for now, so that the OTP functionality can be enabled in such cases.

As a result, `ConfigDialog::isPassOtpAvailable()` now only has the functionality to return `false` on platforms where the OTP functionality is certainly not supported.

CC @FiloSpaTeam as the author of https://github.com/IJHack/QtPass/commit/5fc6c652af6b6cc949b571c090d5e6e65228b135 (via #407); also mentioning #394 and #327 so that this PR shows up there for others that, like me, searched for this problem.

---

A better future detection logic might be to run `pass otp --version` and check if that succeeds, but I'm not doing that here because it's more sophisticated and I'd like qtpass to work well with `pass-otp` for all users as soon as possible.