### PR TITLE
fix: exclude passwords from clipboard history on all platforms

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -22,6 +22,7 @@
 #include <windows.h>
 #include <winnetwk.h>
 #undef DELETE
+#include <QMimeData>
 #endif
 
 #ifdef QT_DEBUG
@@ -475,18 +476,13 @@ void QtPass::clearClipboard() {
 void QtPass::copyTextToClipboard(const QString &text) {
   QClipboard *clip = QApplication::clipboard();
 
+#ifndef Q_OS_WIN
   auto *mimeData = new QMimeData();
   mimeData->setText(text);
 #ifdef Q_OS_LINUX
   mimeData->setData("x-kde-passwordManagerHint", QByteArray("1"));
 #endif
-#ifdef Q_OS_WIN
-  mimeData->setData("ExcludeClipboardContentFromMonitorProcessing",
-                    QByteArray("1"));
-  mimeData->setData("CanIncludeInClipboardHistory", QByteArray("0"));
-  mimeData->setData("CanUploadToCloudClipboard", QByteArray("0"));
-#endif
-#ifdef Q_OS_MACOS
+#ifdef Q_OS_MAC
   mimeData->setData("exclude_from_history", QByteArray("1"));
 #endif
 
@@ -495,6 +491,13 @@ void QtPass::copyTextToClipboard(const QString &text) {
   } else {
     clip->setMimeData(mimeData, QClipboard::Selection);
   }
+#else
+  if (!QtPassSettings::isUseSelection()) {
+    clip->setText(text, QClipboard::Clipboard);
+  } else {
+    clip->setText(text, QClipboard::Selection);
+  }
+#endif
 
   clippedText = text;
   m_mainWindow->showStatusMessage(tr("Copied to clipboard"));

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -492,10 +492,20 @@ void QtPass::copyTextToClipboard(const QString &text) {
     clip->setMimeData(mimeData, QClipboard::Selection);
   }
 #else
+  auto *mimeData = new QMimeData();
+  mimeData->setText(text);
+  const auto dwordBytes = [](quint32 value) {
+    return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value));
+  };
+  mimeData->setData("ExcludeClipboardContentFromMonitorProcessing",
+                    dwordBytes(1));
+  mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
+  mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
+
   if (!QtPassSettings::isUseSelection()) {
-    clip->setText(text, QClipboard::Clipboard);
+    clip->setMimeData(mimeData, QClipboard::Clipboard);
   } else {
-    clip->setText(text, QClipboard::Selection);
+    clip->setMimeData(mimeData, QClipboard::Selection);
   }
 #endif
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -476,6 +476,11 @@ void QtPass::clearClipboard() {
 void QtPass::copyTextToClipboard(const QString &text) {
   QClipboard *clip = QApplication::clipboard();
 
+  QClipboard::Mode mode = QClipboard::Clipboard;
+  if (QtPassSettings::isUseSelection() && clip->supportsSelection()) {
+    mode = QClipboard::Selection;
+  }
+
 #ifndef Q_OS_WIN
   auto *mimeData = new QMimeData();
   mimeData->setText(text);
@@ -485,11 +490,6 @@ void QtPass::copyTextToClipboard(const QString &text) {
 #ifdef Q_OS_MAC
   mimeData->setData("application/x-nspasteboard-concealed-type", QByteArray());
 #endif
-
-  QClipboard::Mode mode = QClipboard::Clipboard;
-  if (QtPassSettings::isUseSelection() && clip->supportsSelection()) {
-    mode = QClipboard::Selection;
-  }
   clip->setMimeData(mimeData, mode);
 #else
   auto *mimeData = new QMimeData();
@@ -501,11 +501,6 @@ void QtPass::copyTextToClipboard(const QString &text) {
                     dwordBytes(1));
   mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
   mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
-
-  QClipboard::Mode mode = QClipboard::Clipboard;
-  if (QtPassSettings::isUseSelection() && clip->supportsSelection()) {
-    mode = QClipboard::Selection;
-  }
   clip->setMimeData(mimeData, mode);
 #endif
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -502,7 +502,7 @@ void QtPass::copyTextToClipboard(const QString &text) {
   mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
   mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
 
-  mode = QClipboard::Clipboard;
+  QClipboard::Mode mode = QClipboard::Clipboard;
   if (QtPassSettings::isUseSelection() && clip->supportsSelection()) {
     mode = QClipboard::Selection;
   }

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -14,6 +14,7 @@
 #ifndef Q_OS_WIN
 #include <QInputDialog>
 #include <QLineEdit>
+#include <QMimeData>
 #include <utility>
 #else
 #define WIN32_LEAN_AND_MEAN /*_KILLING_MACHINE*/
@@ -473,10 +474,17 @@ void QtPass::clearClipboard() {
  */
 void QtPass::copyTextToClipboard(const QString &text) {
   QClipboard *clip = QApplication::clipboard();
+
+  auto *mimeData = new QMimeData();
+  mimeData->setText(text);
+#ifdef Q_OS_LINUX
+  mimeData->setData("x-kde-passwordManagerHint", QByteArray("1"));
+#endif
+
   if (!QtPassSettings::isUseSelection()) {
-    clip->setText(text, QClipboard::Clipboard);
+    clip->setMimeData(mimeData, QClipboard::Clipboard);
   } else {
-    clip->setText(text, QClipboard::Selection);
+    clip->setMimeData(mimeData, QClipboard::Selection);
   }
 
   clippedText = text;

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -480,6 +480,15 @@ void QtPass::copyTextToClipboard(const QString &text) {
 #ifdef Q_OS_LINUX
   mimeData->setData("x-kde-passwordManagerHint", QByteArray("1"));
 #endif
+#ifdef Q_OS_WIN
+  mimeData->setData("ExcludeClipboardContentFromMonitorProcessing",
+                    QByteArray("1"));
+  mimeData->setData("CanIncludeInClipboardHistory", QByteArray("0"));
+  mimeData->setData("CanUploadToCloudClipboard", QByteArray("0"));
+#endif
+#ifdef Q_OS_MACOS
+  mimeData->setData("exclude_from_history", QByteArray("1"));
+#endif
 
   if (!QtPassSettings::isUseSelection()) {
     clip->setMimeData(mimeData, QClipboard::Clipboard);

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -480,17 +480,17 @@ void QtPass::copyTextToClipboard(const QString &text) {
   auto *mimeData = new QMimeData();
   mimeData->setText(text);
 #ifdef Q_OS_LINUX
-  mimeData->setData("x-kde-passwordManagerHint", QByteArray("1"));
+  mimeData->setData("x-kde-passwordManagerHint", QByteArray("secret"));
 #endif
 #ifdef Q_OS_MAC
-  mimeData->setData("exclude_from_history", QByteArray("1"));
+  mimeData->setData("application/x-nspasteboard-concealed-type", QByteArray());
 #endif
 
-  if (!QtPassSettings::isUseSelection()) {
-    clip->setMimeData(mimeData, QClipboard::Clipboard);
-  } else {
-    clip->setMimeData(mimeData, QClipboard::Selection);
+  QClipboard::Mode mode = QClipboard::Clipboard;
+  if (QtPassSettings::isUseSelection() && clip->supportsSelection()) {
+    mode = QClipboard::Selection;
   }
+  clip->setMimeData(mimeData, mode);
 #else
   auto *mimeData = new QMimeData();
   mimeData->setText(text);
@@ -502,11 +502,11 @@ void QtPass::copyTextToClipboard(const QString &text) {
   mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
   mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
 
-  if (!QtPassSettings::isUseSelection()) {
-    clip->setMimeData(mimeData, QClipboard::Clipboard);
-  } else {
-    clip->setMimeData(mimeData, QClipboard::Selection);
+  mode = QClipboard::Clipboard;
+  if (QtPassSettings::isUseSelection() && clip->supportsSelection()) {
+    mode = QClipboard::Selection;
   }
+  clip->setMimeData(mimeData, mode);
 #endif
 
   clippedText = text;


### PR DESCRIPTION
## **User description**
## Summar
- Fix #348: Set password hints when copying to clipboard so clipboard managers (KDE Klipper, Windows Clipboard History, macOS) don't store passwords
- Linux: Set x-kde-passwordManagerHint
- Windows: Set ExcludeClipboardContentFromMonitorProcessing, CanIncludeInClipboardHistory, CanUploadToCloudClipboard
- macOS: Set exclude_from_history\n\n## Testing\nTest on each platform by copying a password and checking clipboard history doesn't contain it.


___

## **CodeAnt-AI Description**
**Keep copied passwords out of clipboard history on all supported platforms**

### What Changed
- Copying a password now marks it so clipboard history tools do not save it on Linux, Windows, and macOS
- This applies whether the password is copied to the main clipboard or the selection clipboard

### Impact
`✅ Fewer saved passwords in clipboard history`
`✅ Lower risk of leaking copied passwords`
`✅ Clearer password privacy across Linux, Windows, and macOS`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved clipboard handling on Linux, macOS, and Windows for better compatibility with password managers and clipboard utilities.
  * Honors the app’s selection vs. primary clipboard preference when copying.
  * Maintains the “Copied to clipboard” confirmation and existing automatic clipboard-clear behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->