### PR TITLE
test: add PassStoreGuard and fix count initialization in util tests

### DIFF
--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -876,6 +876,7 @@ void tst_util::getRecipientListWithComments() {
   file.write("ABCDEF12\n# comment\n34567890\n");
   file.close();
 
+  PassStoreGuard guard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(passStore);
   QStringList recipients = Pass::getRecipientList(passStore);
   QCOMPARE(recipients.size(), 2);
@@ -895,13 +896,13 @@ void tst_util::getRecipientStringCount() {
   const QString originalPassStore = QtPassSettings::getPassStore();
   PassStoreGuard originalGuard(originalPassStore);
   QtPassSettings::setPassStore(passStore);
-  int count = -1;
+  int count = 0;
   QStringList parsedRecipients =
       Pass::getRecipientString(passStore, " ", &count);
   QStringList recipientsNoCount = Pass::getRecipientString(passStore, " ");
 
   QStringList expectedRecipients = {"ABCDEF12", "34567890"};
-  // Verify count was actually updated from initial value
+  // Verify count matches the expected number of parsed recipients.
   QVERIFY(count > 0);
   QCOMPARE(count, (int)expectedRecipients.size());
   // Verify both overloads return the same result


### PR DESCRIPTION
## **User description**
## Summary

Fixed 4 AI findings in tests/auto/util/tst_util.cpp:

1. **getRecipientListBasic** - Added PassStoreGuard for cleanup
2. **getRecipientListWithComments** - Added PassStoreGuard for cleanup  
3. **getRecipientStringCount** - Changed count initialization from -1 to 0
4. **Comment fix** - Updated comment to reflect actual check

Also fixed in previous tests:
- getGpgIdPathBasic, getGpgIdPathSubfolder, getGpgIdPathNotFound - Added PassStoreGuard


___

## **CodeAnt-AI Description**
**Keep utility tests isolated and verify recipient counting starts from a valid value**

### What Changed
- Utility tests now restore the previous pass store setting after they run, so they do not affect later tests.
- The recipient-count test now starts from zero and checks that the parsed recipient count is updated to the expected number.
- A comment was updated to match the actual count check.

### Impact
`✅ Fewer test side effects`
`✅ More reliable util test results`
`✅ Clearer recipient count checks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness with enhanced cleanup and restoration mechanisms.
  * Refined test initialization for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->