### PR TITLE
Fix per-folder encryption not working on Windows

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -312,11 +312,11 @@ void Pass::updateEnv() {
 auto Pass::getGpgIdPath(const QString &for_file) -> QString {
   QString passStore =
       QDir::fromNativeSeparators(QtPassSettings::getPassStore());
-  QDir gpgIdDir(
-      QFileInfo(QDir::fromNativeSeparators(for_file).startsWith(passStore)
-                    ? for_file
-                    : QtPassSettings::getPassStore() + for_file)
-          .absoluteDir());
+  QString normalizedFile = QDir::fromNativeSeparators(for_file);
+  QString fullPath = normalizedFile.startsWith(passStore)
+                         ? normalizedFile
+                         : passStore + "/" + normalizedFile;
+  QDir gpgIdDir(QFileInfo(fullPath).absoluteDir());
   bool found = false;
   while (gpgIdDir.exists() && gpgIdDir.absolutePath().startsWith(passStore)) {
     if (QFile(gpgIdDir.absoluteFilePath(".gpg-id")).exists()) {


### PR DESCRIPTION
## Bug
When combining passStore path with file path, both were not normalized to the same format. This caused path separator mismatches on Windows (e.g. concatenating 'C:/store' + 'C:\\Test\\file.gpg').

## Fix
Normalize both paths to use forward slashes before combining. This ensures the path is constructed correctly regardless of platform path separator conventions.

Fixes #653