### PR TITLE
refactor: extract clipboard MIME helper for testability

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -492,10 +492,20 @@ void QtPass::copyTextToClipboard(const QString &text) {
     clip->setMimeData(mimeData, QClipboard::Selection);
   }
 #else
+  auto *mimeData = new QMimeData();
+  mimeData->setText(text);
+  const auto dwordBytes = [](quint32 value) {
+    return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value));
+  };
+  mimeData->setData("ExcludeClipboardContentFromMonitorProcessing",
+                    dwordBytes(1));
+  mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
+  mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
+
   if (!QtPassSettings::isUseSelection()) {
-    clip->setText(text, QClipboard::Clipboard);
+    clip->setMimeData(mimeData, QClipboard::Clipboard);
   } else {
-    clip->setText(text, QClipboard::Selection);
+    clip->setMimeData(mimeData, QClipboard::Selection);
   }
 #endif
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -470,6 +470,38 @@ void QtPass::clearClipboard() {
 }
 
 /**
+ * @brief Convert quint32 to byte array for Windows clipboard formats.
+ * @param value - DWORD value
+ * @return QByteArray with raw bytes
+ */
+static inline auto dwordBytes(quint32 value) -> QByteArray {
+  return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value));
+}
+
+/**
+ * @brief Build clipboard MIME data with platform-specific security hints.
+ * @param text - Plain text to copy
+ * @return QMimeData with text and security hints
+ */
+auto buildClipboardMimeData(const QString &text) -> QMimeData * {
+  auto *mimeData = new QMimeData();
+  mimeData->setText(text);
+#ifdef Q_OS_LINUX
+  mimeData->setData("x-kde-passwordManagerHint", QByteArray("secret"));
+#endif
+#ifdef Q_OS_MAC
+  mimeData->setData("application/x-nspasteboard-concealed-type", QByteArray());
+#endif
+#ifdef Q_OS_WIN
+  mimeData->setData("ExcludeClipboardContentFromMonitorProcessing",
+                    dwordBytes(1));
+  mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
+  mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
+#endif
+  return mimeData;
+}
+
+/**
  * @brief MainWindow::copyTextToClipboard copies text to your clipboard
  * @param text
  */
@@ -481,28 +513,8 @@ void QtPass::copyTextToClipboard(const QString &text) {
     mode = QClipboard::Selection;
   }
 
-#ifndef Q_OS_WIN
-  auto *mimeData = new QMimeData();
-  mimeData->setText(text);
-#ifdef Q_OS_LINUX
-  mimeData->setData("x-kde-passwordManagerHint", QByteArray("secret"));
-#endif
-#ifdef Q_OS_MAC
-  mimeData->setData("application/x-nspasteboard-concealed-type", QByteArray());
-#endif
+  auto *mimeData = buildClipboardMimeData(text);
   clip->setMimeData(mimeData, mode);
-#else
-  auto *mimeData = new QMimeData();
-  mimeData->setText(text);
-  const auto dwordBytes = [](quint32 value) {
-    return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value));
-  };
-  mimeData->setData("ExcludeClipboardContentFromMonitorProcessing",
-                    dwordBytes(1));
-  mimeData->setData("CanIncludeInClipboardHistory", dwordBytes(0));
-  mimeData->setData("CanUploadToCloudClipboard", dwordBytes(0));
-  clip->setMimeData(mimeData, mode);
-#endif
 
   clippedText = text;
   m_mainWindow->showStatusMessage(tr("Copied to clipboard"));

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -470,15 +470,6 @@ void QtPass::clearClipboard() {
 }
 
 /**
- * @brief Convert quint32 to byte array for Windows clipboard formats.
- * @param value - DWORD value
- * @return QByteArray with raw bytes
- */
-static inline auto dwordBytes(quint32 value) -> QByteArray {
-  return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value));
-}
-
-/**
  * @brief Build clipboard MIME data with platform-specific security hints.
  * @param text - Plain text to copy
  * @return QMimeData with text and security hints

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -14,6 +14,7 @@
 #ifndef Q_OS_WIN
 #include <QInputDialog>
 #include <QLineEdit>
+#include <QMimeData>
 #include <utility>
 #else
 #define WIN32_LEAN_AND_MEAN /*_KILLING_MACHINE*/
@@ -473,10 +474,17 @@ void QtPass::clearClipboard() {
  */
 void QtPass::copyTextToClipboard(const QString &text) {
   QClipboard *clip = QApplication::clipboard();
+
+  auto *mimeData = new QMimeData();
+  mimeData->setText(text);
+#ifdef Q_OS_LINUX
+  mimeData->setData("x-kde-passwordManagerHint", QByteArray("1"));
+#endif
+
   if (!QtPassSettings::isUseSelection()) {
-    clip->setText(text, QClipboard::Clipboard);
+    clip->setMimeData(mimeData, QClipboard::Clipboard);
   } else {
-    clip->setText(text, QClipboard::Selection);
+    clip->setMimeData(mimeData, QClipboard::Selection);
   }
 
   clippedText = text;

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -22,6 +22,7 @@
 #include <windows.h>
 #include <winnetwk.h>
 #undef DELETE
+#include <QMimeData>
 #endif
 
 #ifdef QT_DEBUG
@@ -475,10 +476,14 @@ void QtPass::clearClipboard() {
 void QtPass::copyTextToClipboard(const QString &text) {
   QClipboard *clip = QApplication::clipboard();
 
+#ifndef Q_OS_WIN
   auto *mimeData = new QMimeData();
   mimeData->setText(text);
 #ifdef Q_OS_LINUX
   mimeData->setData("x-kde-passwordManagerHint", QByteArray("1"));
+#endif
+#ifdef Q_OS_MAC
+  mimeData->setData("exclude_from_history", QByteArray("1"));
 #endif
 
   if (!QtPassSettings::isUseSelection()) {
@@ -486,6 +491,13 @@ void QtPass::copyTextToClipboard(const QString &text) {
   } else {
     clip->setMimeData(mimeData, QClipboard::Selection);
   }
+#else
+  if (!QtPassSettings::isUseSelection()) {
+    clip->setText(text, QClipboard::Clipboard);
+  } else {
+    clip->setText(text, QClipboard::Selection);
+  }
+#endif
 
   clippedText = text;
   m_mainWindow->showStatusMessage(tr("Copied to clipboard"));

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -124,6 +124,15 @@ class Pass;
  */
 auto buildClipboardMimeData(const QString &text) -> QMimeData *;
 
+/**
+ * @brief Convert quint32 to byte array for Windows clipboard formats.
+ * @param value - DWORD value
+ * @return QByteArray with raw bytes
+ */
+static inline auto dwordBytes(quint32 value) -> QByteArray {
+  return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value));
+}
+
 class QtPass : public QObject {
   Q_OBJECT
 

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -120,7 +120,8 @@ class Pass;
 /**
  * @brief Build clipboard MIME data with platform-specific security hints.
  * @param text - Plain text to copy
- * @return QMimeData with text and security hints
+ * @return QMimeData* - Ownership transferred to caller. Caller must delete
+ *         or transfer to QClipboard::setMimeData which takes ownership.
  */
 auto buildClipboardMimeData(const QString &text) -> QMimeData *;
 

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -4,6 +4,7 @@
 #define SRC_QTPASS_H_
 
 #include <QDialog>
+#include <QMimeData>
 #include <QObject>
 #include <QPixmap>
 #include <QProcess>
@@ -115,6 +116,14 @@ class Pass;
  * @param prefix Optional prefix to prepend to the output before display.
  * @param postfix Optional postfix to append to the output before display.
  */
+
+/**
+ * @brief Build clipboard MIME data with platform-specific security hints.
+ * @param text - Plain text to copy
+ * @return QMimeData with text and security hints
+ */
+auto buildClipboardMimeData(const QString &text) -> QMimeData *;
+
 class QtPass : public QObject {
   Q_OBJECT
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1115,7 +1115,7 @@ void tst_util::buildClipboardMimeDataLinux() {
 }
 
 void tst_util::buildClipboardMimeDataWindows() {
-`#ifdef` Q_OS_WIN
+#ifdef Q_OS_WIN
   QMimeData *mime = buildClipboardMimeData(QStringLiteral("testpassword"));
   QVERIFY(mime != nullptr);
   QVERIFY2(mime->hasText(), "Mime data should contain text");
@@ -1126,10 +1126,6 @@ void tst_util::buildClipboardMimeDataWindows() {
   QCOMPARE(mime->data("CanIncludeInClipboardHistory"), dwordBytes(0));
   QCOMPARE(mime->data("CanUploadToCloudClipboard"), dwordBytes(0));
   delete mime;
-`#else`
-  QSKIP("Windows-only test");
-`#endif`
-}
 #else
   QSKIP("Windows-only test");
 #endif

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1122,9 +1122,10 @@ void tst_util::buildClipboardMimeDataWindows() {
   QVERIFY2(mime->text() == "testpassword", "Text should match");
   QByteArray excl = mime->data("ExcludeClipboardContentFromMonitorProcessing");
   QVERIFY2(excl.size() == 4, "Windows ExcludeClipboard should be 4 bytes");
-  QVERIFY2(excl.at(0) == char(1), "Windows ExcludeClipboard should be 1");
-  QCOMPARE(mime->data("CanIncludeInClipboardHistory"), dwordBytes(0));
-  QCOMPARE(mime->data("CanUploadToCloudClipboard"), dwordBytes(0));
+  QVERIFY2(excl == dwordBytes(1), "Windows ExcludeClipboard should be DWORD 1");
+  QVERIFY(mime->hasFormat("ExcludeClipboardContentFromMonitorProcessing"));
+  QVERIFY(mime->hasFormat("CanIncludeInClipboardHistory"));
+  QVERIFY(mime->hasFormat("CanUploadToCloudClipboard"));
   delete mime;
 #else
   QSKIP("Windows-only test");
@@ -1157,9 +1158,11 @@ void tst_util::buildClipboardMimeDataMac() {
   QVERIFY(mime != nullptr);
   QVERIFY2(mime->hasText(), "Mime data should contain text");
   QVERIFY2(mime->text() == "testpassword", "Text should match");
+  QVERIFY2(mime->hasFormat("application/x-nspasteboard-concealed-type"),
+           "macOS should have concealed type format");
   QVERIFY2(mime->data("application/x-nspasteboard-concealed-type") ==
                QByteArray(),
-           "macOS should set concealed type");
+           "macOS concealed type should be empty");
   delete mime;
 #else
   QSKIP("macOS-only test");

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -14,6 +14,7 @@
 #include "../../../src/pass.h"
 #include "../../../src/passwordconfiguration.h"
 #include "../../../src/qprogressindicator.h"
+#include "../../../src/qtpass.h"
 #include "../../../src/qtpasssettings.h"
 #include "../../../src/simpletransaction.h"
 #include "../../../src/userinfo.h"
@@ -77,6 +78,9 @@ private Q_SLOTS:
   void qProgressIndicatorStartStop();
   void namedValueBasic();
   void namedValueMultiple();
+  void buildClipboardMimeDataLinux();
+  void buildClipboardMimeDataWindows();
+  void buildClipboardMimeDataDword();
   void imitatePassResolveMoveDestination();
   void imitatePassResolveMoveDestinationForce();
   void imitatePassResolveMoveDestinationDestExistsNoForce();
@@ -1092,6 +1096,55 @@ void tst_util::findBinaryInPathTempExecutableInTempDir() {
   QVERIFY2(QFileInfo(result).isAbsolute(), "Result must be an absolute path");
 #else
   QSKIP("Temp-executable test is Unix-only");
+#endif
+}
+
+void tst_util::buildClipboardMimeDataLinux() {
+#ifdef Q_OS_LINUX
+  QMimeData *mime = buildClipboardMimeData(QStringLiteral("testpassword"));
+  QVERIFY(mime != nullptr);
+  QVERIFY2(mime->hasText(), "Mime data should contain text");
+  QVERIFY2(mime->text() == "testpassword", "Text should match");
+  QVERIFY2(mime->data("x-kde-passwordManagerHint") == QByteArray("secret"),
+           "Linux should set password hint");
+  delete mime;
+#else
+  QSKIP("Linux-only test");
+#endif
+}
+
+void tst_util::buildClipboardMimeDataWindows() {
+#ifdef Q_OS_WIN
+  QMimeData *mime = buildClipboardMimeData(QStringLiteral("testpassword"));
+  QVERIFY(mime != nullptr);
+  QVERIFY2(mime->hasText(), "Mime data should contain text");
+  QVERIFY2(mime->text() == "testpassword", "Text should match");
+  QByteArray excl = mime->data("ExcludeClipboardContentFromMonitorProcessing");
+  QVERIFY2(excl.size() == 4, "Windows ExcludeClipboard should be 4 bytes");
+  QVERIFY2(excl.at(0) == char(1), "Windows ExcludeClipboard should be 1");
+  delete mime;
+#else
+  QSKIP("Windows-only test");
+#endif
+}
+
+void tst_util::buildClipboardMimeDataDword() {
+#ifdef Q_OS_WIN
+  QByteArray zero = dwordBytes(0);
+  QVERIFY2(zero.size() == 4, "DWORD should be 4 bytes");
+  QVERIFY2(zero.at(0) == char(0), "DWORD 0 should be 0x00");
+  QVERIFY2(zero.at(1) == char(0), "DWORD 0 should be 0x00");
+  QVERIFY2(zero.at(2) == char(0), "DWORD 0 should be 0x00");
+  QVERIFY2(zero.at(3) == char(0), "DWORD 0 should be 0x00");
+
+  QByteArray one = dwordBytes(1);
+  QVERIFY2(one.size() == 4, "DWORD should be 4 bytes");
+  QVERIFY2(one.at(0) == char(1), "DWORD 1 should be 0x01");
+  QVERIFY2(one.at(1) == char(0), "DWORD 1 should be 0x00");
+  QVERIFY2(one.at(2) == char(0), "DWORD 1 should be 0x00");
+  QVERIFY2(one.at(3) == char(0), "DWORD 1 should be 0x00");
+#else
+  QSKIP("Windows-only test");
 #endif
 }
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1115,7 +1115,7 @@ void tst_util::buildClipboardMimeDataLinux() {
 }
 
 void tst_util::buildClipboardMimeDataWindows() {
-#ifdef Q_OS_WIN
+`#ifdef` Q_OS_WIN
   QMimeData *mime = buildClipboardMimeData(QStringLiteral("testpassword"));
   QVERIFY(mime != nullptr);
   QVERIFY2(mime->hasText(), "Mime data should contain text");
@@ -1123,7 +1123,13 @@ void tst_util::buildClipboardMimeDataWindows() {
   QByteArray excl = mime->data("ExcludeClipboardContentFromMonitorProcessing");
   QVERIFY2(excl.size() == 4, "Windows ExcludeClipboard should be 4 bytes");
   QVERIFY2(excl.at(0) == char(1), "Windows ExcludeClipboard should be 1");
+  QCOMPARE(mime->data("CanIncludeInClipboardHistory"), dwordBytes(0));
+  QCOMPARE(mime->data("CanUploadToCloudClipboard"), dwordBytes(0));
   delete mime;
+`#else`
+  QSKIP("Windows-only test");
+`#endif`
+}
 #else
   QSKIP("Windows-only test");
 #endif

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -80,6 +80,7 @@ private Q_SLOTS:
   void namedValueMultiple();
   void buildClipboardMimeDataLinux();
   void buildClipboardMimeDataWindows();
+  void buildClipboardMimeDataMac();
   void buildClipboardMimeDataDword();
   void imitatePassResolveMoveDestination();
   void imitatePassResolveMoveDestinationForce();
@@ -1145,6 +1146,21 @@ void tst_util::buildClipboardMimeDataDword() {
   QVERIFY2(one.at(3) == char(0), "DWORD 1 should be 0x00");
 #else
   QSKIP("Windows-only test");
+#endif
+}
+
+void tst_util::buildClipboardMimeDataMac() {
+#ifdef Q_OS_MAC
+  QMimeData *mime = buildClipboardMimeData(QStringLiteral("testpassword"));
+  QVERIFY(mime != nullptr);
+  QVERIFY2(mime->hasText(), "Mime data should contain text");
+  QVERIFY2(mime->text() == "testpassword", "Text should match");
+  QVERIFY2(mime->data("application/x-nspasteboard-concealed-type") ==
+               QByteArray(),
+           "macOS should set concealed type");
+  delete mime;
+#else
+  QSKIP("macOS-only test");
 #endif
 }
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1126,6 +1126,16 @@ void tst_util::buildClipboardMimeDataWindows() {
   QVERIFY(mime->hasFormat("ExcludeClipboardContentFromMonitorProcessing"));
   QVERIFY(mime->hasFormat("CanIncludeInClipboardHistory"));
   QVERIFY(mime->hasFormat("CanUploadToCloudClipboard"));
+  QByteArray canHistory = mime->data("CanIncludeInClipboardHistory");
+  QVERIFY2(canHistory.size() == 4,
+           "CanIncludeInClipboardHistory should be 4 bytes");
+  QVERIFY2(canHistory == dwordBytes(0),
+           "CanIncludeInClipboardHistory should be DWORD 0");
+  QByteArray cloudClip = mime->data("CanUploadToCloudClipboard");
+  QVERIFY2(cloudClip.size() == 4,
+           "CanUploadToCloudClipboard should be 4 bytes");
+  QVERIFY2(cloudClip == dwordBytes(0),
+           "CanUploadToCloudClipboard should be DWORD 0");
   delete mime;
 #else
   QSKIP("Windows-only test");


### PR DESCRIPTION
## **User description**
## Summary
- Extract buildClipboardMimeData() and dwordBytes() helpers from copyTextToClipboard()
- Enables unit testing of platform-specific clipboard security hints
- Centralizes Linux/macOS/Windows MIME data construction

## Changes
- Add static dwordBytes() helper for Windows DWORD conversion
- Add buildClipboardMimeData() that returns populated QMimeData*
- Simplify copyTextToClipboard() to use helper

## Testing
All existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized clipboard/MIME payload construction for more consistent, secure, and correctly applied cross-platform copy behavior; clipboard vs selection is resolved once at application.

* **Tests**
  * Added automated tests verifying copied text, platform-specific security/hint MIME entries, and clipboard payload integrity across Linux, Windows, and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Copying text to the clipboard now applies the right privacy hints on Linux, macOS, and Windows**

### What Changed
- Clipboard copies now include the platform-specific security hints needed to keep copied passwords out of clipboard history and monitoring tools.
- Linux copies now set the password manager hint correctly.
- Windows copies now write the clipboard protection values in the expected format.
- The clipboard setup is now handled in one place, keeping copy behavior consistent across platforms.

### Impact
`✅ Fewer passwords saved in clipboard history`
`✅ Better clipboard privacy on Linux, macOS, and Windows`
`✅ More reliable password copying across platforms`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
