### PR TITLE
fix: ta_IN translation corrections

### DIFF
--- a/localization/localization_ta_IN.ts
+++ b/localization/localization_ta_IN.ts
@@ -642,7 +642,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="734"/>
         <source>GPG ID verification failed</source>
-        <translation>GPG உருப்பாய் சரியானவையால் போர்டம் மாற்றம் தேவையாக விளக்கப்படவில்லை</translation>
+        <translation>GPG ID சரிபார்ப்பு தோல்வியடைந்தது</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="735"/>
@@ -1574,12 +1574,12 @@ Red entries are not valid, you will not be able to encrypt to these.</translatio
     <message>
         <location filename="../src/usersdialog.cpp" line="331"/>
         <source>[EXPIRED] </source>
-        <translation>[பயன்பாட்டு அளவுக்கு வழங்கப்பட்ட] </translation>
+        <translation>[காலாவதியான] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="335"/>
         <source>[PARTIAL] </source>
-        <translation>[அலியான] </translation>
+        <translation>[பகுதி] </translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrects several inaccurate Tamil (India) translations within the application. Specifically, it updates the translations for:
- "GPG ID verification failed"
- "[EXPIRED]"
- "[PARTIAL]"
to be more accurate and contextually appropriate in the `ta_IN` locale.
<!-- kody-pr-summary:end -->