### PR TITLE
Fix taborder and add buddies in keygen dialog

### DIFF
--- a/src/keygendialog.ui
+++ b/src/keygendialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>606</width>
-    <height>480</height>
+    <height>497</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -72,18 +72,6 @@
          </sizepolicy>
         </property>
         <layout class="QFormLayout" name="formLayout">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
          <item row="0" column="0">
           <widget class="QLabel" name="labelEmail">
            <property name="sizePolicy">
@@ -100,6 +88,9 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>email</cstring>
            </property>
           </widget>
          </item>
@@ -130,6 +121,9 @@
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
+           <property name="buddy">
+            <cstring>name</cstring>
+           </property>
           </widget>
          </item>
          <item row="1" column="1">
@@ -158,6 +152,9 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>passphrase1</cstring>
            </property>
           </widget>
          </item>
@@ -200,6 +197,13 @@
            </property>
            <property name="wordWrap">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Repeat pass</string>
            </property>
           </widget>
          </item>
@@ -289,6 +293,7 @@ Expire-Date: 0
  </widget>
  <tabstops>
   <tabstop>email</tabstop>
+  <tabstop>name</tabstop>
   <tabstop>passphrase1</tabstop>
   <tabstop>passphrase2</tabstop>
   <tabstop>checkBox</tabstop>


### PR DESCRIPTION
Tab was jumping weird, and clicking on labels didn't behave