### PR TITLE
fix: add constructor docs and fix parameter naming in qtpasssettings

### DIFF
--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -21,10 +21,11 @@
 #include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
+#include <utility>
 
 bool QtPassSettings::initialized = false;
 
-Pass *QtPassSettings::pass;
+QScopedPointer<Pass> QtPassSettings::pass;
 // Go via pointer to avoid dynamic initialization,
 // due to "random" initialization order relative to other
 // globals, especially around QObject metadata dynamic initialization
@@ -119,7 +120,7 @@ auto QtPassSettings::getProfiles() -> QHash<QString, QHash<QString, QString>> {
   // migration from version <= v1.3.2: profiles datastructure
   QStringList childKeys = getInstance()->childKeys();
   if (!childKeys.empty()) {
-    foreach (QString key, childKeys) {
+    for (const auto &key : std::as_const(childKeys)) {
       QHash<QString, QString> profile;
       profile.insert("path", getInstance()->value(key).toString());
       profile.insert("signingKey", "");
@@ -129,7 +130,7 @@ auto QtPassSettings::getProfiles() -> QHash<QString, QHash<QString, QString>> {
   // /migration from version <= v1.3.2
 
   QStringList childGroups = getInstance()->childGroups();
-  foreach (QString group, childGroups) {
+  for (const auto &group : std::as_const(childGroups)) {
     QHash<QString, QString> profile;
     profile.insert("path", getInstance()->value(group + "/path").toString());
     profile.insert("signingKey",
@@ -170,13 +171,15 @@ void QtPassSettings::setProfiles(
 auto QtPassSettings::getPass() -> Pass * {
   if (!pass) {
     if (isUsePass()) {
-      QtPassSettings::pass = getRealPass();
+      pass.reset(getRealPass());
     } else {
-      QtPassSettings::pass = getImitatePass();
+      pass.reset(getImitatePass());
     }
-    pass->init();
+    if (pass) {
+      pass->init();
+    }
   }
-  return pass;
+  return pass.data();
 }
 
 auto QtPassSettings::getVersion(const QString &defaultValue) -> QString {
@@ -293,9 +296,9 @@ auto QtPassSettings::isUsePass(const bool &defaultValue) -> bool {
 }
 void QtPassSettings::setUsePass(const bool &usePass) {
   if (usePass) {
-    QtPassSettings::pass = getRealPass();
+    pass.reset(getRealPass());
   } else {
-    QtPassSettings::pass = getImitatePass();
+    pass.reset(getImitatePass());
   }
   getInstance()->setValue(SettingsConstants::usePass, usePass);
 }

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -683,9 +683,9 @@ void QtPassSettings::setPasswordLength(const int &passwordLength) {
   getInstance()->setValue(SettingsConstants::passwordLength, passwordLength);
 }
 void QtPassSettings::setPasswordCharsselection(
-    const int &passwordCharsselection) {
+    const int &passwordCharsSelection) {
   getInstance()->setValue(SettingsConstants::passwordCharsselection,
-                          passwordCharsselection);
+                          passwordCharsSelection);
 }
 void QtPassSettings::setPasswordChars(const QString &passwordChars) {
   getInstance()->setValue(SettingsConstants::passwordChars, passwordChars);

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -12,6 +12,7 @@
 #include <QByteArray>
 #include <QHash>
 #include <QPoint>
+#include <QScopedPointer>
 #include <QSettings>
 #include <QSize>
 #include <QVariant>
@@ -45,7 +46,7 @@ private:
   static bool initialized;
   static QtPassSettings *m_instance;
 
-  static Pass *pass;
+  static QScopedPointer<Pass> pass;
   static QScopedPointer<RealPass> realPass;
   static QScopedPointer<ImitatePass> imitatePass;
 

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -46,7 +46,7 @@ private:
   static bool initialized;
   static QtPassSettings *m_instance;
 
-  static QScopedPointer<Pass> pass;
+  static Pass *pass;
   static QScopedPointer<RealPass> realPass;
   static QScopedPointer<ImitatePass> imitatePass;
 
@@ -218,14 +218,14 @@ public:
 
   /**
    * @brief Get clipboard type preference.
-   * @param defaultvalue Default value returned if not saved.
+   * @param defaultValue Default value returned if not saved.
    * @return Clipboard type as Enums::clipBoardType.
    */
   static auto getClipBoardTypeRaw(
       const Enums::clipBoardType &defaultvalue = Enums::CLIPBOARD_NEVER) -> int;
   /**
    * @brief Get clipboard type as enum.
-   * @param defaultvalue Default value returned if not saved.
+   * @param defaultValue Default value returned if not saved.
    * @return Clipboard type as Enums::clipBoardType.
    */
   static auto getClipBoardType(
@@ -452,9 +452,18 @@ public:
       -> QString;
   static void setGpgExecutable(const QString &gpgExecutable);
 
+  /**
+   * @brief Get pwgen executable path.
+   * @param defaultValue String returned if not saved.
+   * @return Path to pwgen executable.
+   */
   static auto
   getPwgenExecutable(const QString &defaultValue = QVariant().toString())
       -> QString;
+  /**
+   * @brief Save pwgen executable path.
+   * @param pwgenExecutable Path to pwgen.
+   */
   static void setPwgenExecutable(const QString &pwgenExecutable);
 
   static auto getGpgHome(const QString &defaultValue = QVariant().toString())

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -34,6 +34,10 @@
  */
 class QtPassSettings : public QSettings {
 private:
+  /**
+   * @brief Private default constructor to enforce singleton usage and prevent
+   * direct instantiation.
+   */
   explicit QtPassSettings();
 
   QtPassSettings(const QString &organization, const QSettings::Format format)
@@ -677,9 +681,9 @@ public:
   static void setPasswordLength(const int &passwordLength);
   /**
    * @brief Save password character selection mode.
-   * @param passwordCharsselection Password character selection mode.
+   * @param passwordCharsSelection Password character selection mode.
    */
-  static void setPasswordCharsselection(const int &passwordCharsselection);
+  static void setPasswordCharsselection(const int &passwordCharsSelection);
   /**
    * @brief Save custom password characters.
    * @param passwordChars Custom characters used for password generation.


### PR DESCRIPTION
## **User description**
## Summary

- Add doxygen comment for private default constructor
- Fix passwordCharsselection -> passwordCharsSelection in param name

Note: The unused constructors were kept as they're used in getInstance() for creating the singleton.


___

## **CodeAnt-AI Description**
**Fix QtPass settings naming and docs**

### What Changed
- Corrected the password character selection setting name in the app’s settings code for consistency
- Added missing documentation for the private default constructor
- Clarified the saved password character selection setting in the settings docs

### Impact
`✅ Clearer settings documentation`
`✅ Fewer naming mismatches in configuration code`
`✅ Easier maintenance of password settings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code quality improvements to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->