### PR TITLE
fix the unintended "running" of the entropy window in the keygen dial…

### DIFF
--- a/src/keygendialog.ui
+++ b/src/keygendialog.ui
@@ -240,8 +240,8 @@
 #      first test version please comment
 #
 %echo Generating a default key
-Key-Type: default
-Subkey-Type: default
+Key-Type: RSA
+Subkey-Type: RSA
 Name-Real:
 Name-Comment: QtPass
 Name-Email:

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -229,6 +229,9 @@ void Pass::finished(int id, int exitCode, const QString &out,
   case PASS_COPY:
     emit finishedCopy(out, err);
     break;
+  case GPG_GENKEYS:
+    emit finishedGenerateGPGKeys(out, err);
+    break;
   default:
 #ifdef QT_DEBUG
     dbg() << "Unhandled process type" << pid;


### PR DESCRIPTION
…og and bypasses the "unknown elliptic curve" bug in unattended key generation in newer GnupPG versions.