### PR TITLE
refactor: improve release-mac.sh script

### DIFF
--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -3,9 +3,17 @@
 set -euo pipefail
 
 README_CLEAN="README.clean"
+DOXYFILE_PATH="Doxyfile"
+DOXYFILE_BACKUP=""
 
 cleanup() {
+	local exit_code=$?
 	rm -f "$README_CLEAN"
+	if [[ $exit_code -ne 0 && -n "${DOXYFILE_BACKUP:-}" && -f "$DOXYFILE_BACKUP" ]]; then
+		mv -f "$DOXYFILE_BACKUP" "$DOXYFILE_PATH"
+	else
+		rm -f "${DOXYFILE_BACKUP:-}"
+	fi
 }
 
 trap cleanup EXIT
@@ -44,11 +52,13 @@ if [[ -z "${VERSION:-}" ]]; then
 	echo "Error: Failed to extract VERSION from qtpass.pri" >&2
 	exit 1
 fi
-require_readable_file "Doxyfile"
+require_readable_file "$DOXYFILE_PATH"
 # Doxygen doesn't expand $ENV{} in config, so substitute directly
 # Use temp file for portable sed across GNU/BSD sed
 TMPFILE=$(mktemp)
-sed "s/^PROJECT_NUMBER.*=.*/PROJECT_NUMBER         = $VERSION/" Doxyfile >"$TMPFILE" && mv "$TMPFILE" Doxyfile
+DOXYFILE_BACKUP=$(mktemp)
+cp "$DOXYFILE_PATH" "$DOXYFILE_BACKUP"
+sed "s/^PROJECT_NUMBER.*=.*/PROJECT_NUMBER         = $VERSION/" "$DOXYFILE_PATH" >"$TMPFILE" && mv "$TMPFILE" "$DOXYFILE_PATH"
 echo "Generating API documentation (v$VERSION)..."
 doxygen || {
 	echo "Error: doxygen failed." >&2


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the `release-mac.sh` script by implementing a robust backup and restore mechanism for the `Doxyfile`.

Specifically, it:
- Creates a temporary backup of the `Doxyfile` before modifying its `PROJECT_NUMBER`.
- Introduces error handling in the `cleanup` function to restore the original `Doxyfile` from the backup if the script fails.
- Deletes the temporary backup file upon successful script completion.

This change ensures that the `Doxyfile` is always reverted to its original state if the release script encounters an error during the API documentation generation process, preventing a partially modified `Doxyfile` from being left behind.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS release process with improved error recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->