### PR TITLE
fix: replace static variables with member variables in UsersDialog

### DIFF
--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -217,15 +217,13 @@ void UsersDialog::itemChange(QListWidgetItem *item) {
  * @param filter
  */
 void UsersDialog::populateList(const QString &filter) {
-  static QString lastFilter;
-  static QRegularExpression cachedNameFilter;
-  if (filter != lastFilter) {
-    lastFilter = filter;
-    cachedNameFilter = QRegularExpression(
+  if (filter != m_lastFilter) {
+    m_lastFilter = filter;
+    m_cachedNameFilter = QRegularExpression(
         QRegularExpression::wildcardToRegularExpression("*" + filter + "*"),
         QRegularExpression::CaseInsensitiveOption);
   }
-  const QRegularExpression &nameFilter = cachedNameFilter;
+  const QRegularExpression &nameFilter = m_cachedNameFilter;
   ui->listWidget->clear();
 
   for (int i = 0; i < m_userList.size(); ++i) {

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -7,6 +7,7 @@
 
 #include <QDialog>
 #include <QList>
+#include <QRegularExpression>
 
 namespace Ui {
 class UsersDialog;
@@ -75,8 +76,10 @@ private slots:
 
 private:
   Ui::UsersDialog *ui;
-  QList<UserInfo> m_userList; /**< List of available GPG users */
-  QString m_dir;              /**< Password store directory */
+  QList<UserInfo> m_userList;            /**< List of available GPG users */
+  QString m_dir;                         /**< Password store directory */
+  QString m_lastFilter;                  /**< Last filter text for caching */
+  QRegularExpression m_cachedNameFilter; /**< Cached regex filter */
 
   void restoreDialogState();
   void connectSignals();


### PR DESCRIPTION
## **User description**
## Summary
- Fix static variable issue in UsersDialog::populateList()
- Replace static QString lastFilter and static QRegularExpression cachedNameFilter with member variables m_lastFilter and m_cachedNameFilter
- Avoids potential thread-safety issues with static local variables

## Changes
- Add m_lastFilter and m_cachedNameFilter member variables to usersdialog.h
- Update populateList() to use member variables instead of statics
- Add #include <QRegularExpression> to usersdialog.h


___

## **CodeAnt-AI Description**
**Keep the user list filter consistent while searching**

### What Changed
- The user list now keeps its filter state inside the dialog, so filtering results stay tied to the current search text.
- Search results continue to use a cached filter while the text stays the same, then refresh when the search changes.
- This removes the shared static state that could cause inconsistent filtering behavior.

### Impact
`✅ Consistent user search results`
`✅ Fewer filter glitches in the users dialog`
`✅ Safer filtering when the dialog is used repeatedly`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal caching mechanism for user list filtering to improve performance while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->