### PR TITLE
Add pass store signing key feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ qmake && make && make install
 ## Using profiles
 
 Profiles allow to group passwords. Each profile might use a different git repository and/or different gpg key.
+Each profile also can be associated with a pass store singing key to verify the detached .gpg-id signature (pass only).
 A typical use case is to separate personal and work passwords.
 
 > **Hint**<br>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ qmake && make && make install
 ## Using profiles
 
 Profiles allow to group passwords. Each profile might use a different git repository and/or different gpg key.
-Each profile also can be associated with a pass store singing key to verify the detached .gpg-id signature (pass only).
+Each profile also can be associated with a pass store singing key to verify the detached .gpg-id signature.
 A typical use case is to separate personal and work passwords.
 
 > **Hint**<br>

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -97,7 +97,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
   useTemplate(QtPassSettings::isUseTemplate());
 
   ui->profileTable->verticalHeader()->hide();
-  ui->profileTable->horizontalHeader()->setStretchLastSection(true);
+  ui->profileTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
   ui->label->setText(ui->label->text() + VERSION);
   ui->comboBoxClipboard->clear();
 
@@ -170,7 +170,7 @@ void ConfigDialog::validate(QTableWidgetItem *item) {
       for (int j = 0; j < ui->profileTable->columnCount(); j++) {
         QTableWidgetItem *_item = ui->profileTable->item(i, j);
 
-        if (_item->text().isEmpty()) {
+        if (_item->text().isEmpty() && j != 2) {
           _item->setBackground(Qt::red);
           status = false;
           break;
@@ -181,7 +181,7 @@ void ConfigDialog::validate(QTableWidgetItem *item) {
         break;
     }
   } else {
-    if (item->text().isEmpty()) {
+    if (item->text().isEmpty() && item->column() != 2) {
       item->setBackground(Qt::red);
       status = false;
     }
@@ -460,8 +460,8 @@ void ConfigDialog::genKey(QString batch, QDialog *dialog) {
  * @param profiles
  * @param profile
  */
-void ConfigDialog::setProfiles(QHash<QString, QString> profiles,
-                               QString profile) {
+void ConfigDialog::setProfiles(QHash<QString, QHash<QString, QString>> profiles,
+                               QString currentProfile) {
   // dbg()<< profiles;
   if (profiles.contains("")) {
     profiles.remove("");
@@ -469,15 +469,19 @@ void ConfigDialog::setProfiles(QHash<QString, QString> profiles,
   }
 
   ui->profileTable->setRowCount(profiles.count());
-  QHashIterator<QString, QString> i(profiles);
+  QHashIterator<QString, QHash<QString, QString>> i(profiles);
   int n = 0;
   while (i.hasNext()) {
     i.next();
     if (!i.value().isEmpty() && !i.key().isEmpty()) {
-      ui->profileTable->setItem(n, 0, new QTableWidgetItem(i.key()));
-      ui->profileTable->setItem(n, 1, new QTableWidgetItem(i.value()));
+      ui->profileTable->setItem(
+        n, 0, new QTableWidgetItem(i.key()));
+      ui->profileTable->setItem(
+        n, 1, new QTableWidgetItem(i.value().value("path")));
+      ui->profileTable->setItem(
+        n, 2, new QTableWidgetItem(i.value().value("signingKey")));
       // dbg()<< "naam:" + i.key();
-      if (i.key() == profile)
+      if (i.key() == currentProfile)
         ui->profileTable->selectRow(n);
     }
     ++n;
@@ -488,17 +492,23 @@ void ConfigDialog::setProfiles(QHash<QString, QString> profiles,
  * @brief ConfigDialog::getProfiles return profile list.
  * @return
  */
-QHash<QString, QString> ConfigDialog::getProfiles() {
-  QHash<QString, QString> profiles;
+QHash<QString, QHash<QString, QString>> ConfigDialog::getProfiles() {
+  QHash<QString, QHash<QString, QString>> profiles;
   // Check?
   for (int i = 0; i < ui->profileTable->rowCount(); ++i) {
+    QHash<QString, QString> profile;
     QTableWidgetItem *pathItem = ui->profileTable->item(i, 1);
     if (nullptr != pathItem) {
       QTableWidgetItem *item = ui->profileTable->item(i, 0);
       if (item == nullptr) {
         continue;
       }
-      profiles.insert(item->text(), pathItem->text());
+      profile["path"] = pathItem->text();
+      QTableWidgetItem *signingKeyItem = ui->profileTable->item(i, 2);
+      if (nullptr != signingKeyItem) {
+        profile["signingKey"] = signingKeyItem->text();
+      }
+      profiles.insert(item->text(), profile);
     }
   }
   return profiles;
@@ -512,6 +522,7 @@ void ConfigDialog::on_addButton_clicked() {
   ui->profileTable->insertRow(n);
   ui->profileTable->setItem(n, 0, new QTableWidgetItem());
   ui->profileTable->setItem(n, 1, new QTableWidgetItem(ui->storePath->text()));
+  ui->profileTable->setItem(n, 2, new QTableWidgetItem());
   ui->profileTable->selectRow(n);
   ui->deleteButton->setEnabled(true);
 

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -97,7 +97,8 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
   useTemplate(QtPassSettings::isUseTemplate());
 
   ui->profileTable->verticalHeader()->hide();
-  ui->profileTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+  ui->profileTable->horizontalHeader()->setSectionResizeMode(
+      1, QHeaderView::Stretch);
   ui->label->setText(ui->label->text() + VERSION);
   ui->comboBoxClipboard->clear();
 
@@ -474,12 +475,11 @@ void ConfigDialog::setProfiles(QHash<QString, QHash<QString, QString>> profiles,
   while (i.hasNext()) {
     i.next();
     if (!i.value().isEmpty() && !i.key().isEmpty()) {
+      ui->profileTable->setItem(n, 0, new QTableWidgetItem(i.key()));
+      ui->profileTable->setItem(n, 1,
+                                new QTableWidgetItem(i.value().value("path")));
       ui->profileTable->setItem(
-        n, 0, new QTableWidgetItem(i.key()));
-      ui->profileTable->setItem(
-        n, 1, new QTableWidgetItem(i.value().value("path")));
-      ui->profileTable->setItem(
-        n, 2, new QTableWidgetItem(i.value().value("signingKey")));
+          n, 2, new QTableWidgetItem(i.value().value("signingKey")));
       // dbg()<< "naam:" + i.key();
       if (i.key() == currentProfile)
         ui->profileTable->selectRow(n);

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -31,7 +31,7 @@ public:
   void useSelection(bool useSelection);
   void useAutoclear(bool useAutoclear);
   void useAutoclearPanel(bool useAutoclearPanel);
-  QHash<QString, QString> getProfiles();
+  QHash<QString, QHash<QString, QString>> getProfiles();
   void wizard();
   void genKey(QString, QDialog *);
   void useTrayIcon(bool useSystray);
@@ -76,7 +76,7 @@ private:
   QStringList getSecretKeys();
 
   void setGitPath(QString);
-  void setProfiles(QHash<QString, QString>, QString);
+  void setProfiles(QHash<QString, QHash<QString, QString>>, QString);
   void usePass(bool usePass);
 
   void setGroupBoxState();

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -913,6 +913,11 @@
            <string>Path</string>
           </property>
          </column>
+         <column>
+          <property name="text">
+           <string>Signing Key</string>
+          </property>
+         </column>
         </widget>
        </item>
        <item>

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -286,7 +286,7 @@ bool ImitatePass::verifyGpgIdFile(const QString &file) {
       QStringList{"--verify", "--status-fd=1", pgpg(file) + ".sig", pgpg(file)};
   exec.executeBlocking(QtPassSettings::getGpgExecutable(), args, &out);
   QRegularExpression re(
-      "^\\[GNUPG:\\] VALIDSIG ([A-F0-9]{40}) .* ([A-F0-9]{40})$",
+      "^\\[GNUPG:\\] VALIDSIG ([A-F0-9]{40}) .* ([A-F0-9]{40})\\r?$",
       QRegularExpression::MultilineOption);
   QRegularExpressionMatch m = re.match(out);
   if (!m.hasMatch())

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -172,8 +172,13 @@ void ImitatePass::Remove(QString file, bool isDir) {
  * path
  */
 void ImitatePass::Init(QString path, const QList<UserInfo> &users) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   QStringList signingKeys =
       QtPassSettings::getPassSigningKey().split(" ", Qt::SkipEmptyParts);
+#else
+  QStringList signingKeys =
+      QtPassSettings::getPassSigningKey().split(" ", QString::SkipEmptyParts);
+#endif
   QString gpgIdSigFile = path + ".gpg-id.sig";
   bool addSigFile = false;
   if (!signingKeys.isEmpty()) {
@@ -267,8 +272,13 @@ void ImitatePass::Init(QString path, const QList<UserInfo> &users) {
  * @return was verification succesful?
  */
 bool ImitatePass::verifyGpgIdFile(const QString &file) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   QStringList signingKeys =
       QtPassSettings::getPassSigningKey().split(" ", Qt::SkipEmptyParts);
+#else
+  QStringList signingKeys =
+      QtPassSettings::getPassSigningKey().split(" ", QString::SkipEmptyParts);
+#endif
   if (signingKeys.isEmpty())
     return true;
   QString out;

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -11,6 +11,7 @@
 class ImitatePass : public Pass, private simpleTransaction {
   Q_OBJECT
 
+  bool verifyGpgIdFile(const QString &file);
   bool removeDir(const QString &dirName);
 
   void GitCommit(const QString &file, const QString &msg);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -766,7 +766,8 @@ void MainWindow::generateKeyPair(QString batch, QDialog *keygenWindow) {
  * select a more appropriate one to view too
  */
 void MainWindow::updateProfileBox() {
-  QHash<QString, QHash<QString, QString>> profiles = QtPassSettings::getProfiles();
+  QHash<QString, QHash<QString, QString>> profiles =
+      QtPassSettings::getProfiles();
 
   if (profiles.isEmpty()) {
     ui->profileWidget->hide();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -766,7 +766,7 @@ void MainWindow::generateKeyPair(QString batch, QDialog *keygenWindow) {
  * select a more appropriate one to view too
  */
 void MainWindow::updateProfileBox() {
-  QHash<QString, QString> profiles = QtPassSettings::getProfiles();
+  QHash<QString, QHash<QString, QString>> profiles = QtPassSettings::getProfiles();
 
   if (profiles.isEmpty()) {
     ui->profileWidget->hide();
@@ -774,7 +774,7 @@ void MainWindow::updateProfileBox() {
     ui->profileWidget->show();
     ui->profileBox->setEnabled(profiles.size() > 1);
     ui->profileBox->clear();
-    QHashIterator<QString, QString> i(profiles);
+    QHashIterator<QString, QHash<QString, QString>> i(profiles);
     while (i.hasNext()) {
       i.next();
       if (!i.key().isEmpty())
@@ -800,7 +800,10 @@ void MainWindow::on_profileBox_currentIndexChanged(QString name) {
 
   QtPassSettings::setProfile(name);
 
-  QtPassSettings::setPassStore(QtPassSettings::getProfiles()[name]);
+  QtPassSettings::setPassStore(
+      QtPassSettings::getProfiles().value(name).value("path"));
+  QtPassSettings::setPassSigningKey(
+      QtPassSettings::getProfiles().value(name).value("signingKey"));
   ui->statusBar->showMessage(tr("Profile changed to %1").arg(name), 2000);
 
   QtPassSettings::getPass()->updateEnv();

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -242,8 +242,29 @@ void Pass::finished(int id, int exitCode, const QString &out,
  * switching profiles)
  */
 void Pass::updateEnv() {
-  QStringList store = env.filter("PASSWORD_STORE_DIR=");
+  // put PASSWORD_STORE_SIGNING_KEY in env
+  QStringList envSigningKey = env.filter("PASSWORD_STORE_SIGNING_KEY=");
+  QString currentSigningKey = QtPassSettings::getPassSigningKey();
+  if (envSigningKey.isEmpty()) {
+    if (!currentSigningKey.isEmpty()) {
+      // dbg()<< "Added
+      // PASSWORD_STORE_SIGNING_KEY with" + currentSigningKey;
+      env.append("PASSWORD_STORE_SIGNING_KEY=" + currentSigningKey);
+    }
+  } else {
+    if (currentSigningKey.isEmpty()) {
+      // dbg() << "Removed
+      // PASSWORD_STORE_SIGNING_KEY";
+      env.removeAll(envSigningKey.first());
+    } else {
+      // dbg()<< "Update
+      // PASSWORD_STORE_SIGNING_KEY with " + currentSigningKey;
+      env.replaceInStrings(envSigningKey.first(),
+        "PASSWORD_STORE_SIGNING_KEY=" + currentSigningKey);
+    }
+  }
   // put PASSWORD_STORE_DIR in env
+  QStringList store = env.filter("PASSWORD_STORE_DIR=");
   if (store.isEmpty()) {
     // dbg()<< "Added
     // PASSWORD_STORE_DIR";

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -284,13 +284,15 @@ void Pass::updateEnv() {
  * @return path to the gpgid file.
  */
 QString Pass::getGpgIdPath(QString for_file) {
-  QDir gpgIdDir(QFileInfo(for_file.startsWith(QtPassSettings::getPassStore())
-                              ? for_file
-                              : QtPassSettings::getPassStore() + for_file)
-                    .absoluteDir());
+  QString passStore =
+      QDir::fromNativeSeparators(QtPassSettings::getPassStore());
+  QDir gpgIdDir(
+      QFileInfo(QDir::fromNativeSeparators(for_file).startsWith(passStore)
+                    ? for_file
+                    : QtPassSettings::getPassStore() + for_file)
+          .absoluteDir());
   bool found = false;
-  while (gpgIdDir.exists() &&
-         gpgIdDir.absolutePath().startsWith(QtPassSettings::getPassStore())) {
+  while (gpgIdDir.exists() && gpgIdDir.absolutePath().startsWith(passStore)) {
     if (QFile(gpgIdDir.absoluteFilePath(".gpg-id")).exists()) {
       found = true;
       break;

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -260,7 +260,7 @@ void Pass::updateEnv() {
       // dbg()<< "Update
       // PASSWORD_STORE_SIGNING_KEY with " + currentSigningKey;
       env.replaceInStrings(envSigningKey.first(),
-        "PASSWORD_STORE_SIGNING_KEY=" + currentSigningKey);
+                           "PASSWORD_STORE_SIGNING_KEY=" + currentSigningKey);
     }
   }
   // put PASSWORD_STORE_DIR in env

--- a/src/pass.h
+++ b/src/pass.h
@@ -57,6 +57,7 @@ public:
   QList<UserInfo> listKeys(QStringList keystrings, bool secret = false);
   QList<UserInfo> listKeys(QString keystring = "", bool secret = false);
   void updateEnv();
+  static QString getGpgIdPath(QString for_file);
   static QStringList getRecipientList(QString for_file);
   //  TODO(bezet): getRecipientString is useless, refactor
   static QStringList getRecipientString(QString for_file,

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -89,14 +89,16 @@ QHash<QString, QHash<QString, QString>> QtPassSettings::getProfiles() {
   return profiles;
 }
 
-void QtPassSettings::setProfiles(const QHash<QString, QHash<QString, QString>> &profiles) {
+void QtPassSettings::setProfiles(
+    const QHash<QString, QHash<QString, QString>> &profiles) {
   getInstance()->remove(SettingsConstants::profile);
   getInstance()->beginGroup(SettingsConstants::profile);
 
   QHash<QString, QHash<QString, QString>>::const_iterator i = profiles.begin();
   for (; i != profiles.end(); ++i) {
     getInstance()->setValue(i.key() + "/path", i.value().value("path"));
-    getInstance()->setValue(i.key() + "/signingKey", i.value().value("signingKey"));
+    getInstance()->setValue(i.key() + "/signingKey",
+                            i.value().value("signingKey"));
   }
 
   getInstance()->endGroup();

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -60,9 +60,21 @@ void QtPassSettings::setPasswordConfiguration(
 
 QHash<QString, QHash<QString, QString>> QtPassSettings::getProfiles() {
   getInstance()->beginGroup(SettingsConstants::profile);
+  QHash<QString, QHash<QString, QString>> profiles;
+
+  // migration from version <= v1.3.2: profiles datastructure
+  QStringList childKeys = getInstance()->childKeys();
+  if (!childKeys.empty()) {
+    foreach (QString key, childKeys) {
+      QHash<QString, QString> profile;
+      profile.insert("path", getInstance()->value(key).toString());
+      profile.insert("signingKey", "");
+      profiles.insert(key, profile);
+    }
+  }
+  // /migration from version <= v1.3.2
 
   QStringList childGroups = getInstance()->childGroups();
-  QHash<QString, QHash<QString, QString>> profiles;
   foreach (QString group, childGroups) {
     QHash<QString, QString> profile;
     profile.insert("path", getInstance()->value(group + "/path").toString());

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -58,13 +58,18 @@ void QtPassSettings::setPasswordConfiguration(
                           config.Characters[PasswordConfiguration::CUSTOM]);
 }
 
-QHash<QString, QString> QtPassSettings::getProfiles() {
+QHash<QString, QHash<QString, QString>> QtPassSettings::getProfiles() {
   getInstance()->beginGroup(SettingsConstants::profile);
 
-  QStringList childrenKeys = getInstance()->childKeys();
-  QHash<QString, QString> profiles;
-  foreach (QString key, childrenKeys) {
-    profiles.insert(key, getInstance()->value(key).toString());
+  QStringList childGroups = getInstance()->childGroups();
+  QHash<QString, QHash<QString, QString>> profiles;
+  foreach (QString group, childGroups) {
+    QHash<QString, QString> profile;
+    profile.insert("path", getInstance()->value(group + "/path").toString());
+    profile.insert("signingKey",
+                   getInstance()->value(group + "/signingKey").toString());
+    // profiles.insert(group, getInstance()->value(group).toString());
+    profiles.insert(group, profile);
   }
 
   getInstance()->endGroup();
@@ -72,13 +77,14 @@ QHash<QString, QString> QtPassSettings::getProfiles() {
   return profiles;
 }
 
-void QtPassSettings::setProfiles(const QHash<QString, QString> &profiles) {
+void QtPassSettings::setProfiles(const QHash<QString, QHash<QString, QString>> &profiles) {
   getInstance()->remove(SettingsConstants::profile);
   getInstance()->beginGroup(SettingsConstants::profile);
 
-  QHash<QString, QString>::const_iterator i = profiles.begin();
+  QHash<QString, QHash<QString, QString>>::const_iterator i = profiles.begin();
   for (; i != profiles.end(); ++i) {
-    getInstance()->setValue(i.key(), i.value());
+    getInstance()->setValue(i.key() + "/path", i.value().value("path"));
+    getInstance()->setValue(i.key() + "/signingKey", i.value().value("signingKey"));
   }
 
   getInstance()->endGroup();
@@ -301,6 +307,15 @@ QString QtPassSettings::getPassStore(const QString &defaultValue) {
 }
 void QtPassSettings::setPassStore(const QString &passStore) {
   getInstance()->setValue(SettingsConstants::passStore, passStore);
+}
+
+QString QtPassSettings::getPassSigningKey(const QString &defaultValue) {
+  return getInstance()
+      ->value(SettingsConstants::passSigningKey, defaultValue)
+      .toString();
+}
+void QtPassSettings::setPassSigningKey(const QString &passSigningKey) {
+  getInstance()->setValue(SettingsConstants::passSigningKey, passSigningKey);
 }
 
 void QtPassSettings::initExecutables() {

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -108,6 +108,10 @@ public:
   getPassStore(const QString &defaultValue = QVariant().toString());
   static void setPassStore(const QString &passStore);
 
+  static QString
+  getPassSigningKey(const QString &defaultValue = QVariant().toString());
+  static void setPassSigningKey(const QString &passSigningKey);
+
   static void initExecutables();
   static QString
   getPassExecutable(const QString &defaultValue = QVariant().toString());
@@ -210,8 +214,8 @@ public:
   isTemplateAllFields(const bool &defaultValue = QVariant().toBool());
   static void setTemplateAllFields(const bool &templateAllFields);
 
-  static QHash<QString, QString> getProfiles();
-  static void setProfiles(const QHash<QString, QString> &profiles);
+  static QHash<QString, QHash<QString, QString>> getProfiles();
+  static void setProfiles(const QHash<QString, QHash<QString, QString>> &profiles);
 
   static Pass *getPass();
   static RealPass *getRealPass();

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -215,7 +215,8 @@ public:
   static void setTemplateAllFields(const bool &templateAllFields);
 
   static QHash<QString, QHash<QString, QString>> getProfiles();
-  static void setProfiles(const QHash<QString, QHash<QString, QString>> &profiles);
+  static void
+  setProfiles(const QHash<QString, QHash<QString, QString>> &profiles);
 
   static Pass *getPass();
   static RealPass *getRealPass();

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -32,6 +32,7 @@ const QString SettingsConstants::displayAsIs = "displayAsIs";
 const QString SettingsConstants::noLineWrapping = "noLineWrapping";
 const QString SettingsConstants::addGPGId = "addGPGId";
 const QString SettingsConstants::passStore = "passStore";
+const QString SettingsConstants::passSigningKey = "passSigningKey";
 const QString SettingsConstants::passExecutable = "passExecutable";
 const QString SettingsConstants::gitExecutable = "gitExecutable";
 const QString SettingsConstants::gpgExecutable = "gpgExecutable";

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -31,6 +31,7 @@ public:
   const static QString noLineWrapping;
   const static QString addGPGId;
   const static QString passStore;
+  const static QString passSigningKey;
   const static QString passExecutable;
   const static QString gitExecutable;
   const static QString gpgExecutable;


### PR DESCRIPTION
# Reason
The [pass store signing key](https://man.archlinux.org/man/pass.1.en#PASSWORD_STORE_SIGNING_KEY) feature would enhance the security of qtpass/pass when used by teams. Teams need fine-grained control over the `.gpg-id` user lists of subpaths/stores, but they also have to be able to verify the `.gpg-id` user lists to prevent accidental/malicious privilege escalation. By setting the `PASSWORD_STORE_SIGNING_KEY` envvar to a trusted team signing key id, password admins can provide prepared and signed `.gpg-id[.sig]` files and team members can easily enable the verification by configuring the new signing key id in the corresponding profile. If the verification fails, the error `Signature for [...]/.gpg-id is invalid.` is visible and further actions are prevented. This PR would fix #624, see further discussion there.

# Changes
Adds the [pass store signing key](https://man.archlinux.org/man/pass.1.en#PASSWORD_STORE_SIGNING_KEY) feature by
- changing the **profile type** from `QString` to `QHash<QString, QString>` in order to be able to represent
  more key/value pairs for one profile (`profile['path']`, `profile['signingKey']`)
- changing the **profiles type** from `QHash<QString, QString>` to `QHash<QString, QHash<QString, QString>>`
  in order to store the new data structure
- changing the **profiles settings** from plain keys (childKeys) to a group (childGroups) in order to store more 
  key/values for one profile (`profile/NAME/path`, `profile/NAME/signingKey`)
- adding a column to the **profile ui table**
- adding a **new setting** for `passSigningKey` for the current value of the profile
- updating the **environment** on profile switch in `updateEnv()` (adding/updating the envvar 
  `PASSWORD_STORE_SIGNING_KEY` to the value from the `passSigningKey` setting or removing the envvar,
  if the `passSigningKey` setting is empty)
- adding a **comment** to the `README.md`

# Notes
- ~~Unfortunately the change of profile(s) data structure results in an **empty profile list** on upgrade, so this PR might
  be considered a **breaking change (consider this, if you want to test this PR with your real qtpass configuration)**. But to introduce another parallel data structure would have been awkward/messy
  and this way in the future it is easy to add further key/value pairs for profiles as needed.~~
- ~~This is `pass` only. Using git/gpg would be possible, but quite more time-consuming~~
- After `qmake`, all translation file items included additional location filenames for header files `../src/*.h`. I saw #606,
  but I have no idea, why this happened again and I'm unsure how to proceed, as some line number references
  need to be updated
- All tests pass
