### PR TITLE
test: address AI findings in util tests

### DIFF
--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -834,14 +834,16 @@ void tst_util::getRecipientStringCount() {
   QStringList recipients = Pass::getRecipientString(passStore, " ", &count);
   QStringList recipientsNoCount = Pass::getRecipientString(passStore, " ");
 
-  QStringList expectedRecipients;
-  expectedRecipients << "ABCDEF12" << "34567890";
-  QCOMPARE(recipients, recipientsNoCount);
+  QStringList expectedRecipients = {"ABCDEF12", "34567890"};
+  // Verify count was actually updated from initial value
+  QVERIFY(count > 0);
   QVERIFY(count == expectedRecipients.size());
+  // Verify both overloads return the same result
+  QCOMPARE(recipients, recipientsNoCount);
   // Verify that the parsed recipients match the expected values.
   QCOMPARE(recipients.size(), 2);
-  QCOMPARE(recipients.at(0), QStringLiteral("ABCDEF12"));
-  QCOMPARE(recipients.at(1), QStringLiteral("34567890"));
+  QVERIFY(recipients.contains("ABCDEF12"));
+  QVERIFY(recipients.contains("34567890"));
 }
 
 void tst_util::getGpgIdPathBasic() {


### PR DESCRIPTION
## Summary

Address GitHub AI findings in tests/auto/util/tst_util.cpp:

1. **Add comment explaining file:/// URL exclusion** - Document why `file:///` URLs don't match the protocol regex (network protocols only)

2. **Verify getDir returns current working directory** - Add assertions to check actual directory path when given an invalid QModelIndex

3. **Use QTemporaryDir instead of hardcoded /tmp** - Fix cross-platform compatibility in imitatePassResolveMoveDestinationNonExistent

4. **Verify actual recipient string content** - Check size and individual values in getRecipientStringCount