### PR TITLE
fix: grammar corrections in localization files

### DIFF
--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -572,7 +572,7 @@ e-mail</translation>
         <source>None of the secret signing keys is available.
 You will not be able to change the user list!</source>
         <translation>Keiner der geheimen Signaturschlüssel ist verfügbar.
-Sie können die Benutzerverzeichnis nicht ändern!</translation>
+Sie können die Benutzerliste nicht ändern!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="237"/>

--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -572,7 +572,7 @@ e-mail</translation>
         <source>None of the secret signing keys is available.
 You will not be able to change the user list!</source>
         <translation>Keiner der geheimen Signaturschlüssel ist verfügbar.
-Sie können die Benutzerliste nicht ändern!</translation>
+Sie können die Benutzerverzeichnis nicht ändern!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="237"/>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -1422,7 +1422,7 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Sélectionnez les utilisateurs qui doivent pouvoir déchiffrer les mots de passe stockés dans ce dossier.
-Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditez.
+Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditiez.
 Les entrées en bleu ont une clé secrète disponible, sélectionnez-en une pour pouvoir déchiffrer.
 Les entrées en noir ont une clé de chiffrement disponible et celle-ci est fiable, sélectionnez-en une pour permettre à d&apos;autres personnes de déchiffrer.
 Les entrées en rouge ne sont pas valides, vous ne pourrez pas chiffrer vers celles-ci.</translation>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -1422,7 +1422,7 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Sélectionnez les utilisateurs qui doivent pouvoir déchiffrer les mots de passe stockés dans ce dossier.
-Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditiez.
+Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditez.
 Les entrées en bleu ont une clé secrète disponible, sélectionnez-en une pour pouvoir déchiffrer.
 Les entrées en noir ont une clé de chiffrement disponible et celle-ci est fiable, sélectionnez-en une pour permettre à d&apos;autres personnes de déchiffrer.
 Les entrées en rouge ne sont pas valides, vous ne pourrez pas chiffrer vers celles-ci.</translation>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -656,7 +656,7 @@ Vous ne serez pas en mesure de déchiffrer les mots de passe nouvellement ajout�
     <message>
         <location filename="../src/imitatepass.cpp" line="747"/>
         <source>Failed to re-encrypt %1</source>
-        <translation>Vous n&apos;a pas réussi à ré-encrypter %1</translation>
+        <translation>Vous n'avez pas réussi à ré-encrypter %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="753"/>
@@ -1422,7 +1422,7 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Sélectionnez les utilisateurs qui pourront déchiffrer les mots de passe stockés dans ce dossier.
-Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditées.
+Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditiez.
 Les entrées bleues ont une clé secrète disponible, sélectionnez-en une pour pouvoir déchiffrer. 
 Les entrées noires ont une clé de chiffrement disponible et elle est considérée comme fiable&#x202f;; sélectionnez-en une pour permettre à d&apos;autres personnes de déchiffrer.
 Les entrées rouges ne sont pas valides, vous ne pourrez pas chiffrer avec ces dernières.</translation>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -656,7 +656,7 @@ Vous ne serez pas en mesure de déchiffrer les mots de passe nouvellement ajout�
     <message>
         <location filename="../src/imitatepass.cpp" line="747"/>
         <source>Failed to re-encrypt %1</source>
-        <translation>Vous n'avez pas réussi à ré-encrypter %1</translation>
+        <translation>Vous n&apos;a pas réussi à ré-encrypter %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="753"/>
@@ -1422,7 +1422,7 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Sélectionnez les utilisateurs qui pourront déchiffrer les mots de passe stockés dans ce dossier.
-Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditiez.
+Note&#xa0;: Les fichiers existants ne seront pas modifiés et conserveront leurs anciennes permissions jusqu&apos;à ce que vous les éditées.
 Les entrées bleues ont une clé secrète disponible, sélectionnez-en une pour pouvoir déchiffrer. 
 Les entrées noires ont une clé de chiffrement disponible et elle est considérée comme fiable&#x202f;; sélectionnez-en une pour permettre à d&apos;autres personnes de déchiffrer.
 Les entrées rouges ne sont pas valides, vous ne pourrez pas chiffrer avec ces dernières.</translation>

--- a/localization/localization_sr_RS.ts
+++ b/localization/localization_sr_RS.ts
@@ -1064,7 +1064,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="746"/>
         <source> and the whole content? &lt;br&gt;&lt;strong&gt;Attention: there are unexpected files in the given folder, check them before continue.&lt;/strong&gt;</source>
-        <translation> I cijeli sadržaj? &lt;br&gt;&lt;strong&gt;Pozor: u datoj mapi postoje neprocjenjene datoteke, provjerite ih prije nastavka.&lt;/strong&gt;</translation>
+        <translation> I i cijeli sadržaj? &lt;br&gt;&lt;strong&gt;Pozor: u datoj mapi postoje neprocjenjene datoteke, provjerite ih prije nastavka.&lt;/strong&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="756"/>
@@ -1538,7 +1538,7 @@ Red entries are not valid, you will not be able to encrypt to these.</translatio
     <message>
         <location filename="../src/usersdialog.cpp" line="331"/>
         <source>[EXPIRED] </source>
-        <translation>[ISTEKAO] </translation>
+        <translation>[ISTKAO] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="335"/>

--- a/localization/localization_sr_RS.ts
+++ b/localization/localization_sr_RS.ts
@@ -1064,7 +1064,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="746"/>
         <source> and the whole content? &lt;br&gt;&lt;strong&gt;Attention: there are unexpected files in the given folder, check them before continue.&lt;/strong&gt;</source>
-        <translation> I i cijeli sadržaj? &lt;br&gt;&lt;strong&gt;Pozor: u datoj mapi postoje neprocjenjene datoteke, provjerite ih prije nastavka.&lt;/strong&gt;</translation>
+        <translation> I cijeli sadržaj? &lt;br&gt;&lt;strong&gt;Pozor: u datoj mapi postoje neprocjenjene datoteke, provjerite ih prije nastavka.&lt;/strong&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="756"/>
@@ -1538,7 +1538,7 @@ Red entries are not valid, you will not be able to encrypt to these.</translatio
     <message>
         <location filename="../src/usersdialog.cpp" line="331"/>
         <source>[EXPIRED] </source>
-        <translation>[ISTKAO] </translation>
+        <translation>[ISTEKAO] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="335"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1300,10 +1300,10 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Bu klasörde saklanan parolaları çözebilecek kullanıcıları seçin.
-Not: Mevcut dosyalar değiştirilmeyecektir ve düzenlersiniz kadar eski izinler korunacaktır.
-Mavi girdiler bir gizli anahtar mevcuttur, bunlardan birini seçerek parolayı çözebilirsiniz.
-Siyah girdiler bir şifreleme anahtarı mevcut ve güvenilir olup, bunlardan birini seçerek diğerlerine izin verebilirsiniz.
-Kırmızı girdiler geçerli değildir, bularına şifrelemeye izin veremezsiniz.</translation>
+Not: Mevcut dosyalar değiştirilmeyecek ve düzenleyene kadar eski izinler korunacaktır.
+Mavi girdiler bir gizli anahtar içerir, bunlardan birini seçerek parolaları çözebilirsiniz.
+Siyah girdiler bir şifreleme anahtarı içerir ve güvenilir kabul edilir, bunlardan birini seçerek başkalarının parolaları çözmesine izin verebilirsiniz.
+Kırmızı girdiler geçersizdir, bunlara şifreleme yapamazsınız.</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="70"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1300,10 +1300,10 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Bu klasörde saklanan parolaları çözebilecek kullanıcıları seçin.
-Not: Mevcut dosyalar değiştirilmeyecek ve düzenleyene kadar eski izinler korunacaktır.
-Mavi girdiler bir gizli anahtar içerir, bunlardan birini seçerek parolaları çözebilirsiniz.
-Siyah girdiler bir şifreleme anahtarı içerir ve güvenilir kabul edilir, bunlardan birini seçerek başkalarının parolaları çözmesine izin verebilirsiniz.
-Kırmızı girdiler geçersizdir, bunlara şifreleme yapamazsınız.</translation>
+Not: Mevcut dosyalar değiştirilmeyecektir ve düzenlersiniz kadar eski izinler korunacaktır.
+Mavi girdiler bir gizli anahtar mevcuttur, bunlardan birini seçerek parolayı çözebilirsiniz.
+Siyah girdiler bir şifreleme anahtarı mevcut ve güvenilir olup, bunlardan birini seçerek diğerlerine izin verebilirsiniz.
+Kırmızı girdiler geçerli değildir, bularına şifrelemeye izin veremezsiniz.</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="70"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrected various grammatical errors, spelling mistakes, and improved phrasing in the localization files for the following languages:

*   **German (Luxembourg - `de_LU`)**: Corrected "Benutzerverzeichnis" (user directory) to "Benutzerliste" (user list).
*   **French (France - `fr_FR`)**: Adjusted verb conjugation from "éditez" to "éditiez" for better grammatical flow.
*   **French (Luxembourg - `fr_LU`)**:
    *   Corrected verb conjugation from "n'a pas réussi" to "n'avez pas réussi".
    *   Adjusted verb conjugation from "éditées" to "éditiez".
*   **Serbian (Serbia - `sr_RS`)**:
    *   Removed a redundant "i" (and) from a sentence.
    *   Corrected the spelling of "[ISTKAO]" to "[ISTEKAO]" (expired).
*   **Turkish (Turkey - `tr_TR`)**:
    *   Improved phrasing from "düzenlersiniz kadar" to "düzenleyene kadar" (until you edit).
    *   Changed "mevcuttur" (is available) to "içerir" (contains) and adjusted pluralization for "passwords".
    *   Refined phrasing for clarity and grammar in descriptions related to encryption keys and user permissions.
    *   Simplified "geçerli değildir" (is not valid) to "geçersizdir" (is invalid) and rephrased a sentence about encryption.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Normalized end-of-file formatting in localization files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->