### PR TITLE
Fix accidental deletion of entire passwordstore

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -621,6 +621,14 @@ void MainWindow::addPassword() {
  * sure.
  */
 void MainWindow::onDelete() {
+  QModelIndex currentIndex = ui->treeView->currentIndex();
+  if (!currentIndex.isValid()) {
+    // This fixes https://github.com/IJHack/QtPass/issues/556
+    // Otherwise the entire password directory would be deleted if
+    // nothing is selected in the tree view.
+    return;
+  }
+
   QFileInfo fileOrFolder =
       model.fileInfo(proxyModel.mapToSource(ui->treeView->currentIndex()));
   QString file = "";


### PR DESCRIPTION
Fixes #556

This happens if you manage to trigger the deletion path while no directory or password is selected in the tree view.