### PR TITLE
Clazy cleanup and other minor fixes

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -41,8 +41,7 @@
  * @return
  */
 int main(int argc, char *argv[]) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) &&                                 \
-    QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
@@ -102,12 +101,10 @@ int main(int argc, char *argv[]) {
                    &MainWindow::messageAvailable);
 #endif
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
   QGuiApplication::setDesktopFileName("qtpass.desktop");
-#endif
 
   // Center the MainWindow on the screen the mouse pointer is currently on
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
   static int cursorScreen =
       app.desktop()->screenNumber(app.desktop()->cursor().pos());
   QPoint cursorScreenCenter =

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -3,6 +3,7 @@
 #include "mainwindow.h"
 #include "qtpasssettings.h"
 #include "ui_configdialog.h"
+#include "util.h"
 #include <QClipboard>
 #include <QDir>
 #include <QFileDialog>
@@ -303,7 +304,7 @@ QString ConfigDialog::selectExecutable() {
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setOption(QFileDialog::ReadOnly);
   if (dialog.exec())
-    return dialog.selectedFiles().first();
+    return dialog.selectedFiles().constFirst();
 
   return QString();
 }
@@ -318,7 +319,7 @@ QString ConfigDialog::selectFolder() {
   dialog.setFilter(QDir::NoFilter);
   dialog.setOption(QFileDialog::ShowDirsOnly);
   if (dialog.exec())
-    return dialog.selectedFiles().first();
+    return dialog.selectedFiles().constFirst();
 
   return QString();
 }

--- a/src/filecontent.cpp
+++ b/src/filecontent.cpp
@@ -11,7 +11,7 @@ FileContent FileContent::parse(const QString &fileContent,
   QString password = lines.takeFirst();
   QStringList remainingData, remainingDataDisplay;
   NamedValues namedValues;
-  for (const QString &line : lines) {
+  for (const QString &line : qAsConst(lines)) {
     if (line.contains(":")) {
       int colon = line.indexOf(':');
       QString name = line.left(colon);

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -11,8 +11,6 @@
 class ImitatePass : public Pass, private simpleTransaction {
   Q_OBJECT
 
-  bool removeDir(const QString &dirName);
-
   void GitCommit(const QString &file, const QString &msg);
 
   void executeGit(PROCESS id, const QStringList &args,

--- a/src/keygendialog.cpp
+++ b/src/keygendialog.cpp
@@ -84,14 +84,14 @@ void KeygenDialog::on_name_textChanged(const QString &arg1) {
 void KeygenDialog::replace(const QString &key, const QString &value) {
   QStringList clear;
   QString expert = ui->plainTextEdit->toPlainText();
+  static const QRegularExpression newLines{"[\r\n]"};
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-  QStringList lines =
-      expert.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
+  const QStringList lines = expert.split(newLines, Qt::SkipEmptyParts);
 #else
-  QStringList lines =
-      expert.split(QRegularExpression("[\r\n]"), QString::SkipEmptyParts);
+  const QStringList lines =
+      expert.split(newLines, QString::SkipEmptyParts);
 #endif
-  foreach (QString line, lines) {
+  for (QString line : lines) {
     line.replace(QRegularExpression(key + ":.*"), key + ": " + value);
     if (key == "Passphrase")
       line.replace("%no-protection", "Passphrase: " + value);
@@ -108,14 +108,13 @@ void KeygenDialog::replace(const QString &key, const QString &value) {
 void KeygenDialog::no_protection(bool enable) {
   QStringList clear;
   QString expert = ui->plainTextEdit->toPlainText();
+  static const QRegularExpression newLines{"[\r\n]"};
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-  QStringList lines =
-      expert.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
+  const QStringList lines = expert.split(newLines, Qt::SkipEmptyParts);
 #else
-  QStringList lines =
-      expert.split(QRegularExpression("[\r\n]"), QString::SkipEmptyParts);
+  const QStringList lines = expert.split(newLines, QString::SkipEmptyParts);
 #endif
-  foreach (QString line, lines) {
+  for (QString line : lines) {
     bool remove = false;
     if (!enable) {
       if (line.indexOf("%no-protection") == 0)
@@ -145,7 +144,7 @@ void KeygenDialog::done(int r) {
     }
 
     // check email
-    QRegularExpression mailre(
+    static const QRegularExpression mailre(
         QRegularExpression::anchoredPattern(
             R"(\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b)"),
         QRegularExpression::CaseInsensitiveOption);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -16,10 +16,8 @@ class SingleApplication;
 #endif
 
 #ifdef __APPLE__
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 // http://doc.qt.io/qt-5/qkeysequence.html#qt_set_sequence_auto_mnemonic
 void qt_set_sequence_auto_mnemonic(bool b);
-#endif
 #endif
 
 namespace Ui {

--- a/src/pass.h
+++ b/src/pass.h
@@ -11,13 +11,6 @@
 #include <cassert>
 #include <map>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-#include <QRandomGenerator>
-#else
-#include <fcntl.h>
-#include <unistd.h>
-#endif
-
 /*!
     \class Pass
     \brief Acts as an abstraction for pass or pass imitation

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -129,13 +129,13 @@ void PasswordDialog::setPassword(QString password) {
   QWidget *previous = ui->checkBoxShow;
   // first set templated values
   NamedValues namedValues = fileContent.getNamedValues();
-  for (QLineEdit *line : templateLines) {
+  for (QLineEdit *line : qAsConst(templateLines)) {
     line->setText(namedValues.takeValue(line->objectName()));
     previous = line;
   }
   // show remaining values (if there are)
   otherLines.clear();
-  for (const NamedValue &nv : namedValues) {
+  for (const NamedValue &nv : qAsConst(namedValues)) {
     auto *line = new QLineEdit();
     line->setObjectName(nv.name);
     line->setText(nv.value);

--- a/src/qprogressindicator.h
+++ b/src/qprogressindicator.h
@@ -15,20 +15,6 @@
  */
 class QProgressIndicator : public QWidget {
   Q_OBJECT
-  /**
-   *  @brief QProgressIndicator::delay in miliseconds.
-   */
-  Q_PROPERTY(int delay READ animationDelay WRITE setAnimationDelay)
-  /**
-   *  @brief QProgressIndicator::displayedWhenStopped render when not spinning.
-   */
-  Q_PROPERTY(bool displayedWhenStopped READ isDisplayedWhenStopped WRITE
-                 setDisplayedWhenStopped)
-  /**
-   *  @brief QProgressIndicator::color of the component..
-   */
-  Q_PROPERTY(QColor color READ color WRITE setColor)
-
 public:
   explicit QProgressIndicator(QWidget *parent = 0);
 

--- a/src/realpass.cpp
+++ b/src/realpass.cpp
@@ -1,5 +1,6 @@
 #include "realpass.h"
 #include "qtpasssettings.h"
+#include "util.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -117,10 +118,10 @@ void RealPass::Move(const QString src, const QString dest, const bool force) {
 
   // remove the .gpg because pass will not work
   if (srcFileInfo.isFile() && srcFileInfo.suffix() == "gpg") {
-    passSrc.replace(QRegularExpression("\\.gpg$"), "");
+    passSrc.replace(Util::endsWithGpg(), "");
   }
   if (destFileInfo.isFile() && destFileInfo.suffix() == "gpg") {
-    passDest.replace(QRegularExpression("\\.gpg$"), "");
+    passDest.replace(Util::endsWithGpg(), "");
   }
 
   QStringList args;
@@ -157,10 +158,10 @@ void RealPass::Copy(const QString src, const QString dest, const bool force) {
 
   // remove the .gpg because pass will not work
   if (srcFileInfo.isFile() && srcFileInfo.suffix() == "gpg") {
-    passSrc.replace(QRegularExpression("\\.gpg$"), "");
+    passSrc.replace(Util::endsWithGpg(), "");
   }
   if (destFileInfo.isFile() && destFileInfo.suffix() == "gpg") {
-    passDest.replace(QRegularExpression("\\.gpg$"), "");
+    passDest.replace(Util::endsWithGpg(), "");
   }
   QStringList args;
   args << "cp";

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -1,7 +1,6 @@
 #ifndef STOREMODEL_H_
 #define STOREMODEL_H_
 
-#include "util.h"
 #include <QSortFilterProxyModel>
 
 /*!

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -71,9 +71,7 @@ UsersDialog::UsersDialog(QString dir, QWidget *parent)
   connect(ui->listWidget, &QListWidget::itemChanged, this,
           &UsersDialog::itemChange);
 
-#if QT_VERSION >= 0x050200
   ui->lineEdit->setClearButtonEnabled(true);
-#endif
 }
 
 /**

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -194,3 +194,14 @@ void Util::copyDir(const QString &src, const QString &dest) {
                 dest + QDir::separator() + file);
   }
 }
+
+const QRegularExpression &Util::endsWithGpg() {
+  static const QRegularExpression expr{"\\.gpg$"};
+  return expr;
+}
+
+const QRegularExpression &Util::protocolRegex() {
+  static const QRegularExpression regex{
+      "((?:https?|ftp|ssh|sftp|ftps|webdav|webdavs)://\\S+)"};
+  return regex;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,7 @@
 #include "storemodel.h"
 #include <QFileSystemModel>
 #include <QProcessEnvironment>
+#include <QRegularExpression>
 #include <QString>
 
 class StoreModel;
@@ -22,6 +23,8 @@ public:
                         const QFileSystemModel &model,
                         const StoreModel &storeModel);
   static void copyDir(const QString &src, const QString &dest);
+  static const QRegularExpression &endsWithGpg();
+  static const QRegularExpression &protocolRegex();
 
 private:
   static void initialiseEnvironment();


### PR DESCRIPTION
 - Code is now clazy clean with CLAZY_CHECKS="no-connect-by-name,no-overloaded-signal"
 - Given the minimum Qt version is 5.10, remove ifdef's for older versions
 - Some more range based for and related cleanups.
 - Some include cleanups