### PR TITLE
test: address review findings for util tests

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -253,6 +253,18 @@ auto Util::endsWithGpg() -> const QRegularExpression & {
   return expr;
 }
 
+/**
+ * @brief Returns a regex matching common remote/network protocol schemes.
+ *
+ * Matches http://, https://, ftp://, ftps://, ssh://, sftp://, webdav://,
+ * webdavs://
+ *
+ * Note: Local file URLs (file:///) are intentionally excluded by design, as
+ * they represent local paths rather than network protocols. If this behavior
+ * needs to change, update both this function and the corresponding test.
+ *
+ * @return QRegularExpression reference
+ */
 auto Util::protocolRegex() -> const QRegularExpression & {
   static const QRegularExpression regex{
       "((?:https?|ftp|ssh|sftp|ftps|webdav|webdavs)://[^\" <>\\)\\]\\[]+)"};

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1080,10 +1080,9 @@ void tst_util::findBinaryInPathTempExecutableInTempDir() {
   // Place a real executable in the same directory as "sh" (which is on the
   // cached PATH) and verify findBinaryInPath locates it.
   //
-  // This test is skipped in restricted environments where we cannot write
-  // to the "sh" directory. Finding 4 suggests an alternative approach
-  // (QTemporaryDir + PATH manipulation) but that doesn't work because
-  // Util::_env is cached at first use.
+  // This test is skipped in restricted environments where writing to the "sh"
+  // directory is not allowed. An alternative approach (QTemporaryDir + PATH
+  // manipulation) doesn't work because Util::_env is cached on first use.
 #ifndef Q_OS_WIN
   QString shPath = Util::findBinaryInPath(QStringLiteral("sh"));
   if (shPath.isEmpty()) {

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -5,7 +5,9 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QList>
+#include <QProcessEnvironment>
 #include <QTemporaryDir>
+#include <QUuid>
 #include <QtTest>
 
 #include "../../../src/enums.h"
@@ -368,9 +370,12 @@ void tst_util::regexPatternEdgeCases() {
 
   const QRegularExpression &proto = Util::protocolRegex();
   QVERIFY(proto.match("webdavs://secure.example.com").hasMatch());
+  QVERIFY(proto.match("webdavs://secure.example.com").hasMatch());
+  QVERIFY(proto.match("ftps://ftp.server.org").hasMatch());
   QVERIFY(proto.match("ftps://ftp.server.org").hasMatch());
   QVERIFY(proto.match("sftp://user:pass@host").hasMatch());
-  // See Util::protocolRegex() - file:// URLs intentionally not matched
+  QVERIFY(proto.match("sftp://user:pass@host").hasMatch());
+  // file:/// URLs are not matched - see Util::protocolRegex()
   QVERIFY(!proto.match("file:///path/to/file").hasMatch());
 
   const QRegularExpression &nl = Util::newLinesRegex();
@@ -1075,20 +1080,21 @@ void tst_util::findBinaryInPathResultContainsBinaryName() {
 }
 
 void tst_util::findBinaryInPathTempExecutableInTempDir() {
-  // Place a real executable in an existing PATH directory and confirm that
-  // findBinaryInPath locates it.
+  // Place a real executable in the same directory as "sh" (which is on the
+  // cached PATH) and verify findBinaryInPath locates it.
   //
-  // Because Util::_env is a static cached copy we cannot inject a new PATH
-  // directory at runtime. Instead we write a uniquely named executable into
-  // the same directory as "sh" (which is already on the cached PATH) and
-  // verify the function finds it.
+  // This test is skipped in restricted environments where we cannot write
+  // to the "sh" directory. Finding 4 suggests an alternative approach
+  // (QTemporaryDir + PATH manipulation) but that doesn't work because
+  // Util::_env is cached at first use.
 #ifndef Q_OS_WIN
   QString shPath = Util::findBinaryInPath(QStringLiteral("sh"));
   if (shPath.isEmpty()) {
     QSKIP("Cannot find 'sh' to determine a writable PATH directory");
   }
   const QString pathDir = QFileInfo(shPath).absolutePath();
-  const QString uniqueName = QStringLiteral("qtpass_test_exec_unique_99");
+  const QString uniqueName = QStringLiteral("qtpass_test_exec_") +
+                             QUuid::createUuid().toString(QUuid::WithoutBraces);
   const QString uniquePath = pathDir + QDir::separator() + uniqueName;
 
   QFile exec(uniquePath);

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -370,10 +370,7 @@ void tst_util::regexPatternEdgeCases() {
 
   const QRegularExpression &proto = Util::protocolRegex();
   QVERIFY(proto.match("webdavs://secure.example.com").hasMatch());
-  QVERIFY(proto.match("webdavs://secure.example.com").hasMatch());
   QVERIFY(proto.match("ftps://ftp.server.org").hasMatch());
-  QVERIFY(proto.match("ftps://ftp.server.org").hasMatch());
-  QVERIFY(proto.match("sftp://user:pass@host").hasMatch());
   QVERIFY(proto.match("sftp://user:pass@host").hasMatch());
   // file:/// URLs are not matched - see Util::protocolRegex()
   QVERIFY(!proto.match("file:///path/to/file").hasMatch());

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -370,10 +370,7 @@ void tst_util::regexPatternEdgeCases() {
   QVERIFY(proto.match("webdavs://secure.example.com").hasMatch());
   QVERIFY(proto.match("ftps://ftp.server.org").hasMatch());
   QVERIFY(proto.match("sftp://user:pass@host").hasMatch());
-  // Note: protocolRegex() is intentionally scoped to remote/network endpoints
-  // used by URL handling. Local file URLs (file:///) are excluded by design
-  // because they represent local paths, not network protocols. If this behavior
-  // needs to change, update Util::protocolRegex() and this test together.
+  // See Util::protocolRegex() - file:// URLs intentionally not matched
   QVERIFY(!proto.match("file:///path/to/file").hasMatch());
 
   const QRegularExpression &nl = Util::newLinesRegex();


### PR DESCRIPTION
## Summary

- Add source documentation to `Util::protocolRegex()` explaining why file:// URLs are excluded
- Simplify test comment to reference source documentation
- Use QUuid for unique executable names in temp test (avoids conflicts)
- Add comment explaining PATH caching limitation in Util::_env

## Changes

- Finding 1: Short comment referencing source replaces verbose test comment
- Finding 2: Uses QUuid for unique names + skips gracefully in restricted env
- Finding 3: Already addressed in PR (QUuid was added here)
- Finding 4: Explained why alternative approach doesn't work (PATH is cached)

All 60 util tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified supported remote/network URI schemes (http, https, ftp, ftps, ssh, sftp, webdav, webdavs) and explicitly noted exclusions such as file:///.

* **Tests**
  * Updated test dependencies and comments, tightened protocol-matching assertions, made temporary test filenames unique to avoid collisions, and clarified behavior/skips in restricted environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->