### PR TITLE
fix: use correct doxygen download URL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.need_docs.outputs.run_docs == 'true'
         run: |
           # Install newer Doxygen from official release
-          curl -fsL https://doxygen.org/files/1.16.1/Doxygen-1.16.1.linux.x86_64.tar.gz -o doxygen.tar.gz
+          curl -fsL https://doxygen.nl/files/doxygen-1.16.1.linux.bin.tar.gz -o doxygen.tar.gz
           tar -xzf doxygen.tar.gz
           sudo cp -r doxygen-1.16.1/bin/* /usr/local/bin/
           sudo cp -r doxygen-1.16.1/lib/* /usr/local/lib/


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates the Doxygen download URL in the GitHub Actions workflow for building documentation. This change ensures that the workflow correctly fetches Doxygen version 1.16.1 from `doxygen.nl` instead of `doxygen.org`, resolving potential issues with the documentation build process.
<!-- kody-pr-summary:end -->