### PR TITLE
fix: hide .git directory in password store

### DIFF
--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -77,6 +77,9 @@ auto StoreModel::ShowThis(const QModelIndex index) const -> bool {
     QModelIndex useIndex = sourceModel()->index(index.row(), 0, index.parent());
     QString path = fs->filePath(useIndex);
     path = QDir(store).relativeFilePath(path);
+    if (path.startsWith(".git")) {
+      return false;
+    }
     path.replace(Util::endsWithGpg(), "");
     retVal = path.contains(filterRegularExpression());
   }

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -22,6 +22,7 @@ private Q_SLOTS:
   void supportedDropActions();
   void supportedDragActions();
   void filterAcceptsRowHidden();
+  void filterExcludesGitDirectory();
   void filterAcceptsRowVisible();
   void setModelAndStore();
   void showThisWithNullFs();
@@ -135,6 +136,22 @@ void tst_storemodel::filterAcceptsRowHidden() {
   QModelIndex index = fsm.index(tempDir.path() + "/secret.gpg");
   bool result = sm.filterAcceptsRow(0, index.parent());
   QVERIFY(!result);
+}
+
+void tst_storemodel::filterExcludesGitDirectory() {
+  QTemporaryDir tempDir;
+  QDir dir(tempDir.path());
+  QVERIFY(dir.mkdir(".git"));
+
+  QFileSystemModel fsm;
+  fsm.setRootPath(tempDir.path());
+
+  StoreModel sm;
+  sm.setModelAndStore(&fsm, tempDir.path());
+
+  QModelIndex gitIndex = fsm.index(tempDir.path() + "/.git");
+  bool result = sm.filterAcceptsRow(0, gitIndex.parent());
+  QVERIFY2(!result, ".git directory should be hidden");
 }
 
 void tst_storemodel::filterAcceptsRowVisible() {


### PR DESCRIPTION
## Summary

Hide `.git` directory from appearing in the password store tree view on Windows (and other platforms).

### Changes

1. **storemodel.cpp**: Added filter in `ShowThis()` to exclude paths starting with `.git`

2. **tst_storemodel.cpp**: Added unit test `filterExcludesGitDirectory()` to verify .git directories are hidden

### Fixes

Fixes issue #312 - Windows: .git folder is listed in the password store