### PR TITLE
docs: fix release workflow per CodeAnt review

### DIFF
--- a/.opencode/skills/qtpass-releasing/SKILL.md
+++ b/.opencode/skills/qtpass-releasing/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 Update version in all build files:
 
-- `qtpass.pri` - `VERSION = "x.y.z"` (note: .pri not .pro)
+- `qtpass.pri` - `VERSION = 1.6.0` (note: .pri not .pro, unquoted number)
 - `qtpass.spec` - `Version:`
 - `qtpass.iss` - `AppVerName=`
 - `Doxyfile` - `PROJECT_NUMBER`
@@ -30,8 +30,8 @@ Update version in all build files:
 **NOTE:** `qtpass.appdata.xml` and `appdmg.json` don't have version fields to update.
 
 ```bash
-# Find version strings
-grep -rn "1\.5" qtpass.pri qtpass.spec qtpass.iss Doxyfile
+# Find version strings (replace X.Y with actual version)
+grep -rn "X\.Y" qtpass.pri qtpass.spec qtpass.iss Doxyfile
 ```
 
 ### 2. Changelog
@@ -104,7 +104,7 @@ git checkout gh-pages
 # Update changelog.1.4.html, old.html (version only)
 
 git add -A
-git commit -m "Release v1.6.0"
+git commit -m "Release vX.Y.Z"
 git push origin gh-pages
 ```
 
@@ -145,13 +145,25 @@ act push -W .github/workflows/linter.yml -j build
 
 ## Protected Main Branch
 
-`main` is protected - cannot push directly. Must create PR:
+`main` is protected - cannot push directly. Must create PR from a release branch:
 
 ```bash
+# Create release branch
+git checkout -b release/vX.Y.Z
+
 # Make changes, commit
-git push origin main
-# Error: protected branch - create PR instead
-gh pr create --base main --head main --title "Release v1.6.0"
+git add -A
+git commit -m "Release vX.Y.Z"
+
+# Push branch
+git push origin release/vX.Y.Z
+
+# Update with latest main before PR
+git fetch upstream
+git rebase upstream/main
+
+# Create PR
+gh pr create --base main --head release/vX.Y.Z --title "Release vX.Y.Z"
 ```
 
 ## Script Best Practices


### PR DESCRIPTION
## **User description**
## Summary

- Fix VERSION format in qtpass.pri (unquoted number)
- Replace remaining hardcoded v1.6.0 with X.Y.Z placeholder
- Fix protected main branch workflow (create release branch first)
- Add rebase onto upstream/main before PR


___

## **CodeAnt-AI Description**
Update release instructions and version references for QtPass 1.6.0

### What Changed
- Release docs now point to the correct version files and version format, including `qtpass.pri` and `Doxyfile`
- The release checklist now includes the site pages that need version and download link updates on `gh-pages`
- The workflow now tells release authors to create a release branch, rebase on `upstream/main`, and open a PR instead of pushing to the protected `main` branch
- The version examples and release commands now use `vX.Y.Z` placeholders instead of hardcoded old versions

### Impact
`✅ Fewer release setup mistakes`
`✅ Clearer site update steps`
`✅ Safer releases on protected main`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to clarify version-bumping procedures and standardize release workflow instructions, including PR creation and branch management best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->