### PR TITLE
fix: export QTPASS_VERSION for Doxygen in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,10 @@ jobs:
         if: steps.need_docs.outputs.run_docs == 'true'
         run: |
           VERSION=$(grep -E '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Failed to extract VERSION from qtpass.pri" >&2
+            exit 1
+          fi
           echo "QTPASS_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Extracted version: $VERSION"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Extract version
         if: steps.need_docs.outputs.run_docs == 'true'
         run: |
-          VERSION=$(grep '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
-          echo "QTPASS_VERSION=$VERSION" >> $GITHUB_ENV
+          VERSION=$(grep -E '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
+          echo "QTPASS_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Extracted version: $VERSION"
 
       - name: Generate documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,6 +72,13 @@ jobs:
         if: steps.need_docs.outputs.run_docs == 'true'
         run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
 
+      - name: Extract version
+        if: steps.need_docs.outputs.run_docs == 'true'
+        run: |
+          VERSION=$(grep '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
+          echo "QTPASS_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Extracted version: $VERSION"
+
       - name: Generate documentation
         if: steps.need_docs.outputs.run_docs == 'true'
         run: doxygen

--- a/.opencode/skills/qtpass-releasing/SKILL.md
+++ b/.opencode/skills/qtpass-releasing/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 Update version in all build files:
 
-- `qtpass.pri` - `VERSION = 1.6.0` (note: .pri not .pro, unquoted number)
+- `qtpass.pri` - `VERSION = X.Y.Z` (note: .pri not .pro, unquoted number)
 - `qtpass.spec` - `Version:`
 - `qtpass.iss` - `AppVerName=`
 - `Doxyfile` - `PROJECT_NUMBER`

--- a/.opencode/skills/qtpass-releasing/SKILL.md
+++ b/.opencode/skills/qtpass-releasing/SKILL.md
@@ -155,12 +155,12 @@ git checkout -b release/vX.Y.Z
 git add -A
 git commit -m "Release vX.Y.Z"
 
-# Push branch
-git push origin release/vX.Y.Z
-
-# Update with latest main before PR
+# Update with latest main before pushing
 git fetch upstream
 git rebase upstream/main
+
+# Push branch (force-with-lease since we rebased)
+git push origin release/vX.Y.Z --force-with-lease
 
 # Create PR
 gh pr create --base main --head release/vX.Y.Z --title "Release vX.Y.Z"

--- a/.opencode/skills/qtpass-releasing/SKILL.md
+++ b/.opencode/skills/qtpass-releasing/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 Update version in all build files:
 
-- `qtpass.pri` - `VERSION = "x.y.z"` (note: .pri not .pro)
+- `qtpass.pri` - `VERSION = 1.6.0` (note: .pri not .pro, unquoted number)
 - `qtpass.spec` - `Version:`
 - `qtpass.iss` - `AppVerName=`
 - `Doxyfile` - `PROJECT_NUMBER`
@@ -30,8 +30,8 @@ Update version in all build files:
 **NOTE:** `qtpass.appdata.xml` and `appdmg.json` don't have version fields to update.
 
 ```bash
-# Find version strings
-grep -rn "1\.5" qtpass.pri qtpass.spec qtpass.iss Doxyfile
+# Find version strings (replace X.Y with actual version)
+grep -rn "X\.Y" qtpass.pri qtpass.spec qtpass.iss Doxyfile
 ```
 
 ### 2. Changelog
@@ -104,7 +104,7 @@ git checkout gh-pages
 # Update changelog.1.4.html, old.html (version only)
 
 git add -A
-git commit -m "Release v1.6.0"
+git commit -m "Release vX.Y.Z"
 git push origin gh-pages
 ```
 
@@ -145,13 +145,25 @@ act push -W .github/workflows/linter.yml -j build
 
 ## Protected Main Branch
 
-`main` is protected - cannot push directly. Must create PR:
+`main` is protected - cannot push directly. Must create PR from a release branch:
 
 ```bash
+# Create release branch
+git checkout -b release/vX.Y.Z
+
 # Make changes, commit
-git push origin main
-# Error: protected branch - create PR instead
-gh pr create --base main --head main --title "Release v1.6.0"
+git add -A
+git commit -m "Release vX.Y.Z"
+
+# Push branch
+git push origin release/vX.Y.Z
+
+# Update with latest main before PR
+git fetch upstream
+git rebase upstream/main
+
+# Create PR
+gh pr create --base main --head release/vX.Y.Z --title "Release vX.Y.Z"
 ```
 
 ## Script Best Practices

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = QtPass
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.6.0
+PROJECT_NUMBER         = $ENV{QTPASS_VERSION}
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a

--- a/Doxyfile
+++ b/Doxyfile
@@ -1926,7 +1926,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # - in case of MathJax version 4: https://cdn.jsdelivr.net/npm/mathjax@4
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -39,7 +39,11 @@ pandoc --standalone --from=gfm --to=rtf --output=README.rtf "$README_CLEAN" FAQ.
 
 echo "Extracting version..."
 VERSION=$(grep '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
-export QTPASS_VERSION
+if [ -z "$VERSION" ]; then
+	echo "Error: Failed to extract VERSION from qtpass.pri" >&2
+	exit 1
+fi
+export QTPASS_VERSION="$VERSION"
 echo "Generating API documentation (v$VERSION)..."
 doxygen || {
 	echo "Error: doxygen failed." >&2

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -37,7 +37,10 @@ pandoc --standalone --from=gfm --to=rtf --output=README.rtf "$README_CLEAN" FAQ.
 	exit 1
 }
 
-echo "Generating API documentation..."
+echo "Extracting version..."
+VERSION=$(grep '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
+export QTPASS_VERSION
+echo "Generating API documentation (v$VERSION)..."
 doxygen || {
 	echo "Error: doxygen failed." >&2
 	exit 1

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -38,8 +38,10 @@ pandoc --standalone --from=gfm --to=rtf --output=README.rtf "$README_CLEAN" FAQ.
 }
 
 echo "Extracting version..."
-VERSION=$(grep '^VERSION *=' qtpass.pri | cut -d'=' -f2 | tr -d ' ')
-if [ -z "$VERSION" ]; then
+require_readable_file "qtpass.pri"
+echo "Extracting version..."
+VERSION=$(awk -F= '/^[[:space:]]*VERSION[[:space:]]*=/ { gsub(/[[:space:]]/, "", $2); print $2; exit }' qtpass.pri)
+if [[ -z "${VERSION:-}" ]]; then
 	echo "Error: Failed to extract VERSION from qtpass.pri" >&2
 	exit 1
 fi


### PR DESCRIPTION
## **User description**
## Summary

- Doxyfile: use $ENV{QTPASS_VERSION} instead of hardcoded version
- docs.yml: extract version from qtpass.pri and export to environment


___

## **CodeAnt-AI Description**
**Use the release version in generated docs**

### What Changed
- Documentation generation now reads the app version from `qtpass.pri` instead of showing a hardcoded number
- The docs workflow exports that version before running Doxygen, so published docs match the current release
- Release notes now reflect the unquoted version format and updated branch flow for release PRs

### Impact
`✅ Correct version shown in docs`
`✅ Fewer stale release numbers`
`✅ Clearer release workflow`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now extracts, validates, exports and logs the project version for docs builds (job fails if missing).
  * Release scripts extract and export the version, include it in status output, and abort on missing version.
  * Documentation generator switched to an environment-driven project version and updated the MathJax CDN.

* **Documentation**
  * Release guide updated to use generic version placeholders and a dedicated release branch/PR workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->