### PR TITLE
Fix multiple profiles issue for Qt6

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -787,7 +787,11 @@ void MainWindow::updateProfileBox() {
  * correct "profile"
  * @param name
  */
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void MainWindow::on_profileBox_currentIndexChanged(QString name) {
+#else
+void MainWindow::on_profileBox_currentTextChanged(QString name) {
+#endif
   if (m_qtPass->isFreshStart() || name == QtPassSettings::getProfile())
     return;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -97,7 +97,11 @@ private slots:
   void clearPanel(bool notify = true);
   void on_lineEdit_textChanged(const QString &arg1);
   void on_lineEdit_returnPressed();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   void on_profileBox_currentIndexChanged(QString);
+#else
+  void on_profileBox_currentTextChanged(QString);
+#endif
   void showContextMenu(const QPoint &pos);
   void showBrowserContextMenu(const QPoint &pos);
   void openFolder();


### PR DESCRIPTION
since qt api changed, the profile combobox on mainwindow cannot be changed successfully when using Qt6 version.

Qt5: [Qcombobox#currentIndexChanged](https://doc.qt.io/qt-5/qcombobox-obsolete.html#currentIndexChanged-1)
Qt6: [Qcombobox#currentIndexChanged](https://doc.qt.io/qt-6.2/qcombobox.html#currentIndexChanged) & [Qcombobox#currentTextChanged](https://doc.qt.io/qt-6.2/qcombobox.html#currentTextChanged)