### PR TITLE
fix: correct Estonian translation file locale code and vanished strings

### DIFF
--- a/localization/localization_et_EE.ts
+++ b/localization/localization_et_EE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="et">
+<TS version="2.1" language="et_EE">
 <context>
     <name>ConfigDialog</name>
     <message>
@@ -36,7 +36,7 @@
     </message>
     <message>
         <source>Password Behaviour:</source>
-        <translation type="vanished">Password Behaviour:</translation>
+        <translation type="vanished">Salasõna käitumine:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
@@ -155,7 +155,7 @@
     </message>
     <message>
         <source>Use pwgen</source>
-        <translation type="vanished">Use pwgen</translation>
+        <translation type="vanished">Kasuta tarvikut pwgen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
@@ -183,7 +183,7 @@
     </message>
     <message>
         <source>Use git</source>
-        <translation type="vanished">Use git</translation>
+        <translation type="vanished">Kasuta Git&apos;i</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="512"/>
@@ -207,7 +207,7 @@
     </message>
     <message>
         <source>Use pass otp extension</source>
-        <translation type="vanished">Use pass otp extension</translation>
+        <translation type="vanished">Kasuta pass-otp lisamoodulit</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="603"/>


### PR DESCRIPTION
## **User description**
## Summary

- Fixed locale code from `et` to `et_EE` in header
- Fixed 4 vanished translation strings to use proper Estonian translations

## Changes

| Original (vanished) | Estonian Translation |
|---------------------|----------------------|
| Password Behaviour: | Salasõna käitumine: |
| Use pwgen | Kasuta tarvikut pwgen |
| Use git | Kasuta Git'i |
| Use pass otp extension | Kasuta pass-otp lisamoodulit |

Fixes #956 related findings


___

## **CodeAnt-AI Description**
**Fix Estonian locale and restore missing translation strings**

### What Changed
- The Estonian language file now uses the correct `et_EE` locale code, so the app can identify the language properly.
- Four missing Estonian labels were restored, including password behavior, pwgen, Git, and pass-otp text.
- Users with Estonian selected will see these settings shown in Estonian instead of untranslated placeholders.

### Impact
`✅ Correct Estonian language selection`
`✅ Fewer untranslated settings labels`
`✅ Clearer Estonian setup screens`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Estonian locale configuration and corrected translations for password settings and extension-related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->