### PR TITLE
docs: add AI findings and test patterns to skills

### DIFF
--- a/.opencode/skills/qtpass-fixing/SKILL.md
+++ b/.opencode/skills/qtpass-fixing/SKILL.md
@@ -112,6 +112,58 @@ QRegularExpression urlRegex("(\\S+)://(\\S+)");
 
 For monospace fonts in tables/lists, use `setStyleHint(QFont::Monospace)` to avoid platform-specific defaults.
 
+### Tautology Assertions in Tests
+
+Avoid assertions that always evaluate to true:
+
+```cpp
+// Bad - always true
+QVERIFY(profiles.isEmpty() || !profiles.isEmpty());
+QVERIFY(!store.isEmpty() || store.isEmpty());
+
+// Good - meaningful check
+QVERIFY(profiles.isEmpty());
+QVERIFY2(store.isEmpty() || store.startsWith("/"), "Pass store should be empty or a plausible path");
+```
+
+### Verify Test Setup Return Values
+
+Always verify that test setup operations succeed:
+
+```cpp
+// Bad - ignores return value
+(void)QDir(srcDir.path()).mkdir("source");
+(void)f1.open(QFile::WriteOnly);
+
+// Good - verify success
+QVERIFY(QDir(srcDir.path()).mkdir("source"));
+QVERIFY(f1.open(QFile::WriteOnly));
+```
+
+### Contractions in Comments
+
+Use "cannot" instead of "can't" for formal consistency:
+
+```cpp
+// Bad
+// On Windows, we can't safely backup
+
+// Good
+// On Windows, we cannot safely backup
+```
+
+### Copyright Year in Templates
+
+Use `YYYY` as placeholder instead of current year:
+
+```cpp
+// Bad
+// SPDX-FileCopyrightText: 2026 Your Name
+
+// Good
+// SPDX-FileCopyrightText: YYYY Your Name
+```
+
 ## Key Source Files
 
 | File                 | Purpose                                 |

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -256,3 +256,51 @@ Check if:
 - Check branch protection rules
 - Ensure all CI checks pass
 - You may need admin rights to bypass some checks
+
+## GitHub AI-Powered Bug Detection
+
+GitHub provides AI-generated code quality suggestions under **Security → AI findings**.
+
+### Common AI Findings
+
+1. **Tautology assertions** - Tests that always pass
+2. **Ignored return values** - Test setup not verified
+3. **Spelling corrections** - Typos in comments/strings
+4. **Formatting consistency** - Backticks, spacing
+5. **Contractions** - "can't" vs "cannot"
+6. **Copyright years** - Use "YYYY" placeholder
+
+### Fixing AI Findings
+
+1. Create a branch for fixes:
+
+   ```bash
+   git checkout -b fix/ai-findings
+   ```
+
+2. Apply the suggested fixes
+
+3. Test locally if possible
+
+4. Push and create PR:
+
+   ```bash
+   git push -u origin fix/ai-findings
+   gh pr create --title "fix: resolve AI findings" --body "## Summary
+
+   Found by GitHub AI-powered bug detection.
+
+   - Fixed tautology assertions in tests
+   - Added return value verification
+   - Corrected spelling typos"
+   ```
+
+### Checking AI Findings
+
+```bash
+# View repo security settings (requires admin)
+# Go to: https://github.com/<owner>/<repo>/security/ai-findings
+
+# Or check via API (if enabled)
+gh api repos/<owner>/<repo>/code-scanning/alerts
+```


### PR DESCRIPTION
## Summary

Added learnings from recent AI-powered bug detection fixes:

### qtpass-fixing skill
- Tautology assertions - how to fix always-true test assertions
- Verify test setup return values - check mkdir(), open() etc.
- Contractions in comments - "can't" → "cannot"
- Copyright year placeholders - use "YYYY"

### qtpass-github skill
- New section on GitHub AI-powered bug detection
- Common AI findings patterns
- How to fix and submit PRs for AI findings