### PR TITLE
test: add filecontent edge case tests

### DIFF
--- a/tests/auto/filecontent/tst_filecontent.cpp
+++ b/tests/auto/filecontent/tst_filecontent.cpp
@@ -19,6 +19,9 @@ private Q_SLOTS:
   void parseEmptyContent();
   void parsePasswordOnly();
   void parseMultipleNamedFields();
+  void parseOtpauthHiddenLine();
+  void parseColonInValue();
+  void parseTemplateFieldsCaseSensitive();
 };
 
 void tst_filecontent::parsePlainPassword() {
@@ -44,11 +47,11 @@ void tst_filecontent::parseWithTemplateFields() {
   QVERIFY2(fc.getPassword() == "mypassword", "Password should be mypassword");
 
   NamedValues nv = fc.getNamedValues();
-  QCOMPARE(nv.size(), 2);
-  QCOMPARE(nv[0].name, QString("username"));
-  QCOMPARE(nv[0].value, QString("john@example.com"));
-  QCOMPARE(nv[1].name, QString("url"));
-  QCOMPARE(nv[1].value, QString("https://example.com"));
+  QVERIFY(nv.size() == 2);
+  QVERIFY(nv[0].name == "username");
+  QVERIFY(nv[0].value == "john@example.com");
+  QVERIFY(nv[1].name == "url");
+  QVERIFY(nv[1].value == "https://example.com");
 }
 
 void tst_filecontent::parseWithAllFields() {
@@ -60,7 +63,7 @@ void tst_filecontent::parseWithAllFields() {
   QVERIFY2(fc.getPassword() == "pass123", "Password should be pass123");
 
   NamedValues nv = fc.getNamedValues();
-  QCOMPARE(nv.size(), 3);
+  QVERIFY(nv.size() == 3);
 }
 
 void tst_filecontent::getRemainingData() {
@@ -108,16 +111,52 @@ void tst_filecontent::parseEmptyContent() {
 
 void tst_filecontent::parsePasswordOnly() {
   FileContent fc = FileContent::parse("single_line", QStringList(), false);
-  QCOMPARE(fc.getPassword(), QString("single_line"));
+  QVERIFY(fc.getPassword() == "single_line");
 }
 
 void tst_filecontent::parseMultipleNamedFields() {
   QString content = "pass\nuser: u1\nuser: u2\nuser: u3";
   QStringList templateFields = {"user"};
   FileContent fc = FileContent::parse(content, templateFields, false);
-  QCOMPARE(fc.getPassword(), QString("pass"));
+  QVERIFY(fc.getPassword() == "pass");
   NamedValues nv = fc.getNamedValues();
   QVERIFY(nv.size() >= 1);
+}
+
+void tst_filecontent::parseOtpauthHiddenLine() {
+  QString content = "secret\notpauth://totp/Example:alice@email?secret=key";
+  FileContent fc = FileContent::parse(content, QStringList(), false);
+  QString expected = "otpauth://totp/Example:alice@email?secret=key";
+  QVERIFY2(fc.getRemainingData() == expected,
+           "otpauth line should be preserved in remaining data");
+  QVERIFY(fc.getRemainingDataForDisplay().isEmpty());
+}
+
+void tst_filecontent::parseColonInValue() {
+  QString content = "pass\nurl: https://example.com:8080/path";
+  QStringList templateFields = {"url"};
+  FileContent fc = FileContent::parse(content, templateFields, false);
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY(nv.size() == 1);
+  QString urlValue;
+  for (const auto &entry : nv) {
+    if (entry.name == "url") {
+      urlValue = entry.value;
+      break;
+    }
+  }
+  QVERIFY2(urlValue == "https://example.com:8080/path",
+           "url value should match full URL with port");
+}
+
+void tst_filecontent::parseTemplateFieldsCaseSensitive() {
+  QString content = "pass\nUser: value";
+  QStringList templateFields = {"user"};
+  FileContent fc = FileContent::parse(content, templateFields, false);
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY(nv.isEmpty());
+  QVERIFY2(fc.getRemainingData().contains("User: value"),
+           "unmatched case should be in remaining data");
 }
 
 QTEST_MAIN(tst_filecontent)


### PR DESCRIPTION
## **User description**
## Summary

Add 3 more tests for filecontent.cpp:

- `parseOtpauthHiddenLine` - verifies otpauth:// lines are hidden from display
- `parseColonInValue` - tests colon in URL values
- `parseTemplateFieldsCaseSensitive` - tests case sensitivity of template fields


___

## **CodeAnt-AI Description**
**Add filecontent tests for hidden OTP lines, URL values with colons, and case-sensitive template fields**

### What Changed
- Adds coverage to keep `otpauth://` lines out of displayed content while still preserving them in the remaining data
- Verifies that values containing a colon, such as URLs with ports, are still captured as named fields
- Confirms template field matching stays case-sensitive, so `User` does not match `user`

### Impact
`✅ Fewer leaked secret URLs in display`
`✅ Correct parsing of URL values with ports`
`✅ Consistent template field matching`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering parsing behavior: hiding otpauth-style lines from display, capturing values that include colons (e.g., URLs with ports), and enforcing case-sensitive template field matching.
  * Switched several assertions to direct boolean/equality checks for stricter validation.

Note: Test-only changes; no user-facing behavior altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->