### PR TITLE
fix: pass dir by const ref, remove unused METATYPE

### DIFF
--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -64,10 +64,6 @@ void UsersDialog::restoreDialogState() {
 }
 
 auto UsersDialog::loadGpgKeys() -> bool {
-  /**
-   * @brief Load GPG keys and determine secret key status.
-   * @return true if successful, false if keys could not be loaded.
-   */
   QList<UserInfo> users = QtPassSettings::getPass()->listKeys();
   if (users.isEmpty()) {
     QMessageBox::critical(parentWidget(), tr("Keylist missing"),
@@ -83,10 +79,6 @@ auto UsersDialog::loadGpgKeys() -> bool {
 }
 
 void UsersDialog::markSecretKeys(QList<UserInfo> &users) {
-  /**
-   * @brief Mark which keys have secret counterparts.
-   * @param users List of users to mark.
-   */
   QList<UserInfo> secret_keys = QtPassSettings::getPass()->listKeys("", true);
   QSet<QString> secretKeyIds;
   for (const UserInfo &sec : secret_keys) {
@@ -100,9 +92,6 @@ void UsersDialog::markSecretKeys(QList<UserInfo> &users) {
 }
 
 void UsersDialog::loadRecipients() {
-  /**
-   * @brief Load recipients and handle missing keys.
-   */
   int count = 0;
   QStringList recipients = QtPassSettings::getPass()->getRecipientString(
       m_dir.isEmpty() ? "" : m_dir, " ", &count);

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -217,15 +217,13 @@ void UsersDialog::itemChange(QListWidgetItem *item) {
  * @param filter
  */
 void UsersDialog::populateList(const QString &filter) {
-  static QString lastFilter;
-  static QRegularExpression cachedNameFilter;
-  if (filter != lastFilter) {
-    lastFilter = filter;
-    cachedNameFilter = QRegularExpression(
+  if (filter != m_lastFilter) {
+    m_lastFilter = filter;
+    m_cachedNameFilter = QRegularExpression(
         QRegularExpression::wildcardToRegularExpression("*" + filter + "*"),
         QRegularExpression::CaseInsensitiveOption);
   }
-  const QRegularExpression &nameFilter = cachedNameFilter;
+  const QRegularExpression &nameFilter = m_cachedNameFilter;
   ui->listWidget->clear();
 
   for (int i = 0; i < m_userList.size(); ++i) {

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -17,10 +17,11 @@
 #endif
 /**
  * @brief UsersDialog::UsersDialog basic constructor
+ * @param dir Password directory
  * @param parent
  */
-UsersDialog::UsersDialog(QString dir, QWidget *parent)
-    : QDialog(parent), ui(new Ui::UsersDialog), m_dir(std::move(dir)) {
+UsersDialog::UsersDialog(const QString &dir, QWidget *parent)
+    : QDialog(parent), ui(new Ui::UsersDialog), m_dir(dir) {
 
   ui->setupUi(this);
 
@@ -130,11 +131,6 @@ void UsersDialog::loadRecipients() {
  * @brief UsersDialog::~UsersDialog basic destructor.
  */
 UsersDialog::~UsersDialog() { delete ui; }
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-Q_DECLARE_METATYPE(UserInfo *)
-Q_DECLARE_METATYPE(const UserInfo *)
-#endif
 
 /**
  * @brief UsersDialog::accept

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -7,6 +7,7 @@
 
 #include <QDialog>
 #include <QList>
+#include <QRegularExpression>
 
 namespace Ui {
 class UsersDialog;
@@ -75,8 +76,10 @@ private slots:
 
 private:
   Ui::UsersDialog *ui;
-  QList<UserInfo> m_userList; /**< List of available GPG users */
-  QString m_dir;              /**< Password store directory */
+  QList<UserInfo> m_userList;            /**< List of available GPG users */
+  QString m_dir;                         /**< Password store directory */
+  QString m_lastFilter;                  /**< Last filter text for caching */
+  QRegularExpression m_cachedNameFilter; /**< Cached regex filter */
 
   void restoreDialogState();
   void connectSignals();

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -82,9 +82,27 @@ private:
   QRegularExpression m_cachedNameFilter; /**< Cached regex filter */
 
   void restoreDialogState();
+
+  /**
+   * @brief Connect dialog signals.
+   */
   void connectSignals();
+
+  /**
+   * @brief Load GPG keys and determine secret key status.
+   * @return true if successful, false if keys could not be loaded.
+   */
   auto loadGpgKeys() -> bool;
+
+  /**
+   * @brief Mark which keys have secret counterparts.
+   * @param users List of users to mark.
+   */
   void markSecretKeys(QList<UserInfo> &users);
+
+  /**
+   * @brief Load recipients and handle missing keys.
+   */
   void loadRecipients();
 
   /**

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -34,7 +34,7 @@ public:
    * @param dir Password store directory path.
    * @param parent Parent widget.
    */
-  explicit UsersDialog(QString dir, QWidget *parent = nullptr);
+  explicit UsersDialog(const QString &dir, QWidget *parent = nullptr);
   /**
    * @brief Destructor.
    */


### PR DESCRIPTION
## **User description**
## Summary
- Pass AGENTS.md			  moc_storemodel.o
appdmg.json			  moc_trayicon.cpp
artwork				  moc_trayicon.o
build				  moc_usersdialog.cpp
CHANGELOG.md			  moc_usersdialog.o
CODE_OF_CONDUCT.md		  model
compile_commands.json		  pass.o
configdialog.o			  passwordconfig
CONTRIBUTING.md			  passworddialog.o
docs				  publiccode.yml
Doxyfile			  qmake_qmake_qm_files.qrc
executor			  qprogressindicator.o
executor.o			  qpushbuttonasqrcode.o
FAQ.md				  qpushbuttonshowpassword.o
filecontent			  qpushbuttonwithclipboard.o
filecontent.o			  qrc_qmake_qmake_qm_files.cpp
gpgkeystate			  qrc_qmake_qmake_qm_files.o
gpgkeystate.o			  qrc_resources.cpp
icons				  qrc_resources.o
imitatepass.o			  qtpass.1
keygendialog.o			  qtpass.appdata.xml
key_management.bat		  qtpass.desktop
LICENSE				  qtpass.iss
LICENSES			  qtpass.o
localization			  qtpass.plist
main				  qtpass.pri
mainwindow.o			  qtpass.pro
Makefile			  qtpasssettings.o
moc_configdialog.cpp		  qtpass.spec
moc_configdialog.o		  README.md
moc_deselectabletreeview.cpp	  realpass.o
moc_deselectabletreeview.o	  release-winstore.bat
moc_executor.cpp		  release-zip.mak
moc_executor.o			  resources.qrc
moc_imitatepass.cpp		  REUSE.toml
moc_imitatepass.o		  scripts
moc_keygendialog.cpp		  SECURITY.md
moc_keygendialog.o		  settings
moc_mainwindow.cpp		  settingsconstants.o
moc_mainwindow.o		  simpletransaction
moc_pass.cpp			  simpletransaction.o
moc_pass.o			  singleapplication.o
moc_passworddialog.cpp		  src
moc_passworddialog.o		  storemodel.o
moc_qprogressindicator.cpp	  tests
moc_qprogressindicator.o	  trayicon.o
moc_qpushbuttonasqrcode.cpp	  ui
moc_qpushbuttonasqrcode.o	  ui_configdialog.h
moc_qpushbuttonshowpassword.cpp   ui_keygendialog.h
moc_qpushbuttonshowpassword.o	  ui_mainwindow.h
moc_qpushbuttonwithclipboard.cpp  ui_passworddialog.h
moc_qpushbuttonwithclipboard.o	  ui_usersdialog.h
moc_qtpass.cpp			  usersdialog.o
moc_qtpass.o			  util
moc_singleapplication.cpp	  util.o
moc_singleapplication.o		  Windows.md
moc_storemodel.cpp		  windows.rc parameter by const reference instead of by value
- Remove unused Q_DECLARE_METATYPE(UserInfo *) declarations

## Changes
- UsersDialog constructor now takes AGENTS.md			  moc_storemodel.o
appdmg.json			  moc_trayicon.cpp
artwork				  moc_trayicon.o
build				  moc_usersdialog.cpp
CHANGELOG.md			  moc_usersdialog.o
CODE_OF_CONDUCT.md		  model
compile_commands.json		  pass.o
configdialog.o			  passwordconfig
CONTRIBUTING.md			  passworddialog.o
docs				  publiccode.yml
Doxyfile			  qmake_qmake_qm_files.qrc
executor			  qprogressindicator.o
executor.o			  qpushbuttonasqrcode.o
FAQ.md				  qpushbuttonshowpassword.o
filecontent			  qpushbuttonwithclipboard.o
filecontent.o			  qrc_qmake_qmake_qm_files.cpp
gpgkeystate			  qrc_qmake_qmake_qm_files.o
gpgkeystate.o			  qrc_resources.cpp
icons				  qrc_resources.o
imitatepass.o			  qtpass.1
keygendialog.o			  qtpass.appdata.xml
key_management.bat		  qtpass.desktop
LICENSE				  qtpass.iss
LICENSES			  qtpass.o
localization			  qtpass.plist
main				  qtpass.pri
mainwindow.o			  qtpass.pro
Makefile			  qtpasssettings.o
moc_configdialog.cpp		  qtpass.spec
moc_configdialog.o		  README.md
moc_deselectabletreeview.cpp	  realpass.o
moc_deselectabletreeview.o	  release-winstore.bat
moc_executor.cpp		  release-zip.mak
moc_executor.o			  resources.qrc
moc_imitatepass.cpp		  REUSE.toml
moc_imitatepass.o		  scripts
moc_keygendialog.cpp		  SECURITY.md
moc_keygendialog.o		  settings
moc_mainwindow.cpp		  settingsconstants.o
moc_mainwindow.o		  simpletransaction
moc_pass.cpp			  simpletransaction.o
moc_pass.o			  singleapplication.o
moc_passworddialog.cpp		  src
moc_passworddialog.o		  storemodel.o
moc_qprogressindicator.cpp	  tests
moc_qprogressindicator.o	  trayicon.o
moc_qpushbuttonasqrcode.cpp	  ui
moc_qpushbuttonasqrcode.o	  ui_configdialog.h
moc_qpushbuttonshowpassword.cpp   ui_keygendialog.h
moc_qpushbuttonshowpassword.o	  ui_mainwindow.h
moc_qpushbuttonwithclipboard.cpp  ui_passworddialog.h
moc_qpushbuttonwithclipboard.o	  ui_usersdialog.h
moc_qtpass.cpp			  usersdialog.o
moc_qtpass.o			  util
moc_singleapplication.cpp	  util.o
moc_singleapplication.o		  Windows.md
moc_storemodel.cpp		  windows.rc instead of 
- Removed unused Q_DECLARE_METATYPE for UserInfo pointers


___

## **CodeAnt-AI Description**
**Keep the password store directory available when opening the users dialog**

### What Changed
- The users dialog now keeps a stable copy of the password store directory when it opens and saves changes
- Removed an obsolete type registration that was no longer needed

### Impact
`✅ Fewer user setup issues`
`✅ More reliable users dialog saves`
`✅ Cleaner Qt 6 dialog startup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal parameter handling for improved performance.
  * Removed legacy compatibility code for older framework versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->