### PR TITLE
Add window icon to all dialogs

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -19,6 +19,10 @@
   <property name="windowTitle">
    <string>Configuration</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../resources.qrc">
+    <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">
     <number>6</number>
@@ -1094,7 +1098,9 @@ e-mail</string>
   <tabstop>storePath</tabstop>
   <tabstop>toolButtonStore</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/keygendialog.ui
+++ b/src/keygendialog.ui
@@ -13,6 +13,10 @@
   <property name="windowTitle">
    <string>Generate GnuPG keypair</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../resources.qrc">
+    <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">
     <number>6</number>
@@ -299,7 +303,9 @@ Expire-Date: 0
   <tabstop>checkBox</tabstop>
   <tabstop>plainTextEdit</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -13,6 +13,10 @@
   <property name="windowTitle">
    <string>QtPass</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../resources.qrc">
+    <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
+  </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QGridLayout" name="gridLayout_2">
     <item row="0" column="0" rowspan="2" colspan="2">
@@ -396,7 +400,9 @@
   <tabstop>treeView</tabstop>
   <tabstop>textBrowser</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
  <connections/>
  <slots>
   <slot>deselect()</slot>

--- a/src/passworddialog.ui
+++ b/src/passworddialog.ui
@@ -13,6 +13,10 @@
   <property name="windowTitle">
    <string>Password</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../resources.qrc">
+    <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">
    <property name="leftMargin">
     <number>6</number>
@@ -191,7 +195,9 @@
   <tabstop>spinBox_pwdLength</tabstop>
   <tabstop>plainTextEdit</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/usersdialog.ui
+++ b/src/usersdialog.ui
@@ -19,6 +19,10 @@
   <property name="windowTitle">
    <string>Read access users</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../resources.qrc">
+    <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
+  </property>
   <property name="modal">
    <bool>true</bool>
   </property>
@@ -104,6 +108,8 @@ Red entries are not valid, you will not be able to encrypt to these.</string>
   <tabstop>lineEdit</tabstop>
   <tabstop>listWidget</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR adds the application's windows icon to all dialogs to address issue #671 .

Below follows a screenshot showcasing the missing app icon:
![Screenshot from 2023-11-03 17-47-48](https://github.com/IJHack/QtPass/assets/169121/eacb2657-e6c8-4c9e-bea3-db6f1bc7cbe3)

Here's a screenshot taken after applying this PR to a local build.
![Screenshot from 2023-11-03 17-56-08](https://github.com/IJHack/QtPass/assets/169121/85a8fa24-5425-4b41-a71c-984505667e4c)