### PR TITLE
fix: correct Estonian translation of 'started it once'

### DIFF
--- a/localization/localization_et_EE.ts
+++ b/localization/localization_et_EE.ts
@@ -453,7 +453,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="713"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store to get it.&lt;br&gt;If you already did so, make sure you started it once and&lt;br&gt;click &quot;Autodetect&quot; in the next dialog.</source>
-        <translation>Palun paigalda oma arvutisse GnuPG.&lt;br&gt;Selleks lisa Microsoft Store&apos;ist &lt;strong&gt;Ubuntu&lt;/strong&gt;. Kui oled seda juba teinud, siis kontrolli, et oled ta vaid üks kord käivitanud ja&lt;br&gt;klõpsi järgmises vaates „Tuvasta automaatselt“.</translation>
+        <translation>Palun paigalda oma arvutisse GnuPG.&lt;br&gt;Selleks lisa Microsoft Store&apos;ist &lt;strong&gt;Ubuntu&lt;/strong&gt;. Kui oled seda juba teinud, siis kontrolli, et oled ta vähemalt korra käivitanud ja&lt;br&gt;klõpsi järgmises vaates „Tuvasta automaatselt“.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="718"/>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -145,7 +145,7 @@ auto main(int argc, char *argv[]) -> int {
                    &MainWindow::messageAvailable);
 #endif
 
-  QGuiApplication::setDesktopFileName("qtpass.desktop");
+  QGuiApplication::setDesktopFileName("qtpass");
 
   // Center the MainWindow on the screen the mouse pointer is currently on
 #if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)


### PR DESCRIPTION
## **User description**
## Summary

- Fix Estonian translation in `localization/localization_et_EE.ts`
- Changed "vaid üks kord käivitanud" (only once) to "vähemalt korra käivitanud" (at least once)

The original translation incorrectly conveyed "only once" instead of "at least once", which could confuse users about the GPG initialization requirement.

## Related

- Issue in Weblate: Estonian translation had mistranslation of English phrase "make sure you started it once"


___

## **CodeAnt-AI Description**
**Fix the desktop entry name and correct an Estonian setup message**

### What Changed
- The app now uses the shorter desktop file name expected by launchers and app menus.
- The Estonian GnuPG setup text now says it must have been started at least once, instead of only once.

### Impact
`✅ Correct app menu and launcher name`
`✅ Clearer GnuPG setup instructions for Estonian users`
`✅ Fewer setup mistakes during GnuPG detection`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Estonian translation for GnuPG setup guidance.

* **Chores**
  * Updated application desktop environment integration identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->