### PR TITLE
test: add charset validation and configIsValid edge cases

### DIFF
--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -529,15 +529,32 @@ void tst_util::generateRandomPassword() {
   QString result = pass.generatePassword(10, charset);
 
   QCOMPARE(result.length(), 10);
+  for (const QChar &ch : result) {
+    QVERIFY2(
+        charset.contains(ch),
+        "Generated password contains character outside the specified charset");
+  }
 
   result = pass.generatePassword(100, "abcd");
+  QString charset2 = "abcd";
   QCOMPARE(result.length(), 100);
+  for (const QChar &ch : result) {
+    QVERIFY2(
+        charset2.contains(ch),
+        "Generated password contains character outside the specified charset");
+  }
 
   result = pass.generatePassword(0, "");
   QVERIFY(result.isEmpty());
 
   result = pass.generatePassword(50, "ABC");
+  QString charset3 = "ABC";
   QCOMPARE(result.length(), 50);
+  for (const QChar &ch : result) {
+    QVERIFY2(
+        charset3.contains(ch),
+        "Generated password contains character outside the specified charset");
+  }
 }
 
 void tst_util::boundedRandom() {
@@ -586,9 +603,31 @@ void tst_util::configIsValid() {
 
   // No .gpg-id in this store => config must be invalid.
   QtPassSettings::setPassStore(tempDir.path());
-  const bool isValid = Util::configIsValid();
-
+  bool isValid = Util::configIsValid();
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id is missing");
+
+  // Create .gpg-id, then force invalid executable configuration.
+  QFile gpgIdFile(tempDir.path() + QDir::separator() +
+                  QStringLiteral(".gpg-id"));
+  QVERIFY2(gpgIdFile.open(QIODevice::WriteOnly | QIODevice::Truncate),
+           "Should be able to create .gpg-id");
+  gpgIdFile.write("test@example.com\n");
+  gpgIdFile.close();
+
+  const QString originalGitExecutable = QtPassSettings::getGitExecutable();
+  const QString originalGpgExecutable = QtPassSettings::getGpgExecutable();
+  QtPassSettings::setGitExecutable(QString());
+  isValid = Util::configIsValid();
+  QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but git "
+                     "executable is missing");
+  QtPassSettings::setGitExecutable(originalGitExecutable);
+  QtPassSettings::setGpgExecutable(
+      QStringLiteral("definitely_nonexistent_gpg_binary_12345"));
+  isValid = Util::configIsValid();
+  QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
+                     "executable is invalid");
+  QtPassSettings::setGitExecutable(originalGitExecutable);
+  QtPassSettings::setGpgExecutable(originalGpgExecutable);
 }
 
 void tst_util::getDirBasic() {

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -614,20 +614,22 @@ void tst_util::configIsValid() {
   gpgIdFile.write("test@example.com\n");
   gpgIdFile.close();
 
-  const QString originalGitExecutable = QtPassSettings::getGitExecutable();
-  const QString originalGpgExecutable = QtPassSettings::getGpgExecutable();
-  QtPassSettings::setGitExecutable(QString());
+  QString originalGpgExecutable = QtPassSettings::getGpgExecutable();
+  struct GpgRollback {
+    QString value;
+    ~GpgRollback() { QtPassSettings::setGpgExecutable(value); }
+  } gpgRollback{originalGpgExecutable};
+
+  QtPassSettings::setGpgExecutable(QString());
   isValid = Util::configIsValid();
-  QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but git "
+  QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is missing");
-  QtPassSettings::setGitExecutable(originalGitExecutable);
+
   QtPassSettings::setGpgExecutable(
       QStringLiteral("definitely_nonexistent_gpg_binary_12345"));
   isValid = Util::configIsValid();
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is invalid");
-  QtPassSettings::setGitExecutable(originalGitExecutable);
-  QtPassSettings::setGpgExecutable(originalGpgExecutable);
 }
 
 void tst_util::getDirBasic() {


### PR DESCRIPTION
## **User description**
## Summary
- Add charset validation in `generateRandomPassword` to verify generated passwords only contain characters from the specified charset
- Extend `configIsValid` test to verify invalid config when .gpg-id exists but git/gpg executable is missing or invalid

These changes address recommendations from code review.


___

## **CodeAnt-AI Description**
Verify password generation stays within the requested character set and config checks catch missing or invalid executables

### What Changed
- Password tests now confirm every generated character comes from the selected character set
- Config validation tests now cover cases where a store has a `.gpg-id` file but the required Git or GPG executable is missing or invalid

### Impact
`✅ Safer password checks`
`✅ Fewer broken config cases slipping through`
`✅ Clearer validation coverage for setup errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened password-generation tests by verifying each character comes from the expected charset across multiple scenarios.
  * Expanded configuration validation tests to cover missing and invalid GPG executable cases, and ensure original settings are restored after test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->