### PR TITLE
fix: add missing QDirIterator include

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include <QCloseEvent>
 #include <QDesktopServices>
 #include <QDialog>
+#include <QDirIterator>
 #include <QFileInfo>
 #include <QInputDialog>
 #include <QLabel>


### PR DESCRIPTION
Added missing include for QDirIterator in mainwindow.cpp to resolve compilation errors introduced with Qt 6.8.