### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/.opencode/skills/qtpass-localization/SKILL.md
+++ b/.opencode/skills/qtpass-localization/SKILL.md
@@ -154,7 +154,7 @@ QtPass uses system locale. To test:
 
 ```bash
 # Linux
-LANG=nl_NL ./qtpass
+LANG=nl_NL.UTF-8 ./qtpass
 
 # Or set in QtPass settings
 ```

--- a/.opencode/skills/qtpass-localization/SKILL.md
+++ b/.opencode/skills/qtpass-localization/SKILL.md
@@ -233,9 +233,16 @@ When source strings change, translations are marked "unfinished" but may still a
 When merging translation PRs that conflict:
 
 ```bash
-# Use theirs strategy for .ts files (they're XML, prefer incoming)
-git checkout --theirs localization/localization_*.ts
-git add localization/
+# Use theirs strategy for conflicted .ts files (they're XML, prefer incoming)
+# 1) List conflicted translation files and review them:
+git diff --name-only --diff-filter=U -- localization/*.ts
+
+# 2) Resolve each intended file explicitly (repeat as needed):
+git checkout --theirs localization/localization_de.ts
+git checkout --theirs localization/localization_fr.ts
+
+# 3) Stage and commit:
+git add localization/localization_de.ts localization/localization_fr.ts
 git commit -m "Resolve merge conflict - use theirs for translations"
 ```
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the localization skill documentation (`.opencode/skills/qtpass-localization/SKILL.md`) with the following improvements:

*   **Refined Localization Testing Command:** Modified the Linux command example for testing localization to use `LANG=nl_NL.UTF-8` instead of `LANG=nl_NL`, providing a more explicit and robust locale setting.
*   **Improved Merge Conflict Resolution Instructions:** Enhanced the guidance for resolving merge conflicts in `.ts` (translation) files. The updated instructions now recommend:
    *   First listing conflicted translation files.
    *   Explicitly resolving each intended file using `git checkout --theirs` (e.g., `localization_de.ts`, `localization_fr.ts`) instead of a wildcard, to prevent accidental overwrites.
    *   Staging the explicitly resolved files.
    This makes the conflict resolution process safer and more precise.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated localization testing guidance to ensure proper UTF-8 character handling and compatibility.
  * Streamlined translation conflict resolution workflow with clearer, step-by-step instructions for managing language file merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->