### PR TITLE
fix: avoid wildcard in merge conflict resolution

### DIFF
--- a/.opencode/skills/qtpass-localization/SKILL.md
+++ b/.opencode/skills/qtpass-localization/SKILL.md
@@ -230,12 +230,20 @@ When source strings change, translations are marked "unfinished" but may still a
 
 ### Merging Translation Conflicts
 
-When merging translation PRs that conflict:
+When merging translation PRs that conflict, **avoid using wildcards** - `git checkout --theirs localization/*.ts` would discard ALL local changes in un-conflicted files.
+
+Instead, identify and resolve conflicted files explicitly:
 
 ```bash
-# Use theirs strategy for .ts files (they're XML, prefer incoming)
-git checkout --theirs localization/localization_*.ts
-git add localization/
+# 1) List conflicted translation files and review them:
+git diff --name-only --diff-filter=U -- localization/*.ts
+
+# 2) Resolve each intended file explicitly (repeat as needed):
+git checkout --theirs localization/localization_de.ts
+git checkout --theirs localization/localization_fr.ts
+
+# 3) Stage and commit:
+git add localization/localization_de.ts localization/localization_fr.ts
 git commit -m "Resolve merge conflict - use theirs for translations"
 ```
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates the documentation for resolving merge conflicts in translation files (`.ts`). The previous guidance, which suggested using a wildcard with `git checkout --theirs localization/*.ts`, has been revised. The updated instructions now explicitly warn against using wildcards, as this could discard local changes in un-conflicted files. Instead, the documentation now recommends identifying and resolving each conflicted translation file individually to ensure only intended changes are applied during merge conflict resolution.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated translation conflict resolution guidance: warn against broad overwrite actions and recommend identifying only conflicted localization files, resolve them individually, and stage only the resolved files to avoid losing unrelated local changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->