### PR TITLE
fix bug => clipboard was not cleared when using primary selection

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -374,7 +374,8 @@ void QtPass::clearClipboard() {
   QClipboard *clipboard = QApplication::clipboard();
   bool cleared = false;
   if (this->clippedText == clipboard->text(QClipboard::Selection)) {
-    clipboard->clear(QClipboard::Clipboard);
+    clipboard->clear(QClipboard::Selection);
+    clipboard->setText(QString(""), QClipboard::Selection);
     cleared = true;
   }
   if (this->clippedText == clipboard->text(QClipboard::Clipboard)) {


### PR DESCRIPTION
Under Ubuntu Mate 22.10, the primary selection were not cleared, i found 2 issues:

- in QtPass::clearClipboard() (qtpass.cpp) if using primary selection (QClipboard::Selection) we clearing the clipboard instead (clipboard->clear(QClipboard::Clipboard);)

- after fix this first issue, i the primary selection was still not cleared, i need to fill an empty string, i'm not sure if it's the better solution, i don't know if an history is kept somewhere but when i check with:
`xclip -o`
primary selection seems to be cleared now
