### PR TITLE
Update new TLDs for email when generating new key pair

### DIFF
--- a/src/keygendialog.cpp
+++ b/src/keygendialog.cpp
@@ -145,7 +145,7 @@ void KeygenDialog::done(int r) {
     // check email
     static const QRegularExpression mailre(
         QRegularExpression::anchoredPattern(
-            R"(\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b)"),
+            R"(\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b)"),
         QRegularExpression::CaseInsensitiveOption);
     if (!mailre.match(ui->email->text()).hasMatch()) {
       QMessageBox::critical(


### PR DESCRIPTION
There are so many new LTLDs with longer than 4 chars: https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains, this commit fixes custom email domains. 

TODO: switch to email validation reference in RFC 5322, eg: https://regex101.com/r/3uvtNl/