### PR TITLE
fix: remove unnecessary Doxyfile cleanup in generate-doxygen-pdf.sh

### DIFF
--- a/scripts/generate-doxygen-pdf.sh
+++ b/scripts/generate-doxygen-pdf.sh
@@ -83,7 +83,3 @@ fi
 OUTPUT_DIR=$(dirname "$PDF_FILE")
 cp "$PDF_FILE" "$OUTPUT_DIR/QtPass-$VERSION.pdf"
 echo "PDF generated: $OUTPUT_DIR/QtPass-$VERSION.pdf"
-
-cp "$DOXYFILE_BACKUP" "$DOXYFILE"
-trap - EXIT
-rm -f "$DOXYFILE_BACKUP" "$TMPFILE"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removes the cleanup steps in `scripts/generate-doxygen-pdf.sh` that were responsible for restoring the original `Doxyfile` from a backup and deleting temporary files after the Doxygen PDF generation.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal build script cleanup logic by removing redundant post-build restoration steps and consolidating error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->