### PR TITLE
chore: Corrected the locale identifier in the Slovenian

### DIFF
--- a/localization/localization_sl_SI.ts
+++ b/localization/localization_sl_SI.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="si_LK">
+<TS version="2.1" language="sl_SI">
 <context>
     <name>ConfigDialog</name>
     <message>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrected the language attribute in the `localization_sl_SI.ts` file from `si_LK` (Sinhala, Sri Lanka) to `sl_SI` (Slovenian, Slovenia) to accurately reflect the intended locale of the localization file.
<!-- kody-pr-summary:end -->