### PR TITLE
Explicitly only remove ".gpg" when renaming files

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1018,7 +1018,10 @@ void MainWindow::renamePassword() {
   bool ok;
   QString file = getFile(ui->treeView->currentIndex(), false);
   QString filePath = QFileInfo(file).path();
-  QString fileName = QFileInfo(file).baseName();
+  QString fileName = QFileInfo(file).fileName();
+  if (fileName.endsWith(".gpg", Qt::CaseInsensitive))
+      fileName.chop(4);
+
   QString newName =
       QInputDialog::getText(this, tr("Rename file"), tr("Rename File To: "),
                             QLineEdit::Normal, fileName, &ok);


### PR DESCRIPTION
QFileInfo::baseName removes any path plus the complete suffix. The alternative QFileInfo::completeBaseName would only remove the last suffix (e.g. ".gz" in "foo.tar.gz") but we want to remove ".gpg" only.

Cf. https://doc.qt.io/qt-5/qfileinfo.html#completeBaseName

This fixes part of #520. I could not reproduce the other errors mentioned there ("different-name.gpg" → "different-name.account" and "`foobar.com` creates a file named `foobar.com` instead of a file named `foobar.com.gpg`").

(Only tested on GNU/Linux.)