### PR TITLE
docs: add missing Black entries message in users dialog

### DIFF
--- a/src/usersdialog.ui
+++ b/src/usersdialog.ui
@@ -45,6 +45,7 @@
       <string>Select which users should be able to decrypt passwords stored in this folder.
 Note: Existing files will not be modified, and retain the old permissions until you edit them.
 Blue entries have a secret key available, select one of these to be able to decrypt.
+Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</string>
      </property>
      <property name="textFormat">


### PR DESCRIPTION
## Summary

Add clarification about Black entries (trusted encryption keys) in the Read access users dialog.

Addresses issue #460 - "Suggesting a clearer message in Read access users"