### PR TITLE
Delete context menu after exec

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -947,6 +947,7 @@ void MainWindow::showBrowserContextMenu(const QPoint &pos) {
   QPoint globalPos = ui->textBrowser->viewport()->mapToGlobal(pos);
 
   contextMenu->exec(globalPos);
+  delete contextMenu;
 }
 
 /**


### PR DESCRIPTION
Delete context menu after exec to prevent "memory eating".
Also we can delete MainWindow::showBrowserContextMenu entirely because there is nothing "custom" here now.