### PR TITLE
refactor: improve UsersDialog code quality

### DIFF
--- a/src/userinfo.h
+++ b/src/userinfo.h
@@ -17,16 +17,16 @@ struct UserInfo {
    * @brief UserInfo::fullyValid when validity is f or u.
    * http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
    */
-  auto fullyValid() -> bool { return validity == 'f' || validity == 'u'; }
+  auto fullyValid() const -> bool { return validity == 'f' || validity == 'u'; }
   /**
    * @brief UserInfo::marginallyValid when validity is m.
    * http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
    */
-  auto marginallyValid() -> bool { return validity == 'm'; }
+  auto marginallyValid() const -> bool { return validity == 'm'; }
   /**
    * @brief UserInfo::isValid when fullyValid or marginallyValid.
    */
-  auto isValid() -> bool { return fullyValid() || marginallyValid(); }
+  auto isValid() const -> bool { return fullyValid() || marginallyValid(); }
 
   /**
    * @brief UserInfo::name full name

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -147,52 +147,62 @@ void UsersDialog::populateList(const QString &filter) {
       QRegularExpression::wildcardToRegularExpression("*" + filter + "*"),
       QRegularExpression::CaseInsensitiveOption);
   ui->listWidget->clear();
-  if (!m_userList.isEmpty()) {
-    for (auto &user : m_userList) {
-      if (filter.isEmpty() || nameFilter.match(user.name).hasMatch()) {
-        if (!user.isValid() && !ui->checkBox->isChecked()) {
-          continue;
-        }
-        if (user.expiry.toSecsSinceEpoch() > 0 &&
-            user.expiry.daysTo(QDateTime::currentDateTime()) > 0 &&
-            !ui->checkBox->isChecked()) {
-          continue;
-        }
-        QString userText = user.name + "\n" + user.key_id;
-        if (user.created.toSecsSinceEpoch() > 0) {
-          userText +=
-              " " + tr("created") + " " +
-              QLocale::system().toString(user.created, QLocale::ShortFormat);
-        }
-        if (user.expiry.toSecsSinceEpoch() > 0) {
-          userText +=
-              " " + tr("expires") + " " +
-              QLocale::system().toString(user.expiry, QLocale::ShortFormat);
-        }
-        auto *item = new QListWidgetItem(userText, ui->listWidget);
-        item->setCheckState(user.enabled ? Qt::Checked : Qt::Unchecked);
-        item->setData(Qt::UserRole, QVariant::fromValue(&user));
-        if (user.have_secret) {
-          // item->setForeground(QColor(32, 74, 135));
-          item->setForeground(Qt::blue);
-          QFont font;
-          font.setFamily(font.defaultFamily());
-          font.setBold(true);
-          item->setFont(font);
-        } else if (!user.isValid()) {
-          item->setBackground(QColor(164, 0, 0));
-          item->setForeground(Qt::white);
-        } else if (user.expiry.toSecsSinceEpoch() > 0 &&
-                   user.expiry.daysTo(QDateTime::currentDateTime()) > 0) {
-          item->setForeground(QColor(164, 0, 0));
-        } else if (!user.fullyValid()) {
-          item->setBackground(QColor(164, 80, 0));
-          item->setForeground(Qt::white);
-        }
 
-        ui->listWidget->addItem(item);
-      }
+  for (auto &user : m_userList) {
+    if (!passesFilter(user, filter, nameFilter)) {
+      continue;
     }
+
+    auto *item = new QListWidgetItem(buildUserText(user), ui->listWidget);
+    applyUserStyling(item, user);
+    item->setCheckState(user.enabled ? Qt::Checked : Qt::Unchecked);
+    item->setData(Qt::UserRole, QVariant::fromValue(&user));
+    ui->listWidget->addItem(item);
+  }
+}
+
+bool UsersDialog::passesFilter(const UserInfo &user, const QString &filter,
+                               const QRegularExpression &nameFilter) const {
+  if (!filter.isEmpty() && !nameFilter.match(user.name).hasMatch()) {
+    return false;
+  }
+  if (!user.isValid() && !ui->checkBox->isChecked()) {
+    return false;
+  }
+  bool expired = user.expiry.toSecsSinceEpoch() > 0 &&
+                 user.expiry.daysTo(QDateTime::currentDateTime()) > 0;
+  return !(expired && !ui->checkBox->isChecked());
+}
+
+QString UsersDialog::buildUserText(const UserInfo &user) const {
+  QString text = user.name + "\n" + user.key_id;
+  if (user.created.toSecsSinceEpoch() > 0) {
+    text += " " + tr("created") + " " +
+            QLocale::system().toString(user.created, QLocale::ShortFormat);
+  }
+  if (user.expiry.toSecsSinceEpoch() > 0) {
+    text += " " + tr("expires") + " " +
+            QLocale::system().toString(user.expiry, QLocale::ShortFormat);
+  }
+  return text;
+}
+
+void UsersDialog::applyUserStyling(QListWidgetItem *item,
+                                   const UserInfo &user) const {
+  if (user.have_secret) {
+    item->setForeground(Qt::blue);
+    QFont font;
+    font.setBold(true);
+    item->setFont(font);
+  } else if (!user.isValid()) {
+    item->setBackground(Qt::darkRed);
+    item->setForeground(Qt::white);
+  } else if (user.expiry.toSecsSinceEpoch() > 0 &&
+             user.expiry.daysTo(QDateTime::currentDateTime()) > 0) {
+    item->setForeground(Qt::darkRed);
+  } else if (!user.fullyValid()) {
+    item->setBackground(Qt::darkYellow);
+    item->setForeground(Qt::white);
   }
 }
 

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -47,6 +47,10 @@ private:
   QString m_dir;
 
   void populateList(const QString &filter = QString());
+  bool passesFilter(const UserInfo &user, const QString &filter,
+                    const QRegularExpression &nameFilter) const;
+  QString buildUserText(const UserInfo &user) const;
+  void applyUserStyling(QListWidgetItem *item, const UserInfo &user) const;
 };
 
 #endif // SRC_USERSDIALOG_H_


### PR DESCRIPTION
## Summary

### Code improvements

1. **Use Qt color enums** instead of hardcoded RGB values:
   - `QColor(164, 0, 0)` → `Qt::darkRed`
   - `QColor(164, 80, 0)` → `Qt::darkYellow`

2. **Remove dead code** - commented out `QColor(32, 74, 135)`

3. **Refactor populateList()** into smaller functions:
   - `passesFilter()` - filtering logic
   - `buildUserText()` - display text building
   - `applyUserStyling()` - styling logic

This improves readability by reducing nesting and separating concerns.