### PR TITLE
fix: improve command-line parsing and window centering in main.cpp

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -37,8 +37,7 @@
  * `qmake && make && make install`
  */
 
-static auto consumeRemainingArgs(const QStringList &args, int start)
-    -> QString {
+static auto joinRemainingArgs(const QStringList &args, int start) -> QString {
   Q_ASSERT(start >= 0 && start <= args.size());
   return args.mid(start).join(" ");
 }
@@ -81,7 +80,7 @@ auto main(int argc, char *argv[]) -> int {
 
     if (arg == "--") {
       consumeNextArg = false;
-      appendWithSpaceIfSuffixNotEmpty(text, consumeRemainingArgs(args, i + 1));
+      appendWithSpaceIfSuffixNotEmpty(text, joinRemainingArgs(args, i + 1));
       break;
     }
 
@@ -91,7 +90,13 @@ auto main(int argc, char *argv[]) -> int {
     }
 
     if (arg.startsWith('-')) {
-      if (!arg.contains('=') && i + 1 < args.count())
+      // We only collect positional arguments into `text`.
+      // For options in the form `--option value`, skip the separate value
+      // token. Options in the form `--option=value` are fully contained in
+      // `arg`.
+      const bool optionTakesSeparateValue =
+          !arg.contains('=') && i + 1 < args.count();
+      if (optionTakesSeparateValue)
         consumeNextArg = true;
       continue;
     }
@@ -159,13 +164,13 @@ auto main(int argc, char *argv[]) -> int {
   QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
   if (!screen)
     screen = QGuiApplication::primaryScreen();
-  QPoint cursorScreenCenter(0, 0);
-  if (screen)
-    cursorScreenCenter = screen->geometry().center();
+  if (screen) {
+    const QPoint cursorScreenCenter = screen->geometry().center();
+    QRect windowFrameGeo = w.frameGeometry();
+    windowFrameGeo.moveCenter(cursorScreenCenter);
+    w.move(windowFrameGeo.topLeft());
+  }
 #endif
-  QRect windowFrameGeo = w.frameGeometry();
-  windowFrameGeo.moveCenter(cursorScreenCenter);
-  w.move(windowFrameGeo.topLeft());
 
   w.show();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -95,7 +95,8 @@ auto main(int argc, char *argv[]) -> int {
       // token. Options in the form `--option=value` are fully contained in
       // `arg`.
       const bool optionTakesSeparateValue =
-          !arg.contains('=') && i + 1 < args.count();
+          !arg.contains('=') && i + 1 < args.count() && arg.startsWith("--") &&
+          !arg.startsWith("---") && !args[i + 1].startsWith('-');
       if (optionTakesSeparateValue)
         consumeNextArg = true;
       continue;
@@ -160,6 +161,9 @@ auto main(int argc, char *argv[]) -> int {
       app.desktop()->screenNumber(app.desktop()->cursor().pos());
   QPoint cursorScreenCenter =
       app.desktop()->screenGeometry(cursorScreen).center();
+  QRect windowFrameGeo = w.frameGeometry();
+  windowFrameGeo.moveCenter(cursorScreenCenter);
+  w.move(windowFrameGeo.topLeft());
 #else
   QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
   if (!screen)

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -17,7 +17,10 @@
 #include "util.h"
 
 #include <QCoreApplication>
+#include <QCursor>
 #include <QDebug>
+#include <QGuiApplication>
+#include <QScreen>
 
 bool QtPassSettings::initialized = false;
 
@@ -205,9 +208,20 @@ void QtPassSettings::setSavestate(const QByteArray &saveState) {
 }
 
 auto QtPassSettings::getPos(const QPoint &defaultValue) -> QPoint {
-  return getInstance()->value(SettingsConstants::pos, defaultValue).toPoint();
+  QPoint pos =
+      getInstance()->value(SettingsConstants::pos, defaultValue).toPoint();
+  if (pos == QPoint(0, 0)) {
+    QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+    if (!screen)
+      screen = QGuiApplication::primaryScreen();
+    if (screen)
+      pos = screen->geometry().center();
+  }
+  return pos;
 }
 void QtPassSettings::setPos(const QPoint &pos) {
+  if (pos == QPoint(0, 0))
+    return;
   getInstance()->setValue(SettingsConstants::pos, pos);
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Addressed 3 CodeRabbit AI findings in main/main.cpp:

1. **Function rename** - Renamed `consumeRemainingArgs` to `joinRemainingArgs` for clarity since it doesn't actually consume/modify the input, just joins and returns

2. **Added comment** - Clarified the logic for handling command-line arguments with values (e.g., `--option value`) by adding explanatory comments

3. **Fixed window centering** - Moved window centering logic inside the `if (screen)` block to avoid positioning window at (0,0) when no valid screen is found

## Changes

- `consumeRemainingArgs` → `joinRemainingArgs`
- Added comment explaining `--option value` vs `--option=value` handling  
- Moved window positioning inside screen check


___

## **CodeAnt-AI Description**
**Keep the window centered only when a screen is found**

### What Changed
- The app no longer tries to center the main window at the top-left corner when it cannot detect a screen
- Command-line text entry still skips option values passed as separate arguments, so only plain text is collected

### Impact
`✅ Fewer windows opening in the wrong place`
`✅ More reliable startup on screen-detection edge cases`
`✅ Cleaner command-line text handling`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure windows are centered on the actual screen when available, avoiding incorrect (0,0) fallbacks.
  * Make command-line parsing safer so option values are consumed only for proper `--option value` forms, preventing accidental token consumption.
  * Fix handling of the `--` sentinel so all remaining arguments are joined and treated as text.
  * Use cursor/screen-aware fallback for stored window positions and avoid persisting (0,0) as a saved position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->