### PR TITLE
fix: resolve clangd static analysis findings

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -220,7 +220,7 @@ static auto decodeAssumingUtf8(const QByteArray &in) -> QString {
  * Note: Returning error code instead of throwing to maintain compatibility
  * with the existing error handling pattern used throughout QtPass.
  */
-auto Executor::executeBlocking(QString app, const QStringList &args,
+auto Executor::executeBlocking(const QString &app, const QStringList &args,
                                const QString &input, QString *process_out,
                                QString *process_err) -> int {
   QProcess internal;
@@ -265,11 +265,10 @@ auto Executor::executeBlocking(QString app, const QStringList &args,
  * @param process_err
  * @return
  */
-auto Executor::executeBlocking(QString app, const QStringList &args,
+auto Executor::executeBlocking(const QString &app, const QStringList &args,
                                QString *process_out, QString *process_err)
     -> int {
-  return executeBlocking(std::move(app), args, QString(), process_out,
-                         process_err);
+  return executeBlocking(app, args, QString(), process_out, process_err);
 }
 
 /**
@@ -281,7 +280,7 @@ auto Executor::executeBlocking(QString app, const QStringList &args,
  * @param process_err Standard error
  * @return Exit code
  */
-auto Executor::executeBlocking(const QStringList &env, QString app,
+auto Executor::executeBlocking(const QStringList &env, const QString &app,
                                const QStringList &args, QString *process_out,
                                QString *process_err) -> int {
   QProcess process;

--- a/src/executor.h
+++ b/src/executor.h
@@ -140,16 +140,16 @@ public:
                const QStringList &args, QString input = QString(),
                bool readStdout = false, bool readStderr = true);
 
-  static auto executeBlocking(QString app, const QStringList &args,
+  static auto executeBlocking(const QString &app, const QStringList &args,
                               const QString &input = QString(),
                               QString *process_out = nullptr,
                               QString *process_err = nullptr) -> int;
 
-  static auto executeBlocking(QString app, const QStringList &args,
+  static auto executeBlocking(const QString &app, const QStringList &args,
                               QString *process_out,
                               QString *process_err = nullptr) -> int;
 
-  static auto executeBlocking(const QStringList &env, QString app,
+  static auto executeBlocking(const QStringList &env, const QString &app,
                               const QStringList &args,
                               QString *process_out = nullptr,
                               QString *process_err = nullptr) -> int;

--- a/src/gpgkeystate.cpp
+++ b/src/gpgkeystate.cpp
@@ -127,7 +127,7 @@ auto parseGpgColonOutput(const QString &output, bool secret)
       continue;
     }
 
-    const QString record_type = props[0];
+    const QString &record_type = props[0];
     const GpgRecordType type = classifyRecord(record_type);
 
     switch (type) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1323,7 +1323,7 @@ void MainWindow::showStatusMessage(const QString &msg, int timeout) {
  * @brief MainWindow::reencryptPath re-encrypt all passwords in a directory
  * @param dir Directory path to re-encrypt
  */
-void MainWindow::reencryptPath(QString dir) {
+void MainWindow::reencryptPath(const QString &dir) {
   QDir checkDir(dir);
   if (!checkDir.exists()) {
     QMessageBox::critical(this, tr("Error"),

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -151,7 +151,7 @@ private:
   void initTrayIcon();
   void destroyTrayIcon();
   void clearTemplateWidgets();
-  void reencryptPath(QString dir);
+  void reencryptPath(const QString &dir);
   void addToGridLayout(int position, const QString &field,
                        const QString &value);
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -147,7 +147,7 @@ void QtPass::setMainWindow() {
   connect(QtPassSettings::getImitatePass(), &ImitatePass::endReencryptPath,
           m_mainWindow, &MainWindow::endReencryptPath);
 
-  connect(m_mainWindow, &MainWindow::passGitInitNeeded, [this]() {
+  connect(m_mainWindow, &MainWindow::passGitInitNeeded, []() {
 #ifdef QT_DEBUG
     dbg() << "Pass git init called";
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -117,7 +117,7 @@ auto Util::normalizeFolderPath(const QString &path) -> QString {
  * @return QString - The absolute path to the binary, or an empty string if not
  * found.
  */
-auto Util::findBinaryInPath(QString binary) -> QString {
+auto Util::findBinaryInPath(const QString &binary) -> QString {
   initialiseEnvironment();
 
   QString ret;

--- a/src/util.h
+++ b/src/util.h
@@ -27,7 +27,7 @@ public:
    * @return QString Absolute path to the executable if found, empty QString
    * otherwise.
    */
-  static auto findBinaryInPath(QString binary) -> QString;
+  static auto findBinaryInPath(const QString &binary) -> QString;
   /**
    * @brief Locate the password store directory.
    * @return QString Path to the password store, always ends with native


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses several findings identified by static analysis tools, primarily focusing on optimizing parameter passing and minor code hygiene.

Key changes include:

*   **Optimized `QString` Parameter Passing**: Modified numerous function signatures across `Executor`, `MainWindow`, and `Util` classes to pass `QString` parameters by `const QString &` (constant reference) instead of by value. This change avoids unnecessary deep copies of `QString` objects, improving performance and efficiency.
*   **Refactored `Executor::executeBlocking` Call**: Adjusted an internal call within `Executor::executeBlocking` to pass the `app` parameter directly instead of using `std::move`, consistent with the updated `const QString &` signature.
*   **Minor Lambda Capture Optimization**: Removed an unnecessary `[this]` capture in a lambda connected to `MainWindow::passGitInitNeeded` in `qtpass.cpp`, as the `this` pointer was not utilized within the lambda's body.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parameter passing for improved performance across multiple functions by reducing unnecessary data copies during function calls.
  * Removed unused variable capture in event handler callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->