### PR TITLE
docs: clarify Qt5 and Qt6 dependencies in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,8 @@ QtPass is a GUI for [pass](https://www.passwordstore.org/), the standard Unix pa
 
 QtPass depends on:
 
-- **Qt6** (primary; use `qmake6`) — **Qt5** (5.15+, legacy; use `qmake`) - GUI framework
+- **Qt6** (primary; use `qmake6`) - GUI framework
+- **Qt5** (5.15+, legacy; use `qmake`) - GUI framework
 - **GPG** (gpg2) - encryption
 - **pass** (optional) - password store CLI
 - **Git** (optional) - version control


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the security documentation to clarify GUI framework dependencies, now separately listing Qt5 and Qt6 requirements with their respective version ranges and build commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->