### PR TITLE
perf: use static regex instances and test cleanup

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -151,10 +151,8 @@ auto Util::findBinaryInPath(QString binary) -> QString {
   }
 #ifdef Q_OS_WIN
   if (ret.isEmpty()) {
-    // Validate binary name before attempting WSL fallback: require a non-empty,
-    // whitespace-free program name to avoid confusing WSL invocations.
-    const bool hasWhitespace =
-        binary.contains(QRegularExpression(QStringLiteral("\\s")));
+    static const QRegularExpression whitespaceRegex(QStringLiteral("\\s"));
+    const bool hasWhitespace = binary.contains(whitespaceRegex);
     if (!binary.isEmpty() && !hasWhitespace) {
       QString wslCommand = QStringLiteral("wsl ") + binary;
 #ifdef QT_DEBUG
@@ -277,6 +275,10 @@ auto Util::newLinesRegex() -> const QRegularExpression & {
 }
 
 auto Util::isValidKeyId(const QString &keyId) -> bool {
+  static const QRegularExpression hexPrefixRegex{"^0[xX]"};
+  static const QRegularExpression specialPrefixRegex{"^[@/#&]"};
+  static const QRegularExpression hexKeyIdRegex{"^[0-9A-Fa-f]{8,40}$"};
+
   if (keyId.isEmpty()) {
     return false;
   }
@@ -285,12 +287,12 @@ auto Util::isValidKeyId(const QString &keyId) -> bool {
   if (normalized.startsWith('<') && normalized.endsWith('>')) {
     normalized = normalized.mid(1, normalized.length() - 2);
   }
-  normalized.remove(QRegularExpression("^0[xX]"));
+  normalized.remove(hexPrefixRegex);
 
-  if (QRegularExpression("^[@/#&]").match(normalized).hasMatch() ||
+  if (specialPrefixRegex.match(normalized).hasMatch() ||
       normalized.contains('@')) {
     return true;
   }
 
-  return QRegularExpression("^[0-9A-Fa-f]{8,40}$").match(normalized).hasMatch();
+  return hexKeyIdRegex.match(normalized).hasMatch();
 }

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -873,6 +873,7 @@ void tst_util::getRecipientListBasic() {
   file.write("ABCDEF12\n34567890\n");
   file.close();
 
+  PassStoreGuard guard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(passStore);
   QStringList recipients = Pass::getRecipientList(passStore);
   QCOMPARE(recipients.size(), 2);
@@ -1006,6 +1007,7 @@ void tst_util::getGpgIdPathBasic() {
   file.write("ABCDEF12\n");
   file.close();
 
+  PassStoreGuard guard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(passStore);
   QString path = QDir::cleanPath(Pass::getGpgIdPath(passStore));
   QString expected = QDir::cleanPath(gpgIdFile);
@@ -1025,6 +1027,7 @@ void tst_util::getGpgIdPathSubfolder() {
   file.write("ABCDEF12\n");
   file.close();
 
+  PassStoreGuard guard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(passStore);
   QString path = Pass::getGpgIdPath(subfolder + "/password.gpg");
   QVERIFY2(path == gpgIdFile,
@@ -1035,6 +1038,7 @@ void tst_util::getGpgIdPathNotFound() {
   QTemporaryDir tempDir;
   QString passStore = tempDir.path();
 
+  PassStoreGuard guard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(passStore);
   QString path =
       QDir::cleanPath(Pass::getGpgIdPath(passStore + "/nonexistent"));


### PR DESCRIPTION
## **User description**
## Summary
- Use static const QRegularExpression instances in `isValidKeyId` and `findBinaryInPath` to avoid creating objects on each call
- Add PassStoreGuard to tests that modify QtPassSettings::setPassStore for proper cleanup

## Changes
- src/util.cpp: Add static regexes for hexPrefixRegex, specialPrefixRegex, hexKeyIdRegex, whitespaceRegex
- tests/auto/util/tst_util.cpp: Add PassStoreGuard to getRecipientListBasic, getGpgIdPathBasic, getGpgIdPathSubfolder, getGpgIdPathNotFound


___

## **CodeAnt-AI Description**
**Speed up key ID checks and keep test settings isolated**

### What Changed
- Key ID validation now reuses the same pattern checks instead of recreating them on each call
- Windows binary lookup now reuses the same whitespace check before trying the WSL fallback
- Tests that change the pass store now clean up after themselves so later tests keep the right settings

### Impact
`✅ Faster key ID validation`
`✅ Lower overhead during binary lookup`
`✅ Fewer test setting leaks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
