### PR TITLE
Add more options for the password displaying

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -38,6 +38,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
   ui->checkBoxHidePassword->setChecked(QtPassSettings::isHidePassword());
   ui->checkBoxHideContent->setChecked(QtPassSettings::isHideContent());
   ui->checkBoxUseMonospace->setChecked(QtPassSettings::isUseMonospace());
+  ui->checkBoxDisplayAsIs->setChecked(QtPassSettings::isDisplayAsIs());
   ui->checkBoxAddGPGId->setChecked(QtPassSettings::isAddGPGId(true));
 
   if (QSystemTrayIcon::isSystemTrayAvailable()) {
@@ -205,6 +206,7 @@ void ConfigDialog::on_accepted() {
   QtPassSettings::setHidePassword(ui->checkBoxHidePassword->isChecked());
   QtPassSettings::setHideContent(ui->checkBoxHideContent->isChecked());
   QtPassSettings::setUseMonospace(ui->checkBoxUseMonospace->isChecked());
+  QtPassSettings::setDisplayAsIs(ui->checkBoxDisplayAsIs->isChecked());
   QtPassSettings::setAddGPGId(ui->checkBoxAddGPGId->isChecked());
   QtPassSettings::setUseTrayIcon(ui->checkBoxUseTrayIcon->isEnabled() &&
                                  ui->checkBoxUseTrayIcon->isChecked());

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -37,6 +37,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
       QtPassSettings::getAutoclearPanelSeconds());
   ui->checkBoxHidePassword->setChecked(QtPassSettings::isHidePassword());
   ui->checkBoxHideContent->setChecked(QtPassSettings::isHideContent());
+  ui->checkBoxUseMonospace->setChecked(QtPassSettings::isUseMonospace());
   ui->checkBoxAddGPGId->setChecked(QtPassSettings::isAddGPGId(true));
 
   if (QSystemTrayIcon::isSystemTrayAvailable()) {
@@ -203,6 +204,7 @@ void ConfigDialog::on_accepted() {
       ui->spinBoxAutoclearPanelSeconds->value());
   QtPassSettings::setHidePassword(ui->checkBoxHidePassword->isChecked());
   QtPassSettings::setHideContent(ui->checkBoxHideContent->isChecked());
+  QtPassSettings::setUseMonospace(ui->checkBoxUseMonospace->isChecked());
   QtPassSettings::setAddGPGId(ui->checkBoxAddGPGId->isChecked());
   QtPassSettings::setUseTrayIcon(ui->checkBoxUseTrayIcon->isEnabled() &&
                                  ui->checkBoxUseTrayIcon->isChecked());

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -39,6 +39,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
   ui->checkBoxHideContent->setChecked(QtPassSettings::isHideContent());
   ui->checkBoxUseMonospace->setChecked(QtPassSettings::isUseMonospace());
   ui->checkBoxDisplayAsIs->setChecked(QtPassSettings::isDisplayAsIs());
+  ui->checkBoxNoLineWrapping->setChecked(QtPassSettings::isNoLineWrapping());
   ui->checkBoxAddGPGId->setChecked(QtPassSettings::isAddGPGId(true));
 
   if (QSystemTrayIcon::isSystemTrayAvailable()) {
@@ -207,6 +208,7 @@ void ConfigDialog::on_accepted() {
   QtPassSettings::setHideContent(ui->checkBoxHideContent->isChecked());
   QtPassSettings::setUseMonospace(ui->checkBoxUseMonospace->isChecked());
   QtPassSettings::setDisplayAsIs(ui->checkBoxDisplayAsIs->isChecked());
+  QtPassSettings::setNoLineWrapping(ui->checkBoxNoLineWrapping->isChecked());
   QtPassSettings::setAddGPGId(ui->checkBoxAddGPGId->isChecked());
   QtPassSettings::setUseTrayIcon(ui->checkBoxUseTrayIcon->isEnabled() &&
                                  ui->checkBoxUseTrayIcon->isChecked());

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>659</width>
-    <height>650</height>
+    <height>728</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -199,6 +199,30 @@
            </item>
            <item>
             <spacer name="horizontalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_19">
+           <item>
+            <widget class="QCheckBox" name="checkBoxUseMonospace">
+             <property name="text">
+              <string>Use a monospace font</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_9">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -222,6 +222,13 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="checkBoxDisplayAsIs">
+             <property name="text">
+              <string>Display the files content as-is</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="horizontalSpacer_9">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -229,6 +229,13 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="checkBoxNoLineWrapping">
+             <property name="text">
+              <string>No line wrapping</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="horizontalSpacer_9">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -87,6 +87,9 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   connect(ui->treeView, &DeselectableTreeView::emptyClicked, this,
           &MainWindow::deselect);
 
+  if (QtPassSettings::isUseMonospace()) {
+    ui->textBrowser->setFont(QFont(QStringLiteral("Monospace")));
+  }
   ui->textBrowser->setOpenExternalLinks(true);
   ui->textBrowser->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(ui->textBrowser, &QWidget::customContextMenuRequested, this,
@@ -239,6 +242,13 @@ void MainWindow::config() {
     d->wizard(); // does shit
   if (d->exec()) {
     if (d->result() == QDialog::Accepted) {
+      // Update the textBrowser font
+      if (QtPassSettings::isUseMonospace()) {
+        ui->textBrowser->setFont(QFont(QStringLiteral("Monospace")));
+      } else {
+        ui->textBrowser->setFont(QFont());
+      }
+
       if (QtPassSettings::isAlwaysOnTop()) {
         Qt::WindowFlags flags = windowFlags();
         this->setWindowFlags(flags | Qt::WindowStaysOnTopHint);
@@ -1098,13 +1108,17 @@ void MainWindow::addToGridLayout(int position, const QString &field,
   }
 
   // set the echo mode to password, if the field is "password"
+  const QString lineStyle = QtPassSettings::isUseMonospace()
+    ? "border-style: none; background: transparent; font-family: monospace;"
+    : "border-style: none; background: transparent;";
+
   if (QtPassSettings::isHidePassword() && trimmedField == tr("Password")) {
 
     auto *line = new QLineEdit();
     line->setObjectName(trimmedField);
     line->setText(trimmedValue);
     line->setReadOnly(true);
-    line->setStyleSheet("border-style: none ; background: transparent;");
+    line->setStyleSheet(lineStyle);
     line->setContentsMargins(0, 0, 0, 0);
     line->setEchoMode(QLineEdit::Password);
     QPushButtonShowPassword *showButton =
@@ -1128,7 +1142,7 @@ void MainWindow::addToGridLayout(int position, const QString &field,
         R"(<a href="\1">\1</a>)");
     line->setText(trimmedValue);
     line->setReadOnly(true);
-    line->setStyleSheet("border-style: none ; background: transparent;");
+    line->setStyleSheet(lineStyle);
     line->setContentsMargins(0, 0, 0, 0);
     frame->layout()->addWidget(line);
   }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -395,7 +395,7 @@ void MainWindow::passShowHandler(const QString &p_output) {
   // show what is needed:
   if (QtPassSettings::isHideContent()) {
     output = "***" + tr("Content hidden") + "***";
-  } else {
+  } else if (! QtPassSettings::isDisplayAsIs()) {
     if (!password.isEmpty()) {
       // set the password, it is hidden if needed in addToGridLayout
       addToGridLayout(0, tr("Password"), password);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -90,6 +90,9 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   if (QtPassSettings::isUseMonospace()) {
     ui->textBrowser->setFont(QFont(QStringLiteral("Monospace")));
   }
+  if (QtPassSettings::isNoLineWrapping()) {
+    ui->textBrowser->setLineWrapMode(QTextBrowser::NoWrap);
+  }
   ui->textBrowser->setOpenExternalLinks(true);
   ui->textBrowser->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(ui->textBrowser, &QWidget::customContextMenuRequested, this,
@@ -247,6 +250,12 @@ void MainWindow::config() {
         ui->textBrowser->setFont(QFont(QStringLiteral("Monospace")));
       } else {
         ui->textBrowser->setFont(QFont());
+      }
+      // Update the textBrowser line wrap mode
+      if (QtPassSettings::isNoLineWrapping()) {
+        ui->textBrowser->setLineWrapMode(QTextBrowser::NoWrap);
+      } else {
+        ui->textBrowser->setLineWrapMode(QTextBrowser::WidgetWidth);
       }
 
       if (QtPassSettings::isAlwaysOnTop()) {

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -251,6 +251,15 @@ void QtPassSettings::setUseMonospace(const bool &useMonospace) {
   getInstance()->setValue(SettingsConstants::useMonospace, useMonospace);
 }
 
+bool QtPassSettings::isDisplayAsIs(const bool &defaultValue) {
+  return getInstance()
+      ->value(SettingsConstants::displayAsIs, defaultValue)
+      .toBool();
+}
+void QtPassSettings::setDisplayAsIs(const bool &displayAsIs) {
+  getInstance()->setValue(SettingsConstants::displayAsIs, displayAsIs);
+}
+
 bool QtPassSettings::isAddGPGId(const bool &defaultValue) {
   return getInstance()
       ->value(SettingsConstants::addGPGId, defaultValue)

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -260,6 +260,15 @@ void QtPassSettings::setDisplayAsIs(const bool &displayAsIs) {
   getInstance()->setValue(SettingsConstants::displayAsIs, displayAsIs);
 }
 
+bool QtPassSettings::isNoLineWrapping(const bool &defaultValue) {
+  return getInstance()
+      ->value(SettingsConstants::noLineWrapping, defaultValue)
+      .toBool();
+}
+void QtPassSettings::setNoLineWrapping(const bool &noLineWrapping) {
+  getInstance()->setValue(SettingsConstants::noLineWrapping, noLineWrapping);
+}
+
 bool QtPassSettings::isAddGPGId(const bool &defaultValue) {
   return getInstance()
       ->value(SettingsConstants::addGPGId, defaultValue)

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -242,6 +242,15 @@ void QtPassSettings::setHideContent(const bool &hideContent) {
   getInstance()->setValue(SettingsConstants::hideContent, hideContent);
 }
 
+bool QtPassSettings::isUseMonospace(const bool &defaultValue) {
+  return getInstance()
+      ->value(SettingsConstants::useMonospace, defaultValue)
+      .toBool();
+}
+void QtPassSettings::setUseMonospace(const bool &useMonospace) {
+  getInstance()->setValue(SettingsConstants::useMonospace, useMonospace);
+}
+
 bool QtPassSettings::isAddGPGId(const bool &defaultValue) {
   return getInstance()
       ->value(SettingsConstants::addGPGId, defaultValue)

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -98,6 +98,9 @@ public:
   static bool isDisplayAsIs(const bool &defaultValue = QVariant().toBool());
   static void setDisplayAsIs(const bool &displayAsIs);
 
+  static bool isNoLineWrapping(const bool &defaultValue = QVariant().toBool());
+  static void setNoLineWrapping(const bool &noLineWrapping);
+
   static bool isAddGPGId(const bool &defaultValue = QVariant().toBool());
   static void setAddGPGId(const bool &addGPGId);
 

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -92,6 +92,9 @@ public:
   static bool isHideContent(const bool &defaultValue = QVariant().toBool());
   static void setHideContent(const bool &hideContent);
 
+  static bool isUseMonospace(const bool &defaultValue = QVariant().toBool());
+  static void setUseMonospace(const bool &hideContent);
+
   static bool isAddGPGId(const bool &defaultValue = QVariant().toBool());
   static void setAddGPGId(const bool &addGPGId);
 

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -93,7 +93,10 @@ public:
   static void setHideContent(const bool &hideContent);
 
   static bool isUseMonospace(const bool &defaultValue = QVariant().toBool());
-  static void setUseMonospace(const bool &hideContent);
+  static void setUseMonospace(const bool &useMonospace);
+
+  static bool isDisplayAsIs(const bool &defaultValue = QVariant().toBool());
+  static void setDisplayAsIs(const bool &displayAsIs);
 
   static bool isAddGPGId(const bool &defaultValue = QVariant().toBool());
   static void setAddGPGId(const bool &addGPGId);

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -27,6 +27,7 @@ const QString SettingsConstants::autoclearPanelSeconds =
     "autoclearPanelSeconds";
 const QString SettingsConstants::hidePassword = "hidePassword";
 const QString SettingsConstants::hideContent = "hideContent";
+const QString SettingsConstants::useMonospace = "useMonospace";
 const QString SettingsConstants::addGPGId = "addGPGId";
 const QString SettingsConstants::passStore = "passStore";
 const QString SettingsConstants::passExecutable = "passExecutable";

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -29,6 +29,7 @@ const QString SettingsConstants::hidePassword = "hidePassword";
 const QString SettingsConstants::hideContent = "hideContent";
 const QString SettingsConstants::useMonospace = "useMonospace";
 const QString SettingsConstants::displayAsIs = "displayAsIs";
+const QString SettingsConstants::noLineWrapping = "noLineWrapping";
 const QString SettingsConstants::addGPGId = "addGPGId";
 const QString SettingsConstants::passStore = "passStore";
 const QString SettingsConstants::passExecutable = "passExecutable";

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -28,6 +28,7 @@ const QString SettingsConstants::autoclearPanelSeconds =
 const QString SettingsConstants::hidePassword = "hidePassword";
 const QString SettingsConstants::hideContent = "hideContent";
 const QString SettingsConstants::useMonospace = "useMonospace";
+const QString SettingsConstants::displayAsIs = "displayAsIs";
 const QString SettingsConstants::addGPGId = "addGPGId";
 const QString SettingsConstants::passStore = "passStore";
 const QString SettingsConstants::passExecutable = "passExecutable";

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -28,6 +28,7 @@ public:
   const static QString hideContent;
   const static QString useMonospace;
   const static QString displayAsIs;
+  const static QString noLineWrapping;
   const static QString addGPGId;
   const static QString passStore;
   const static QString passExecutable;

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -27,6 +27,7 @@ public:
   const static QString hidePassword;
   const static QString hideContent;
   const static QString useMonospace;
+  const static QString displayAsIs;
   const static QString addGPGId;
   const static QString passStore;
   const static QString passExecutable;

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -26,6 +26,7 @@ public:
   const static QString autoclearPanelSeconds;
   const static QString hidePassword;
   const static QString hideContent;
+  const static QString useMonospace;
   const static QString addGPGId;
   const static QString passStore;
   const static QString passExecutable;


### PR DESCRIPTION
This addresses both issue #586 and issue #577.

I added two additional checkboxes to the configuration dialog:

* "Use a monospace font" that, if activated, sets the system's default monospace font for both the `QTextBrowser` and all `QLineEdit`s used to display password files
* "Display the files content as-is" that, if activated, skips the parsing of the pass file content and simply puts everything into the `QTextBrowser`, as `pass` does when used on the console.

Imo this won't hurt, as the default behavior remains unchanged, but it's convenient for console pass users that want to have the same behavior in QtPass.