### PR TITLE
Keep suffices when moving (to) a directory while imitiating pass

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -366,9 +366,9 @@ void ImitatePass::Move(const QString src, const QString dest,
       destFile = dest;
     }
 
-    if (!destFile.endsWith(".gpg"))
-      destFile.append(".gpg");
-
+    if (destFile.endsWith(".gpg", Qt::CaseInsensitive))
+      destFile.chop(4); // make sure suffix is lowercase
+    destFile.append(".gpg");
   } else if (srcFileInfo.isDir()) {
     if (destFileInfo.isDir()) {
       destFile = QDir(dest).filePath(srcFileBaseName);

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -350,6 +350,7 @@ void ImitatePass::Move(const QString src, const QString dest,
   QFileInfo srcFileInfo(src);
   QFileInfo destFileInfo(dest);
   QString destFile;
+  QString srcFileBaseName = srcFileInfo.fileName();
 
   if (srcFileInfo.isFile()) {
     if (destFileInfo.isFile()) {
@@ -360,7 +361,7 @@ void ImitatePass::Move(const QString src, const QString dest,
         return;
       }
     } else if (destFileInfo.isDir()) {
-      destFile = QDir(dest).filePath(srcFileInfo.baseName());
+      destFile = QDir(dest).filePath(srcFileBaseName);
     } else {
       destFile = dest;
     }
@@ -370,7 +371,7 @@ void ImitatePass::Move(const QString src, const QString dest,
 
   } else if (srcFileInfo.isDir()) {
     if (destFileInfo.isDir()) {
-      destFile = QDir(dest).filePath(srcFileInfo.baseName());
+      destFile = QDir(dest).filePath(srcFileBaseName);
     } else if (destFileInfo.isFile()) {
 #ifdef QT_DEBUG
       dbg() << "Destination is a file";
@@ -379,7 +380,6 @@ void ImitatePass::Move(const QString src, const QString dest,
     } else {
       destFile = dest;
     }
-
   } else {
 #ifdef QT_DEBUG
     dbg() << "Source file does not exist";


### PR DESCRIPTION
This makes moving a bit more robust by fixing three bugs that were not mentioned in #520 .

- 2x the same as in #558 when moving a directory and moving to a directory
- make sure filenames end with lowercase ".gpg" (can't hurt to be careful and explicit, I guess)

I still cannot reproduce the other errors in #520 .