### PR TITLE
qtpass do not strip comments of gpg_id file 

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -322,7 +322,7 @@ QStringList Pass::getRecipientList(QString for_file) {
   QStringList recipients;
   while (!gpgId.atEnd()) {
     QString recipient(gpgId.readLine());
-    recipient = recipient.trimmed();
+    recipient = recipient.split("#")[0].trimmed();
     if (!recipient.isEmpty())
       recipients += recipient;
   }


### PR DESCRIPTION
See #625

Hi

it was not fixed in recent version of qtPass, it just striped spaces and did not split by "#"

You test that, by seeing that the checklist of the `userdialog.cpp` did not checked the existed users with `#`

I think we expected 
```
selected_users = QtPassSettings::getPass()->listKeys(recipients);
  foreach (const UserInfo &sel, selected_users) {
    for (auto &user : users)
      if (sel.key_id == user.key_id)
        user.enabled = true;
  }
```

todo the right thing but `listKeys(recipients)` don`t return anything as examined by debugger.  

before ->listKeys(recipients)

![Screen Shot 2023-09-24 at 4 15 50](https://github.com/IJHack/QtPass/assets/8200598/931679fa-781a-4ac4-ab47-01b9d814e44f)

After ->listKeys(recipients)
![Screen Shot 2023-09-24 at 4 14 53](https://github.com/IJHack/QtPass/assets/8200598/5aafde0c-6b67-41f0-8517-99c79724bfc1)

