### PR TITLE
refactor: remove unnecessary charset variables in generateRandomPassword tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,6 @@ jobs:
           curl -fsL https://doxygen.org/files/1.16.1/Doxygen-1.16.1.linux.x86_64.tar.gz -o doxygen.tar.gz
           tar -xzf doxygen.tar.gz
           sudo cp -r doxygen-1.16.1/bin/* /usr/local/bin/
-          sudo cp -r doxygen-1.16.1/lib/* /usr/local/lib/
           rm -rf doxygen.tar.gz doxygen-1.16.1
           # Install graphviz via apt
           sudo apt-get update && sudo apt-get install -y graphviz

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -537,11 +537,10 @@ void tst_util::generateRandomPassword() {
   }
 
   result = pass.generatePassword(100, "abcd");
-  QString charset2 = "abcd";
   QCOMPARE(result.length(), 100);
   for (const QChar &ch : result) {
     QVERIFY2(
-        charset2.contains(ch),
+        QStringLiteral("abcd").contains(ch),
         "Generated password contains character outside the specified charset");
   }
 
@@ -549,11 +548,10 @@ void tst_util::generateRandomPassword() {
   QVERIFY(result.isEmpty());
 
   result = pass.generatePassword(50, "ABC");
-  QString charset3 = "ABC";
   QCOMPARE(result.length(), 50);
   for (const QChar &ch : result) {
     QVERIFY2(
-        charset3.contains(ch),
+        QStringLiteral("ABC").contains(ch),
         "Generated password contains character outside the specified charset");
   }
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removes the unnecessary step of copying Doxygen library files to `/usr/local/lib/` during the documentation build process in the GitHub Actions workflow.
<!-- kody-pr-summary:end -->