### PR TITLE
test: strengthen test assertions per review

### DIFF
--- a/tests/auto/filecontent/tst_filecontent.cpp
+++ b/tests/auto/filecontent/tst_filecontent.cpp
@@ -19,6 +19,7 @@ private Q_SLOTS:
   void parseEmptyContent();
   void parsePasswordOnly();
   void parseMultipleNamedFields();
+  void parseMatchingTemplateFields();
   void parseOtpauthHiddenLine();
   void parseColonInValue();
   void parseTemplateFieldsCaseSensitive();
@@ -64,6 +65,12 @@ void tst_filecontent::parseWithAllFields() {
 
   NamedValues nv = fc.getNamedValues();
   QVERIFY(nv.size() == 3);
+  QVERIFY(nv[0].name == "username");
+  QVERIFY(nv[0].value == "admin");
+  QVERIFY(nv[1].name == "notes");
+  QVERIFY(nv[1].value == "some notes");
+  QVERIFY(nv[2].name == "custom");
+  QVERIFY(nv[2].value == "value");
 }
 
 void tst_filecontent::getRemainingData() {
@@ -120,7 +127,13 @@ void tst_filecontent::parseMultipleNamedFields() {
   FileContent fc = FileContent::parse(content, templateFields, false);
   QVERIFY(fc.getPassword() == "pass");
   NamedValues nv = fc.getNamedValues();
-  QVERIFY(nv.size() >= 1);
+  QVERIFY2(nv.size() == 3, "Expected exactly three parsed user fields");
+  QVERIFY2(nv[0].name == "user" && nv[0].value == "u1",
+           "First user field should be parsed as user: u1");
+  QVERIFY2(nv[1].name == "user" && nv[1].value == "u2",
+           "Second user field should be parsed as user: u2");
+  QVERIFY2(nv[2].name == "user" && nv[2].value == "u3",
+           "Third user field should be parsed as user: u3");
 }
 
 void tst_filecontent::parseOtpauthHiddenLine() {
@@ -132,19 +145,26 @@ void tst_filecontent::parseOtpauthHiddenLine() {
   QVERIFY(fc.getRemainingDataForDisplay().isEmpty());
 }
 
+void tst_filecontent::parseMatchingTemplateFields() {
+  QString content = "secret123\nusername: john\npassword: doe";
+  QStringList templateFields = {"username", "password"};
+  FileContent fc = FileContent::parse(content, templateFields, false);
+  QVERIFY2(fc.getPassword() == "secret123", "Password should be secret123");
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY(nv.size() == 2);
+  QVERIFY(nv[0].name == "username");
+  QVERIFY(nv[0].value == "john");
+  QVERIFY(nv[1].name == "password");
+  QVERIFY(nv[1].value == "doe");
+}
+
 void tst_filecontent::parseColonInValue() {
   QString content = "pass\nurl: https://example.com:8080/path";
   QStringList templateFields = {"url"};
   FileContent fc = FileContent::parse(content, templateFields, false);
   NamedValues nv = fc.getNamedValues();
   QVERIFY(nv.size() == 1);
-  QString urlValue;
-  for (const auto &entry : nv) {
-    if (entry.name == "url") {
-      urlValue = entry.value;
-      break;
-    }
-  }
+  QString urlValue = nv.takeValue("url");
   QVERIFY2(urlValue == "https://example.com:8080/path",
            "url value should match full URL with port");
 }

--- a/tests/auto/gpgkeystate/tst_gpgkeystate.cpp
+++ b/tests/auto/gpgkeystate/tst_gpgkeystate.cpp
@@ -238,20 +238,31 @@ void tst_gpgkeystate::handlePubSecEmptyFields() {
 }
 
 void tst_gpgkeystate::handlePubSecShortList() {
-  UserInfo user;
   QStringList shortProps;
   shortProps.append("pub");
   shortProps.append("");
   shortProps.append("4096");
   shortProps.append("1");
   shortProps.append(""); // 5: created
-  handlePubSecRecord(shortProps, true, user);
-  QVERIFY2(user.key_id.isEmpty(), "Short list should be ignored");
-  QVERIFY2(user.name.isEmpty(), "Short list ignored: name empty");
-  QVERIFY2(user.validity == '-', "Short list ignored: default validity");
-  QVERIFY2(!user.created.isValid(), "Short list ignored: created invalid");
-  QVERIFY2(!user.expiry.isValid(), "Short list ignored: expiry invalid");
-  QVERIFY2(!user.have_secret, "Short list ignored: no secret");
+
+  auto verifyShortListIgnored = [](const UserInfo &u, const char *ctx) {
+    QVERIFY2(u.key_id.isEmpty(), "Short list should be ignored");
+    QVERIFY2(u.name.isEmpty(), "Short list ignored: name empty");
+    QVERIFY2(u.validity == '-', "Short list ignored: default validity");
+    QVERIFY2(!u.created.isValid(), "Short list ignored: created invalid");
+    QVERIFY2(!u.expiry.isValid(), "Short list ignored: expiry invalid");
+    QVERIFY2(!u.have_secret, ctx);
+  };
+
+  UserInfo publicUser;
+  handlePubSecRecord(shortProps, false, publicUser);
+  verifyShortListIgnored(publicUser,
+                         "Short list ignored: no secret for public");
+
+  UserInfo secretUser;
+  handlePubSecRecord(shortProps, true, secretUser);
+  verifyShortListIgnored(secretUser,
+                         "Short list ignored: no secret for secret input");
 }
 
 void tst_gpgkeystate::handleFprEdgeCases() {
@@ -261,7 +272,6 @@ void tst_gpgkeystate::handleFprEdgeCases() {
   QStringList emptyProps;
   for (int i = 0; i < 10; ++i)
     emptyProps.append("");
-  emptyProps[9] = "";
   handleFprRecord(emptyProps, user);
   QVERIFY2(user.key_id == "id123", "Empty fpr should not change key_id");
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -725,15 +725,17 @@ void tst_util::userInfoCreatedAndExpiry() {
   ui.name = "Test User";
   ui.key_id = "ABCDEF12";
 
-  QVERIFY(ui.created.toSecsSinceEpoch() == 0);
-  QVERIFY(ui.expiry.toSecsSinceEpoch() == 0);
+  QVERIFY(!ui.created.isValid());
+  QVERIFY(!ui.expiry.isValid());
 
   QDateTime future = QDateTime::currentDateTime().addYears(1);
   ui.expiry = future;
+  QVERIFY(ui.expiry.isValid());
   QVERIFY(ui.expiry.toSecsSinceEpoch() > 0);
 
   QDateTime past = QDateTime::currentDateTime().addYears(-1);
   ui.created = past;
+  QVERIFY(ui.created.isValid());
   QVERIFY(ui.created.toSecsSinceEpoch() > 0);
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Strengthen test assertions based on code review findings:

### filecontent/tst_filecontent.cpp
- Add `parseMatchingTemplateFields` test for matching template fields
- Add exact value assertions for `parseWithAllFields` (check names and values)
- Add exact assertions for `parseMultipleNamedFields` (exact count + values)
- Use `nv.takeValue("url")` instead of manual iteration

### gpgkeystate/tst_gpgkeystate.cpp
- Add test cases for both `secret=true` and `secret=false` short list handling
- Remove redundant `emptyProps[9] = ""` assignment

### util/tst_util.cpp
- Replace `toSecsSinceEpoch() == 0` with `isValid()` for QDateTime checks

All 288 tests pass.


___

## **CodeAnt-AI Description**
**Strengthen test coverage for parsing and key-state handling**

### What Changed
- Added coverage for parsing fields that match the expected template, including exact checks for field names and values.
- Tightened existing parsing tests to verify all parsed entries exactly, including URLs that contain a colon.
- Expanded short-list key-state tests to cover both secret and public input paths, confirming they are ignored consistently.
- Updated date checks to confirm unset dates are treated as invalid, and valid dates are recognized as such.

### Impact
`✅ Fewer parsing regressions`
`✅ Safer key-state handling`
`✅ Clearer date validation checks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added a test for parsing template-style fields and extracting named values in order.
  - Tightened parsing tests to require exact counts and specific ordered values for multiple named fields.
  - Consolidated GPG key state tests to validate short-list handling across secret and non-secret cases.
  - Strengthened datetime tests to explicitly check validity before timestamp assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->