### PR TITLE
test: improve GPG tests with better assertions

### DIFF
--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -101,16 +101,35 @@ void tst_executor::executeBlockingGpgVersion() {
 
 void tst_executor::gpgSupportsEd25519() {
   bool result = Pass::gpgSupportsEd25519();
-  QVERIFY2(result == true || result == false, "Should return boolean");
+  QString output;
+  int gpgVersionExitCode = Executor::executeBlocking(
+      "gpg", {"--version"}, QString(), &output, nullptr);
+  if (gpgVersionExitCode != 0) {
+    QVERIFY2(
+        result == false,
+        "gpgSupportsEd25519() should return false when GPG is not available");
+  } else {
+    QVERIFY2(result == true || result == false,
+             "gpgSupportsEd25519() must return a boolean value");
+  }
 }
 
 void tst_executor::getDefaultKeyTemplate() {
+  bool ed25519Supported = Pass::gpgSupportsEd25519();
   QString templateStr = Pass::getDefaultKeyTemplate();
   QVERIFY2(!templateStr.isEmpty(), "Template should not be empty");
   QVERIFY2(templateStr.contains("Key-Type:"),
            "Template should contain Key-Type");
   QVERIFY2(templateStr.contains("%echo done"),
            "Template should contain done marker");
+  if (ed25519Supported) {
+    QVERIFY2(templateStr.contains("ed25519") || templateStr.contains("EdDSA"),
+             "Template should be the Ed25519 variant when gpgSupportsEd25519() "
+             "is true");
+  } else {
+    QVERIFY2(templateStr.contains("RSA"), "Template should be the RSA fallback "
+                                          "when gpgSupportsEd25519() is false");
+  }
 }
 
 QTEST_MAIN(tst_executor)

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -592,8 +592,9 @@ void tst_util::findPasswordStore() {
 void tst_util::checkConfig() { (void)Util::checkConfig(); }
 
 void tst_util::getDirBasic() {
-  QString result =
-      Util::getDir(QModelIndex(), false, QFileSystemModel(), StoreModel());
+  QFileSystemModel fsm;
+  StoreModel sm;
+  QString result = Util::getDir(QModelIndex(), false, fsm, sm);
   QVERIFY(result.endsWith(QDir::separator()));
 }
 
@@ -713,13 +714,13 @@ void tst_util::imitatePassResolveMoveDestinationForce() {
   QTemporaryDir tmpDir;
   QString srcPath = tmpDir.path() + "/test.gpg";
   QFile srcFile(srcPath);
-  (void)srcFile.open(QFile::WriteOnly);
+  QVERIFY(srcFile.open(QFile::WriteOnly));
   srcFile.write("test");
   srcFile.close();
 
   QString destPath = tmpDir.path() + "/existing.gpg";
   QFile destFile(destPath);
-  (void)destFile.open(QFile::WriteOnly);
+  QVERIFY(destFile.open(QFile::WriteOnly));
   destFile.write("old");
   destFile.close();
 
@@ -732,7 +733,7 @@ void tst_util::imitatePassResolveMoveDestinationDir() {
   QTemporaryDir tmpDir;
   QString srcPath = tmpDir.path() + "/test.gpg";
   QFile srcFile(srcPath);
-  (void)srcFile.open(QFile::WriteOnly);
+  QVERIFY(srcFile.open(QFile::WriteOnly));
   srcFile.write("test");
   srcFile.close();
 
@@ -752,7 +753,7 @@ void tst_util::imitatePassRemoveDir() {
   ImitatePass pass;
   QTemporaryDir tmpDir;
   QString subDir = tmpDir.path() + "/testdir";
-  (void)QDir().mkdir(subDir);
+  QVERIFY(QDir().mkpath(subDir));
   QVERIFY(QDir(subDir).exists());
   bool result = pass.removeDir(subDir);
   QVERIFY(result);


### PR DESCRIPTION
## Summary

Improve unit tests based on AI findings feedback:

### tests/auto/executor/tst_executor.cpp
- gpgSupportsEd25519(): Now checks if GPG is available and verifies behavior accordingly
- getDefaultKeyTemplate(): Verifies template matches expected key type based on GPG version

### tests/auto/util/tst_util.cpp
- getDirBasic(): Use local variables instead of temporary objects
- imitatePassResolveMoveDestinationForce(): Use QVERIFY instead of (void) cast
- imitatePassResolveMoveDestinationDir(): Use QVERIFY instead of (void) cast
- imitatePassRemoveDir(): Use QVERIFY with mkpath instead of (void) cast