### PR TITLE
feat: auto-detect git in existing password-store

### DIFF
--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -447,7 +447,16 @@ void QtPassSettings::setProfile(const QString &profile) {
 }
 
 auto QtPassSettings::isUseGit(const bool &defaultValue) -> bool {
-  return getInstance()->value(SettingsConstants::useGit, defaultValue).toBool();
+  bool storedValue =
+      getInstance()->value(SettingsConstants::useGit, defaultValue).toBool();
+  if (storedValue == defaultValue && defaultValue) {
+    QString passStore = getPassStore();
+    if (QFileInfo(passStore).isDir() &&
+        QFileInfo(passStore + QDir::separator() + ".git").isDir()) {
+      return true;
+    }
+  }
+  return storedValue;
 }
 void QtPassSettings::setUseGit(const bool &useGit) {
   getInstance()->setValue(SettingsConstants::useGit, useGit);

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include <QtTest>
 
+#include <QDir>
 #include <QFile>
 #include <QSettings>
 
@@ -29,6 +30,7 @@ private Q_SLOTS:
   void setAndGetAutoclearSeconds();
   void setAndGetPasswordLength();
   void setAndGetUseGit();
+  void autoDetectGit();
   void setAndGetUseOtp();
   void setAndGetUseTrayIcon();
   void setAndGetUsePwgen();
@@ -209,6 +211,38 @@ void tst_settings::setAndGetUseGit() {
   QVERIFY(QtPassSettings::isUseGit());
   QtPassSettings::setUseGit(false);
   QVERIFY(!QtPassSettings::isUseGit());
+}
+
+void tst_settings::autoDetectGit() {
+  QTemporaryDir tempDir;
+  QtPassSettings::setPassStore(tempDir.path());
+
+  QDir gitDir(tempDir.path());
+  QVERIFY(gitDir.mkdir(".git"));
+  QtPassSettings::getInstance()->sync();
+
+  QtPassSettings::getInstance()->remove("useGit");
+  QtPassSettings::getInstance()->sync();
+  QVERIFY2(QtPassSettings::isUseGit(true),
+           "Should auto-detect .git and return true when default is true");
+
+  QtPassSettings::getInstance()->remove("useGit");
+  QtPassSettings::getInstance()->sync();
+  QVERIFY2(!QtPassSettings::isUseGit(false),
+           "Should respect false default when .git exists");
+
+  QVERIFY(gitDir.rmdir(".git"));
+  QtPassSettings::getInstance()->sync();
+
+  QtPassSettings::getInstance()->remove("useGit");
+  QtPassSettings::getInstance()->sync();
+  QVERIFY2(QtPassSettings::isUseGit(true),
+           "Should return true default when .git not present");
+
+  QtPassSettings::getInstance()->remove("useGit");
+  QtPassSettings::getInstance()->sync();
+  QVERIFY2(!QtPassSettings::isUseGit(false),
+           "Should return false default when .git not present");
 }
 
 void tst_settings::setAndGetUseOtp() {


### PR DESCRIPTION
## Summary

Check if `.git` directory exists in password store root and auto-enable git feature.

This addresses issue #592 - users with an existing password-store using git will now have git enabled by default.

## Changes

Modified `QtPassSettings::isUseGit()` to:
1. Check if the stored value equals the default value (meaning user hasn't explicitly set it)
2. If so, check if `.git` directory exists in the password store
3. If `.git` exists, return true to auto-enable git

Based on suggestion from @trentbuck to simply stat the `.git` directory rather than analyzing the full directory structure.

Fixes #592