### PR TITLE
fix: improve error handling in release-mac.sh

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,10 +89,22 @@ jobs:
           fi
           echo "QTPASS_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Extracted version: $VERSION"
-          # Doxygen doesn't expand $ENV{} in config, so substitute directly
-          # Use temp file for portable sed across GNU/BSD sed
           TMPFILE=$(mktemp)
-          sed "s/^PROJECT_NUMBER.*=.*/PROJECT_NUMBER         = $VERSION/" Doxyfile > "$TMPFILE" && mv "$TMPFILE" Doxyfile
+          if [ -z "$TMPFILE" ]; then
+            echo "Error: Failed to create temporary file." >&2
+            exit 1
+          fi
+          if ! sed "s|^PROJECT_NUMBER.*=.*|PROJECT_NUMBER         = $VERSION|" Doxyfile > "$TMPFILE"; then
+            echo "Error: Failed to update PROJECT_NUMBER in Doxyfile." >&2
+            rm -f "$TMPFILE"
+            exit 1
+          fi
+          if ! grep -qF -- "PROJECT_NUMBER         = $VERSION" "$TMPFILE"; then
+            echo "Error: PROJECT_NUMBER was not updated in Doxyfile." >&2
+            rm -f "$TMPFILE"
+            exit 1
+          fi
+          mv "$TMPFILE" Doxyfile
           echo "Updated Doxyfile with version: $VERSION"
 
       - name: Generate documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -104,7 +104,11 @@ jobs:
             rm -f "$TMPFILE"
             exit 1
           fi
-          mv "$TMPFILE" Doxyfile
+          if ! mv "$TMPFILE" Doxyfile; then
+            echo "Error: Failed to replace Doxyfile with updated content." >&2
+            rm -f "$TMPFILE"
+            exit 1
+          fi
           echo "Updated Doxyfile with version: $VERSION"
 
       - name: Generate documentation

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -72,7 +72,18 @@ if [[ -z "${TMPFILE:-}" || -z "${DOXYFILE_BACKUP:-}" ]]; then
 	exit 1
 fi
 cp "$DOXYFILE_PATH" "$DOXYFILE_BACKUP"
-sed "s|^PROJECT_NUMBER.*=.*|PROJECT_NUMBER         = $ESCAPED_VERSION|" "$DOXYFILE_PATH" >"$TMPFILE" && mv "$TMPFILE" "$DOXYFILE_PATH"
+if ! sed "s|^PROJECT_NUMBER.*=.*|PROJECT_NUMBER         = $ESCAPED_VERSION|" "$DOXYFILE_PATH" >"$TMPFILE"; then
+	echo "Error: Failed to update PROJECT_NUMBER in $DOXYFILE_PATH." >&2
+	exit 1
+fi
+if [[ ! -s "$TMPFILE" ]]; then
+	echo "Error: Generated temporary Doxyfile is empty." >&2
+	exit 1
+fi
+if ! mv "$TMPFILE" "$DOXYFILE_PATH"; then
+	echo "Error: Failed to replace $DOXYFILE_PATH with updated content." >&2
+	exit 1
+fi
 echo "Generating API documentation (v$VERSION)..."
 doxygen || {
 	echo "Error: doxygen failed." >&2

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -72,12 +72,20 @@ if [[ -z "${TMPFILE:-}" || -z "${DOXYFILE_BACKUP:-}" ]]; then
 	exit 1
 fi
 cp "$DOXYFILE_PATH" "$DOXYFILE_BACKUP"
+if ! grep -qE '^PROJECT_NUMBER.*=.*' "$DOXYFILE_PATH"; then
+	echo "Error: PROJECT_NUMBER entry not found in $DOXYFILE_PATH." >&2
+	exit 1
+fi
 if ! sed "s|^PROJECT_NUMBER.*=.*|PROJECT_NUMBER         = $ESCAPED_VERSION|" "$DOXYFILE_PATH" >"$TMPFILE"; then
 	echo "Error: Failed to update PROJECT_NUMBER in $DOXYFILE_PATH." >&2
 	exit 1
 fi
 if [[ ! -s "$TMPFILE" ]]; then
 	echo "Error: Generated temporary Doxyfile is empty." >&2
+	exit 1
+fi
+if ! grep -qF "PROJECT_NUMBER         = $ESCAPED_VERSION" "$TMPFILE"; then
+	echo "Error: PROJECT_NUMBER was not updated in $DOXYFILE_PATH." >&2
 	exit 1
 fi
 if ! mv "$TMPFILE" "$DOXYFILE_PATH"; then

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -53,7 +53,6 @@ if [[ -z "${VERSION:-}" ]]; then
 	echo "Error: Failed to extract VERSION from qtpass.pri" >&2
 	exit 1
 fi
-ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed -e 's/[\\&|]/\\&/g')
 require_readable_file "$DOXYFILE_PATH"
 # Doxygen doesn't expand $ENV{} in config, so substitute directly
 # Use temp file for portable sed across GNU/BSD sed
@@ -76,7 +75,7 @@ if ! grep -qE '^PROJECT_NUMBER.*=.*' "$DOXYFILE_PATH"; then
 	echo "Error: PROJECT_NUMBER entry not found in $DOXYFILE_PATH." >&2
 	exit 1
 fi
-if ! sed "s|^PROJECT_NUMBER.*=.*|PROJECT_NUMBER         = $ESCAPED_VERSION|" "$DOXYFILE_PATH" >"$TMPFILE"; then
+if ! sed "s|^PROJECT_NUMBER.*=.*|PROJECT_NUMBER         = $VERSION|" "$DOXYFILE_PATH" >"$TMPFILE"; then
 	echo "Error: Failed to update PROJECT_NUMBER in $DOXYFILE_PATH." >&2
 	exit 1
 fi

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -53,7 +53,7 @@ if [[ -z "${VERSION:-}" ]]; then
 	echo "Error: Failed to extract VERSION from qtpass.pri" >&2
 	exit 1
 fi
-ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed -e 's/[\/\\&|]/\\&/g')
+ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed -e 's/[\\&|]/\\&/g')
 require_readable_file "$DOXYFILE_PATH"
 # Doxygen doesn't expand $ENV{} in config, so substitute directly
 # Use temp file for portable sed across GNU/BSD sed
@@ -84,7 +84,7 @@ if [[ ! -s "$TMPFILE" ]]; then
 	echo "Error: Generated temporary Doxyfile is empty." >&2
 	exit 1
 fi
-if ! grep -qF "PROJECT_NUMBER         = $ESCAPED_VERSION" "$TMPFILE"; then
+if ! grep -qF -- "PROJECT_NUMBER         = $VERSION" "$TMPFILE"; then
 	echo "Error: PROJECT_NUMBER was not updated in $DOXYFILE_PATH." >&2
 	exit 1
 fi

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -53,7 +53,7 @@ if [[ -z "${VERSION:-}" ]]; then
 	echo "Error: Failed to extract VERSION from qtpass.pri" >&2
 	exit 1
 fi
-ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed -e 's/[\\&|]/\\&/g')
+ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed -e 's/[\/\\&|]/\\&/g')
 require_readable_file "$DOXYFILE_PATH"
 # Doxygen doesn't expand $ENV{} in config, so substitute directly
 # Use temp file for portable sed across GNU/BSD sed


### PR DESCRIPTION
## **User description**
<!-- kody-pr-summary:start -->
Refactored the `release-mac.sh` script to enhance robustness and error handling during the Doxygen documentation generation process.

Key changes include:
*   **Improved Version String Escaping:** Modified the `sed` command to correctly escape forward slashes (`/`) in the `VERSION` string, preventing potential issues when substituting the version into the Doxyfile.
*   **Enhanced Error Handling for Doxyfile Updates:** Added explicit checks and error messages for each step of updating the `PROJECT_NUMBER` in the Doxyfile. This includes verifying the success of the `sed` command, ensuring the generated temporary file is not empty, and confirming the successful replacement of the original Doxyfile.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS release script with multi-step validation before modifying release files to reduce accidental changes.
  * Added checks to ensure temporary file creation and that the expected version string is present before replacing originals.
  * Hardened error handling and cleanup with clear failure messages and safer replace behavior.
  * Added equivalent defensive checks to the CI workflow's version-extraction step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix release-mac.sh handling for Doxygen version updates**

### What Changed
- Release builds now correctly escape version strings that include slashes, so the generated documentation version is inserted safely.
- The script now checks that the Doxyfile contains a project version entry before editing it, and stops with a clear error if it does not.
- If the Doxyfile update fails, produces empty output, or cannot be written back, the release process now fails immediately with a specific message instead of continuing with a broken file.

### Impact
`✅ Fewer broken documentation releases`
`✅ Clearer release failures`
`✅ Safer version updates in macOS builds`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=sYz40Y63YefrqsXzcz5pXIskeMlZmet2JCe_Kmt_RRw&org=IJHack)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
