### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ FreeBSD
 `pkg install qtpass`
 
 macOS
-`brew cask install qtpass`
+`brew install --cask qtpass`
 
 Windows
 `choco install qtpass`


### PR DESCRIPTION
Use `brew install --cask` instead of `brew cask install`

Close #564 
