### PR TITLE
Fix blurry icons when fractional scaling is enabled

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -42,6 +42,7 @@
 int main(int argc, char *argv[]) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
   QString text = "";
   for (int i = 1; i < argc; ++i) {


### PR DESCRIPTION
...by adding UseHighDpiPixmaps flag to the main.cpp file. Currently icons are blurry with fractional scaling enabled. This change fixes this issue. I built and tested this on KDE Plasma with fractional scaling at 1.25.