### PR TITLE
refactor: rename ambiguous variable names in util tests

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -81,11 +81,11 @@ public:
   static auto newLinesRegex() -> const QRegularExpression &;
   /**
    * @brief Check if a string looks like a valid GPG key ID.
-   * Validates a GPG key ID after normalization:
-   * - Strips optional 0x/0X prefix
-   * - Strips surrounding angle brackets <...>
-   * - Strips leading @, /, #, or & prefix
-   * - Validates remaining string is 8-40 hex characters (0-9, A-F, a-f)
+   * Accepts:
+   * - Key IDs: 8-40 hex characters (0-9, A-F, a-f), optional 0x prefix
+   * - Emails: any string containing @ (e.g., user@domain.org,
+   * <user@domain.org>)
+   * - Special prefixes: leading @, /, #, or & (any content after prefix)
    * @param keyId The string to validate.
    * @return true if the key ID format is valid, false otherwise.
    */

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -458,19 +458,20 @@ void tst_util::passwordConfigurationCharacters() {
 }
 
 void tst_util::simpleTransactionBasic() {
-  simpleTransaction trans;
-  trans.transactionAdd(Enums::PASS_INSERT);
-  Enums::PROCESS result = trans.transactionIsOver(Enums::PASS_INSERT);
+  simpleTransaction transaction;
+  transaction.transactionAdd(Enums::PASS_INSERT);
+  Enums::PROCESS result = transaction.transactionIsOver(Enums::PASS_INSERT);
   QCOMPARE(result, Enums::PASS_INSERT);
 }
 
 void tst_util::simpleTransactionNested() {
-  simpleTransaction trans;
-  trans.transactionAdd(Enums::PASS_INSERT);
-  trans.transactionAdd(Enums::GIT_PUSH);
-  Enums::PROCESS passInsertResult = trans.transactionIsOver(Enums::PASS_INSERT);
+  simpleTransaction transaction;
+  transaction.transactionAdd(Enums::PASS_INSERT);
+  transaction.transactionAdd(Enums::GIT_PUSH);
+  Enums::PROCESS passInsertResult =
+      transaction.transactionIsOver(Enums::PASS_INSERT);
   QCOMPARE(passInsertResult, Enums::PASS_INSERT);
-  Enums::PROCESS gitPushResult = trans.transactionIsOver(Enums::GIT_PUSH);
+  Enums::PROCESS gitPushResult = transaction.transactionIsOver(Enums::GIT_PUSH);
   QCOMPARE(gitPushResult, Enums::GIT_PUSH);
 }
 
@@ -596,19 +597,20 @@ void tst_util::getDirBasic() {
   QVERIFY2(tempDir.isValid(),
            "Temporary directory should be created successfully");
 
-  QFileSystemModel fsm;
-  fsm.setRootPath(tempDir.path());
-  StoreModel sm;
-  sm.setModelAndStore(&fsm, tempDir.path());
-  QVERIFY(sm.sourceModel() != nullptr);
-  QVERIFY2(sm.getStore() == tempDir.path(),
+  QFileSystemModel fileSystemModel;
+  fileSystemModel.setRootPath(tempDir.path());
+  StoreModel storeModel;
+  storeModel.setModelAndStore(&fileSystemModel, tempDir.path());
+  QVERIFY(storeModel.sourceModel() != nullptr);
+  QVERIFY2(storeModel.getStore() == tempDir.path(),
            "Store path should match the set value");
-  QModelIndex rootIndex = fsm.index(tempDir.path());
+  QModelIndex rootIndex = fileSystemModel.index(tempDir.path());
   QVERIFY2(rootIndex.isValid(), "Filesystem model root index should be valid");
   const QString originalStore = QtPassSettings::getPassStore();
   QtPassSettings::setPassStore(tempDir.path());
 
-  QString result = Util::getDir(QModelIndex(), false, fsm, sm);
+  QString result =
+      Util::getDir(QModelIndex(), false, fileSystemModel, storeModel);
   QString expectedDir = QDir(tempDir.path()).absolutePath();
   if (!expectedDir.endsWith(QDir::separator())) {
     expectedDir += QDir::separator();
@@ -641,21 +643,22 @@ void tst_util::getDirWithIndex() {
   PassStoreGuard passStoreGuard(originalPassStore);
   QtPassSettings::setPassStore(dirPath);
 
-  QFileSystemModel fsm;
-  fsm.setRootPath(dirPath);
+  QFileSystemModel fileSystemModel;
+  fileSystemModel.setRootPath(dirPath);
 
-  StoreModel sm;
-  sm.setModelAndStore(&fsm, dirPath);
-  QVERIFY2(sm.getStore() == dirPath, "Store path should match the set value");
+  StoreModel storeModel;
+  storeModel.setModelAndStore(&fileSystemModel, dirPath);
+  QVERIFY2(storeModel.getStore() == dirPath,
+           "Store path should match the set value");
 
-  QModelIndex sourceIndex = fsm.index(filePath);
+  QModelIndex sourceIndex = fileSystemModel.index(filePath);
   QVERIFY2(sourceIndex.isValid(),
            "Source index should be valid for the test file");
-  QModelIndex fileIndex = sm.mapFromSource(sourceIndex);
+  QModelIndex fileIndex = storeModel.mapFromSource(sourceIndex);
   QVERIFY2(fileIndex.isValid(),
            "Proxy index should be valid for the test file");
 
-  QString result = Util::getDir(fileIndex, false, fsm, sm);
+  QString result = Util::getDir(fileIndex, false, fileSystemModel, storeModel);
   QVERIFY2(!result.isEmpty(),
            "getDir should return a non-empty directory for a valid index");
   QVERIFY(result.endsWith(QDir::separator()));
@@ -670,7 +673,8 @@ void tst_util::getDirWithIndex() {
           QStringLiteral("Expected '%1', got '%2'").arg(expectedPath, result)));
 
   QModelIndex invalidIndex;
-  QString invalidResult = Util::getDir(invalidIndex, false, fsm, sm);
+  QString invalidResult =
+      Util::getDir(invalidIndex, false, fileSystemModel, storeModel);
   QString expectedForInvalid = dirPath;
   if (!expectedForInvalid.endsWith(QDir::separator())) {
     expectedForInvalid += QDir::separator();

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -920,8 +920,8 @@ void tst_util::getRecipientListInvalidKeyId() {
 
   QFile file(gpgIdFile);
   QVERIFY(file.open(QIODevice::WriteOnly));
-  file.write(
-      "ABCDEF12\ninvalid\n0xABCDEF123456789012\n<a@b>\nuser@domain.org\n");
+  file.write("ABCDEF12\ninvalid\n0xABCDEF123456789012\n<a@b>\nuser@qtpass@"
+             "example.org\n");
   file.close();
 
   const QString originalPassStore = QtPassSettings::getPassStore();
@@ -930,6 +930,8 @@ void tst_util::getRecipientListInvalidKeyId() {
   QStringList recipients = Pass::getRecipientList(passStore);
   QVERIFY(!recipients.contains("invalid"));
   QVERIFY(recipients.contains("ABCDEF12"));
+  QVERIFY(recipients.contains("0xABCDEF123456789012"));
+  QVERIFY(recipients.contains("user@qtpass@example.org"));
 }
 
 void tst_util::isValidKeyIdBasic() {
@@ -949,7 +951,7 @@ void tst_util::isValidKeyIdWith0xPrefix() {
 
 void tst_util::isValidKeyIdWithEmail() {
   QVERIFY(Util::isValidKeyId("<a@b>"));
-  QVERIFY(Util::isValidKeyId("user@domain.org"));
+  QVERIFY(Util::isValidKeyId("user@qtpass@example.org"));
   QVERIFY(Util::isValidKeyId("/any/text/here"));
   QVERIFY(Util::isValidKeyId("#anything"));
   QVERIFY(Util::isValidKeyId("&anything"));


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the documentation for the `Util::isGpgKeyIdValid` method in `src/util.h`. The previous comment was updated to accurately reflect the broader range of inputs the method accepts, which now explicitly includes email addresses and strings with special leading prefixes (e.g., `@`, `/`, `#`, `&`), in addition to GPG key IDs. This clarifies the method's validation criteria.
<!-- kody-pr-summary:end -->