### PR TITLE
docs: update qmake to qmake6 in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ QtPass uses [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/) for tr
 To add a new language:
 
 - Add your language code to `src/qtpass.pro` under TRANSLATIONS
-- Run `qmake` to generate the translation files
+- Run `qmake6` to generate the translation files
 - Edit the `.ts` file with Qt Linguist: `linguist localization/qtpass_xx_YY.ts`
 
 Qt Linguist has helpful [in-context translation options](https://doc.qt.io/qt-5/linguist-translators.html).

--- a/FAQ.md
+++ b/FAQ.md
@@ -112,8 +112,20 @@ Please install using your favorite package manager.
 export DESKTOP_SESSION=gnome
 ```
 
-- Another possible reason is that the currently installed Qt version gives problems.
-  Then you'll have to install the current version via your package manager or download it from <https://www.qt.io/download/> and build from source.
+### Can not find either qmake or qmake6
+
+QtPass uses Qt6 by default. Use:
+
+- `qmake6` - for Qt6 (recommended, default)
+- `qmake` - for Qt5
+
+If you get an error like "QApplication" not found or Qt installation issues, make sure you're using the correct qmake version for your Qt installation.
+
+On some systems, you may need to specify the full path, e.g., `/usr/lib/qt6/bin/qmake6`.
+
+### Qt installation issues
+
+Then you'll have to install the current version via your package manager or download it from <https://www.qt.io/download/> and build from source.
 
 ### I don't like the design, what gives?
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ On macOS, `pinentry-mac` from Homebrew works best (gpgtools also works).
 On most Unix systems all you need is:
 
 ```sh
-qmake && make && make install
+qmake6 && make && make install
 ```
 
 ### Windows


### PR DESCRIPTION
## Summary

- Add troubleshooting section in FAQ about Qt5 vs Qt6 qmake
- Update README build instructions to use `qmake6`
- Update CONTRIBUTING.md translation instructions to use `qmake6`

This helps avoid confusion between qmake (Qt5) and qmake6 (Qt6).