### PR TITLE
fix: show status message on GPG key generation complete

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -283,6 +283,14 @@ void QtPass::processError(QProcess::ProcessError error) {
 }
 
 void QtPass::processErrorExit(int exitCode, const QString &p_error) {
+  if (nullptr != m_mainWindow->getKeygenDialog()) {
+    m_mainWindow->cleanKeygenDialog();
+    if (exitCode != 0) {
+      m_mainWindow->showStatusMessage(tr("GPG key pair generation failed"),
+                                      10000);
+    }
+  }
+
   if (!p_error.isEmpty()) {
     QString output;
     QString error = p_error.toHtmlEscaped();
@@ -337,7 +345,8 @@ void QtPass::onKeyGenerationComplete(const QString &p_output,
 #endif
 
     m_mainWindow->cleanKeygenDialog();
-    // TODO(annejan): some sanity checking ?
+    m_mainWindow->showStatusMessage(tr("GPG key pair generated successfully"),
+                                    10000);
   }
 
   processFinished(p_output, p_errout);

--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -19,6 +19,7 @@ private Q_SLOTS:
   void executeBlockingEchoMultiple();
 #endif
   void executeBlockingNotFound();
+  void executeBlockingGpgVersion();
 };
 
 void tst_executor::initTestCase() {}
@@ -85,6 +86,14 @@ void tst_executor::executeBlockingNotFound() {
   int result = Executor::executeBlocking(
       "nonexistent-command-12345.exe", QStringList(), QString(), &output, &err);
   QVERIFY2(result != 0, "non-existent command should fail");
+}
+
+void tst_executor::executeBlockingGpgVersion() {
+  QString output;
+  int result = Executor::executeBlocking("gpg", {"--version"}, QString(),
+                                         &output, nullptr);
+  QVERIFY2(result == 0, "gpg --version should succeed");
+  QVERIFY2(output.contains("gpg"), "output should contain gpg version");
 }
 
 QTEST_MAIN(tst_executor)


### PR DESCRIPTION
## Summary

Fixes #406 - GPG keypair generation takes more than an hour

### Problem
When generating a GPG key pair, there was no feedback to the user when the process completed or failed. The status message showed "Generating GPG key pair" but only for 60 seconds, then disappeared.

### Solution
- Show success status message when key generation completes: "GPG key pair generated successfully"
- Show error status message when key generation fails: "GPG key pair generation failed"
- Close keygen dialog on both success and failure

### Changes
- src/qtpass.cpp: 
  - Added status message in `onKeyGenerationComplete()` for success
  - Added error handling in `processErrorExit()` to close dialog and show error message on failure
- tests/auto/executor/tst_executor.cpp: Added test to verify GPG is available