### PR TITLE
docs: improve Signing Key help text

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -66,6 +66,14 @@ Your GPG key may not be trusted or has expired. Run `gpg --edit-key <KEYID>` and
 - Check if the key has expired (`expire` command to extend if needed)
 - For smartcards/YubiKeys, ensure the card is connected and unlocked (you can verify with `gpg --card-status`)
 
+### What is the "Signing Key" in profile settings?
+
+The Signing Key field in profile configuration is **optional** and usually should be **left empty**.
+
+It is only needed if you want to create **detached signatures** for your `.gpg-id` files to verify the recipients list hasn't been tampered with. Most users can ignore this field.
+
+Common mistake: Putting your GPG key ID here will cause "Signature does not exist" errors when saving passwords. Leave it empty unless you specifically need signature verification.
+
 ### OTP QR codes don't work on macOS
 
 Applications launched from Finder don't inherit the shell PATH. Install QtPass via Homebrew (which sets up PATH correctly) or create a wrapper script that sets PATH before launching QtPass.

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -937,6 +937,9 @@
           <property name="text">
            <string>Signing Key</string>
           </property>
+          <property name="toolTip">
+           <string>Optional: Key used to sign .gpg-id files. Leave empty unless you need detached signatures for verification.</string>
+          </property>
          </column>
         </widget>
        </item>


### PR DESCRIPTION
## Summary

Improve help text for Signing Key field to prevent user confusion.

### Changes

1. **UI**: Added tooltip to "Signing Key" column in profile settings explaining the field is optional

2. **FAQ**: Added entry explaining:
   - What Signing Key does (detached signatures for .gpg-id files)
   - That it should usually be left empty
   - Common mistake: putting GPG key ID causes "Signature does not exist" errors

### Fixes

Fixes issue #599 where users put their GPG key ID in Signing Key field causing save failures.