### PR TITLE
Restore existing window when invoking `qtpass` with no arguments

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -62,8 +62,7 @@ int main(int argc, char *argv[]) {
     name = qgetenv("USERNAME");
   SingleApplication app(argc, argv, name + "QtPass");
   if (app.isRunning()) {
-    if (text.length() > 0)
-      app.sendMessage(text);
+    app.sendMessage(text);
     return 0;
   }
 #else

--- a/src/singleapplication.cpp
+++ b/src/singleapplication.cpp
@@ -80,7 +80,11 @@ bool SingleApplication::sendMessage(const QString &message) {
 #endif
     return false;
   }
-  localSocket.write(message.toUtf8());
+  QByteArray payload = message.toUtf8();
+  if (payload.isEmpty()) {
+    payload = QByteArray(1, '\0');
+  }
+  localSocket.write(payload);
   if (!localSocket.waitForBytesWritten(timeout)) {
 #ifdef QT_DEBUG
     dbg() << localSocket.errorString().toLatin1();


### PR DESCRIPTION
### Problem

See #602. When QtPass is already running (single-instance mode, tray enabled) and hidden/minimized, running `qtpass` with no arguments does nothing. The second process exits and the existing instance is unaffected. Users currently need to either interact with the tray menu or pass dummy arguments (e.g. `qtpass TEST`) just to make the window reappear. This is a nuisance for users who wish to configure a keybinding in their Wayland compositor to reactivate the window.

### Evaluation

- `main.cpp` only calls `sendMessage(text)` when `text.length() > 0`, so plain `qtpass` never even attempts IPC.
- Even if forced, `sendMessage("")` uses `message.toUtf8()`, which yields an empty `QByteArray` for the empty string.
- Writing an empty buffer means:
  - On the client side, `waitForBytesWritten()` times out because no bytes are ever written.
  - On the server side, `waitForReadyRead()` times out because no data arrives, and `receiveMessage()` returns without emitting `messageAvailable`.

(For non-empty messages this works fine because there is at least one byte to send, so both waits complete and `messageAvailable` is emitted.)

### Solution

Allow a plain `qtpass` invocation (e.g. from a keybinding) to reliably trigger the existing path to show and focus the window on receiving an empty message:

- Always send a message from a second `qtpass` process to the already-running instance, even when the CLI argument string is empty.
- Ensure the IPC payload is never zero-length by sending a single NUL (0x00) byte when the logical message is empty. No changes are required on the receiving side: `QString::fromUtf8(byteArray.constData())` still yields an empty `QString` for the NUL-only payload, so `MainWindow::messageAvailable("")` continues to follow the existing "empty message" behavior.

### Testing done

- Started QtPass with tray enabled, minimized to tray.
- Ran `qtpass` with no arguments:
  - Before this PR, nothing happens.
  - After this PR, the QtPass window is restored and focused.

Fixes #602