### PR TITLE
fix: move docstrings outside function bodies in UsersDialog

### DIFF
--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -64,10 +64,6 @@ void UsersDialog::restoreDialogState() {
 }
 
 auto UsersDialog::loadGpgKeys() -> bool {
-  /**
-   * @brief Load GPG keys and determine secret key status.
-   * @return true if successful, false if keys could not be loaded.
-   */
   QList<UserInfo> users = QtPassSettings::getPass()->listKeys();
   if (users.isEmpty()) {
     QMessageBox::critical(parentWidget(), tr("Keylist missing"),
@@ -83,10 +79,6 @@ auto UsersDialog::loadGpgKeys() -> bool {
 }
 
 void UsersDialog::markSecretKeys(QList<UserInfo> &users) {
-  /**
-   * @brief Mark which keys have secret counterparts.
-   * @param users List of users to mark.
-   */
   QList<UserInfo> secret_keys = QtPassSettings::getPass()->listKeys("", true);
   QSet<QString> secretKeyIds;
   for (const UserInfo &sec : secret_keys) {
@@ -100,9 +92,6 @@ void UsersDialog::markSecretKeys(QList<UserInfo> &users) {
 }
 
 void UsersDialog::loadRecipients() {
-  /**
-   * @brief Load recipients and handle missing keys.
-   */
   int count = 0;
   QStringList recipients = QtPassSettings::getPass()->getRecipientString(
       m_dir.isEmpty() ? "" : m_dir, " ", &count);

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -46,10 +46,10 @@ void UsersDialog::connectSignals() {
   ui->lineEdit->setClearButtonEnabled(true);
 }
 
+/**
+ * @brief Restore dialog geometry from settings.
+ */
 void UsersDialog::restoreDialogState() {
-  /**
-   * @brief Restore dialog geometry from settings.
-   */
   QByteArray savedGeometry = QtPassSettings::getDialogGeometry("usersDialog");
   bool hasSavedGeometry = !savedGeometry.isEmpty();
   if (hasSavedGeometry) {

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -217,15 +217,13 @@ void UsersDialog::itemChange(QListWidgetItem *item) {
  * @param filter
  */
 void UsersDialog::populateList(const QString &filter) {
-  static QString lastFilter;
-  static QRegularExpression cachedNameFilter;
-  if (filter != lastFilter) {
-    lastFilter = filter;
-    cachedNameFilter = QRegularExpression(
+  if (filter != m_lastFilter) {
+    m_lastFilter = filter;
+    m_cachedNameFilter = QRegularExpression(
         QRegularExpression::wildcardToRegularExpression("*" + filter + "*"),
         QRegularExpression::CaseInsensitiveOption);
   }
-  const QRegularExpression &nameFilter = cachedNameFilter;
+  const QRegularExpression &nameFilter = m_cachedNameFilter;
   ui->listWidget->clear();
 
   for (int i = 0; i < m_userList.size(); ++i) {

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -7,6 +7,7 @@
 
 #include <QDialog>
 #include <QList>
+#include <QRegularExpression>
 
 namespace Ui {
 class UsersDialog;
@@ -75,8 +76,10 @@ private slots:
 
 private:
   Ui::UsersDialog *ui;
-  QList<UserInfo> m_userList; /**< List of available GPG users */
-  QString m_dir;              /**< Password store directory */
+  QList<UserInfo> m_userList;            /**< List of available GPG users */
+  QString m_dir;                         /**< Password store directory */
+  QString m_lastFilter;                  /**< Last filter text for caching */
+  QRegularExpression m_cachedNameFilter; /**< Cached regex filter */
 
   void restoreDialogState();
   void connectSignals();

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -82,9 +82,27 @@ private:
   QRegularExpression m_cachedNameFilter; /**< Cached regex filter */
 
   void restoreDialogState();
+
+  /**
+   * @brief Connect dialog signals.
+   */
   void connectSignals();
+
+  /**
+   * @brief Load GPG keys and determine secret key status.
+   * @return true if successful, false if keys could not be loaded.
+   */
   auto loadGpgKeys() -> bool;
+
+  /**
+   * @brief Mark which keys have secret counterparts.
+   * @param users List of users to mark.
+   */
   void markSecretKeys(QList<UserInfo> &users);
+
+  /**
+   * @brief Load recipients and handle missing keys.
+   */
   void loadRecipients();
 
   /**


### PR DESCRIPTION
## **User description**
## Summary
- Move docstrings from inside function bodies to before function definitions in usersdialog.cpp
- Keep docstrings in header file for public API docs

## Changes
- Fixed docstring placement in restoreDialogState()


___

## **CodeAnt-AI Description**
Move Users dialog docs to the function declarations

### What Changed
- Public notes for Users dialog actions now sit with the function declarations instead of inside the function bodies
- The dialog’s documented behavior stays the same; this change only makes the code comments easier to find and keep aligned with the public API

### Impact
`✅ Clearer developer-facing API docs`
`✅ Easier maintenance of Users dialog notes`
`✅ Less confusion when reading the dialog code`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and documentation structure in the users dialog module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->