### PR TITLE
feat: add re-encrypt context menu for directories

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1054,6 +1054,13 @@ void MainWindow::showContextMenu(const QPoint &pos) {
     }
     QAction *deleteItem = contextMenu.addAction(tr("Delete"));
     connect(deleteItem, &QAction::triggered, this, &MainWindow::onDelete);
+    if (fileOrFolder.isDir()) {
+      QString dirPath = QDir::cleanPath(
+          Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel));
+      QAction *reencrypt = contextMenu.addAction(tr("Re-encrypt"));
+      connect(reencrypt, &QAction::triggered, this,
+              [this, dirPath]() { reencryptPath(dirPath); });
+    }
   }
   contextMenu.exec(globalPos);
 }
@@ -1310,6 +1317,39 @@ void MainWindow::addToGridLayout(int position, const QString &field,
  */
 void MainWindow::showStatusMessage(const QString &msg, int timeout) {
   ui->statusBar->showMessage(msg, timeout);
+}
+
+/**
+ * @brief MainWindow::reencryptPath re-encrypt all passwords in a directory
+ * @param dir Directory path to re-encrypt
+ */
+void MainWindow::reencryptPath(QString dir) {
+  QDir checkDir(dir);
+  if (!checkDir.exists()) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Directory does not exist: %1").arg(dir));
+    return;
+  }
+
+  int ret = QMessageBox::question(
+      this, tr("Re-encrypt passwords"),
+      tr("Re-encrypt all passwords in %1?\n\n"
+         "This will re-encrypt ALL password files in this folder "
+         "using the current recipients defined in .gpg-id.\n\n"
+         "This may rewrite many files and cannot be undone easily.\n\n"
+         "Continue?")
+          .arg(QDir(dir).dirName()),
+      QMessageBox::Yes | QMessageBox::No);
+
+  if (ret != QMessageBox::Yes)
+    return;
+
+  // Prevent double execution - use same method as startReencryptPath
+  setUiElementsEnabled(false);
+  ui->treeView->setDisabled(true);
+
+  QtPassSettings::getImitatePass()->reencryptPath(
+      QDir::cleanPath(QDir(dir).absolutePath()));
 }
 
 /**

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -87,6 +87,8 @@ private Q_SLOTS:
   void utilRegexEnsuresGpg();
   void utilRegexProtocol();
   void utilRegexNewLines();
+  void reencryptPathNormalization();
+  void reencryptPathAbsolutePath();
   void buildClipboardMimeDataDword();
   void imitatePassResolveMoveDestination();
   void imitatePassResolveMoveDestinationForce();
@@ -1332,6 +1334,35 @@ void tst_util::utilRegexNewLines() {
   QVERIFY2(rex.match("\n").hasMatch(), "Should match newline");
   QVERIFY2(rex.match("line1\nline2").hasMatch(),
            "Should match embedded newline");
+}
+
+void tst_util::reencryptPathNormalization() {
+  QTemporaryDir tempDir;
+  QVERIFY2(tempDir.isValid(), "Temporary directory should be created");
+
+  QString basePath = tempDir.path();
+  QString withExtraSlashes = basePath + "/./subdir/../";
+  QString cleaned = QDir::cleanPath(withExtraSlashes);
+  QString normalized = QDir::cleanPath(basePath);
+  QVERIFY2(cleaned == normalized,
+           qPrintable(QString("cleanPath should normalize: expected %1, got %2")
+                          .arg(normalized, cleaned)));
+}
+
+void tst_util::reencryptPathAbsolutePath() {
+  QTemporaryDir tempDir;
+  QVERIFY2(tempDir.isValid(), "Temporary directory should be created");
+
+  QString tempPath = tempDir.path();
+  QDir(tempPath).mkdir("testdir");
+  QString relativePathFromTemp = tempPath + "/testdir";
+  QDir dir;
+  QString result = QDir::cleanPath(QDir(relativePathFromTemp).absolutePath());
+  QString expected = QDir::cleanPath(tempPath + "/testdir");
+  QVERIFY2(
+      result == expected,
+      qPrintable(
+          QString("Absolute path: expected %1, got %2").arg(expected, result)));
 }
 
 QTEST_MAIN(tst_util)


### PR DESCRIPTION
Fixes: #269 

<!-- kody-pr-summary:start -->
This pull request introduces a new "Re-encrypt" context menu option for directories within the main application's tree view.

Key changes include:
*   **Context Menu Integration:** When a directory is right-clicked, a "Re-encrypt" action is now available in the context menu.
*   **Re-encryption Functionality:** A new `reencryptPath` function handles the re-encryption process.
    *   It first validates the directory path.
    *   It presents a confirmation dialog to the user, explaining that all password files within the selected directory will be re-encrypted using the current GPG recipients defined in `.gpg-id`, and that this action is not easily reversible.
    *   Upon user confirmation, the main window is temporarily disabled to prevent further interaction, and the re-encryption operation is delegated to the `ImitatePass` backend for the specified directory.
<!-- kody-pr-summary:end -->