### PR TITLE
fix: set PASSWORD_STORE_* env vars and grey out pass-managed controls

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -356,6 +356,17 @@ void ConfigDialog::setGroupBoxState() {
   bool state = ui->radioButtonPass->isChecked();
   ui->groupBoxNative->setEnabled(!state);
   ui->groupBoxPass->setEnabled(state);
+  // password generation controls are pass-managed when using pass binary
+  bool enablePwgen = !state;
+  ui->spinBoxPasswordLength->setEnabled(enablePwgen);
+  ui->labelPasswordChars->setEnabled(enablePwgen);
+  ui->passwordCharTemplateSelector->setEnabled(enablePwgen);
+  ui->lineEditPasswordChars->setEnabled(enablePwgen);
+  ui->checkBoxUsePwgen->setEnabled(enablePwgen);
+  ui->checkBoxAvoidCapitals->setEnabled(enablePwgen);
+  ui->checkBoxUseSymbols->setEnabled(enablePwgen);
+  ui->checkBoxLessRandom->setEnabled(enablePwgen);
+  ui->checkBoxAvoidNumbers->setEnabled(enablePwgen);
 }
 
 /**

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -356,17 +356,23 @@ void ConfigDialog::setGroupBoxState() {
   bool state = ui->radioButtonPass->isChecked();
   ui->groupBoxNative->setEnabled(!state);
   ui->groupBoxPass->setEnabled(state);
-  // password generation controls are pass-managed when using pass binary
-  bool enablePwgen = !state;
-  ui->spinBoxPasswordLength->setEnabled(enablePwgen);
-  ui->labelPasswordChars->setEnabled(enablePwgen);
-  ui->passwordCharTemplateSelector->setEnabled(enablePwgen);
-  ui->lineEditPasswordChars->setEnabled(enablePwgen);
-  ui->checkBoxUsePwgen->setEnabled(enablePwgen);
-  ui->checkBoxAvoidCapitals->setEnabled(enablePwgen);
-  ui->checkBoxUseSymbols->setEnabled(enablePwgen);
-  ui->checkBoxLessRandom->setEnabled(enablePwgen);
-  ui->checkBoxAvoidNumbers->setEnabled(enablePwgen);
+  if (state) {
+    // pass mode: disable all password generation controls
+    ui->spinBoxPasswordLength->setEnabled(false);
+    ui->checkBoxUsePwgen->setEnabled(false);
+    ui->checkBoxAvoidCapitals->setEnabled(false);
+    ui->checkBoxUseSymbols->setEnabled(false);
+    ui->checkBoxLessRandom->setEnabled(false);
+    ui->checkBoxAvoidNumbers->setEnabled(false);
+    ui->labelPasswordChars->setEnabled(false);
+    ui->passwordCharTemplateSelector->setEnabled(false);
+    ui->lineEditPasswordChars->setEnabled(false);
+  } else {
+    // native mode: restore pwgen/charset state from existing handlers
+    ui->spinBoxPasswordLength->setEnabled(true);
+    ui->checkBoxUsePwgen->setEnabled(!ui->pwgenPath->text().isEmpty());
+    on_checkBoxUsePwgen_clicked();
+  }
 }
 
 /**
@@ -961,6 +967,8 @@ void ConfigDialog::setPwgenPath(const QString &pwgen) {
  * options in the interface.
  */
 void ConfigDialog::on_checkBoxUsePwgen_clicked() {
+  if (ui->radioButtonPass->isChecked())
+    return;
   bool usePwgen = ui->checkBoxUsePwgen->isChecked();
   ui->checkBoxAvoidCapitals->setEnabled(usePwgen);
   ui->checkBoxAvoidNumbers->setEnabled(usePwgen);

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -321,6 +321,10 @@ void Executor::setEnvironment(const QStringList &env) {
   m_process.setEnvironment(env);
 }
 
+auto Executor::environment() const -> QStringList {
+  return m_process.environment();
+}
+
 /**
  * @brief Executor::cancelNext  cancels execution of first process in queue
  *                              if it's not already running

--- a/src/executor.h
+++ b/src/executor.h
@@ -155,6 +155,10 @@ public:
                               QString *process_err = nullptr) -> int;
 
   void setEnvironment(const QStringList &env);
+  /**
+   * @brief Return the environment passed to child processes.
+   * @return Environment as a list of "KEY=value" strings.
+   */
   auto environment() const -> QStringList;
 
   auto cancelNext() -> int;

--- a/src/executor.h
+++ b/src/executor.h
@@ -155,6 +155,7 @@ public:
                               QString *process_err = nullptr) -> int;
 
   void setEnvironment(const QStringList &env);
+  auto environment() const -> QStringList;
 
   auto cancelNext() -> int;
 private slots:

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -509,6 +509,28 @@ void Pass::updateEnv() {
     env.replaceInStrings(store.first(), "PASSWORD_STORE_DIR=" +
                                             QtPassSettings::getPassStore());
   }
+  // put PASSWORD_STORE_GENERATED_LENGTH in env
+  PasswordConfiguration passConfig = QtPassSettings::getPasswordConfiguration();
+  QString lenKey = QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH=");
+  QString lenVal = lenKey + QString::number(passConfig.length);
+  QStringList envLen = env.filter(lenKey);
+  if (envLen.isEmpty()) {
+    env.append(lenVal);
+  } else {
+    env.replaceInStrings(envLen.first(), lenVal);
+  }
+  // put PASSWORD_STORE_CHARACTER_SET in env
+  QString charset = passConfig.Characters[passConfig.selected];
+  if (!charset.isEmpty()) {
+    QString charKey = QStringLiteral("PASSWORD_STORE_CHARACTER_SET=");
+    QString charVal = charKey + charset;
+    QStringList envChar = env.filter(charKey);
+    if (envChar.isEmpty()) {
+      env.append(charVal);
+    } else {
+      env.replaceInStrings(envChar.first(), charVal);
+    }
+  }
   exec.setEnvironment(env);
 }
 

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -496,7 +496,10 @@ void Pass::finished(int id, int exitCode, const QString &out,
  * @brief Pass::updateEnv update the execution environment (used when
  * switching profiles)
  */
+// key must include the trailing '=' (e.g. "FOO="); env.filter() does substring
+// matching so the '=' anchors the lookup to avoid collisions with longer names.
 void Pass::setEnvVar(const QString &key, const QString &value) {
+  Q_ASSERT(key.endsWith('='));
   QStringList existing = env.filter(key);
   if (value.isEmpty()) {
     for (const QString &entry : existing)
@@ -521,8 +524,10 @@ void Pass::updateEnv() {
   int sel = passConfig.selected;
   if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
     sel = PasswordConfiguration::ALLCHARS;
-  setEnvVar(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="),
-            passConfig.Characters[sel]);
+  QString charset = passConfig.Characters[sel];
+  if (charset.isEmpty())
+    charset = passConfig.Characters[PasswordConfiguration::ALLCHARS];
+  setEnvVar(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="), charset);
 
   exec.setEnvironment(env);
 }

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -43,8 +43,23 @@ Pass::Pass() : wrapperRunning(false), env(QProcess::systemEnvironment()) {
   //        SIGNAL(error(QProcess::ProcessError)));
 
   connect(&exec, &Executor::starting, this, &Pass::startingExecuteWrapper);
-  env.append("WSLENV=PASSWORD_STORE_DIR/p:PASSWORD_STORE_GENERATED_LENGTH/"
-             "w:PASSWORD_STORE_CHARACTER_SET/w");
+  // Merge our vars into WSLENV rather than blindly appending a duplicate entry
+  const QStringList wslenvVars = {
+      QStringLiteral("PASSWORD_STORE_DIR/p"),
+      QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w"),
+      QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")};
+  QStringList existing = env.filter(QStringLiteral("WSLENV="));
+  if (existing.isEmpty()) {
+    env.append(QStringLiteral("WSLENV=") + wslenvVars.join(':'));
+  } else {
+    QString current = existing.first();
+    QString val = current.mid(7); // skip "WSLENV="
+    for (const QString &v : wslenvVars) {
+      if (!val.contains(v))
+        val += ':' + v;
+    }
+    env.replaceInStrings(current, QStringLiteral("WSLENV=") + val);
+  }
 }
 
 /**
@@ -480,64 +495,34 @@ void Pass::finished(int id, int exitCode, const QString &out,
  * @brief Pass::updateEnv update the execution environment (used when
  * switching profiles)
  */
+void Pass::setEnvVar(const QString &key, const QString &value) {
+  QStringList existing = env.filter(key);
+  if (value.isEmpty()) {
+    for (const QString &entry : existing)
+      env.removeAll(entry);
+  } else if (existing.isEmpty()) {
+    env.append(key + value);
+  } else {
+    env.replaceInStrings(existing.first(), key + value);
+  }
+}
+
 void Pass::updateEnv() {
-  // put PASSWORD_STORE_SIGNING_KEY in env
-  QStringList envSigningKey = env.filter("PASSWORD_STORE_SIGNING_KEY=");
-  QString currentSigningKey = QtPassSettings::getPassSigningKey();
-  if (envSigningKey.isEmpty()) {
-    if (!currentSigningKey.isEmpty()) {
-      // dbg()<< "Added
-      // PASSWORD_STORE_SIGNING_KEY with" + currentSigningKey;
-      env.append("PASSWORD_STORE_SIGNING_KEY=" + currentSigningKey);
-    }
-  } else {
-    if (currentSigningKey.isEmpty()) {
-      env.removeAll(envSigningKey.first());
-    } else {
-      // dbg()<< "Update
-      // PASSWORD_STORE_SIGNING_KEY with " + currentSigningKey;
-      env.replaceInStrings(envSigningKey.first(),
-                           "PASSWORD_STORE_SIGNING_KEY=" + currentSigningKey);
-    }
-  }
-  // put PASSWORD_STORE_DIR in env
-  QStringList store = env.filter("PASSWORD_STORE_DIR=");
-  if (store.isEmpty()) {
-    env.append("PASSWORD_STORE_DIR=" + QtPassSettings::getPassStore());
-  } else {
-    // dbg()<< "Update
-    // PASSWORD_STORE_DIR with " + passStore;
-    env.replaceInStrings(store.first(), "PASSWORD_STORE_DIR=" +
-                                            QtPassSettings::getPassStore());
-  }
-  // put PASSWORD_STORE_GENERATED_LENGTH in env
+  setEnvVar(QStringLiteral("PASSWORD_STORE_SIGNING_KEY="),
+            QtPassSettings::getPassSigningKey());
+  setEnvVar(QStringLiteral("PASSWORD_STORE_DIR="),
+            QtPassSettings::getPassStore());
+
   PasswordConfiguration passConfig = QtPassSettings::getPasswordConfiguration();
-  QString lenKey = QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH=");
-  QString lenVal = lenKey + QString::number(passConfig.length);
-  QStringList envLen = env.filter(lenKey);
-  if (envLen.isEmpty()) {
-    env.append(lenVal);
-  } else {
-    env.replaceInStrings(envLen.first(), lenVal);
-  }
-  // put PASSWORD_STORE_CHARACTER_SET in env (clamp selected to valid range)
+  setEnvVar(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH="),
+            QString::number(passConfig.length));
+
   int sel = passConfig.selected;
   if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
     sel = PasswordConfiguration::ALLCHARS;
-  QString charset = passConfig.Characters[sel];
-  QString charKey = QStringLiteral("PASSWORD_STORE_CHARACTER_SET=");
-  QStringList envChar = env.filter(charKey);
-  if (charset.isEmpty()) {
-    for (const QString &entry : envChar)
-      env.removeAll(entry);
-  } else {
-    QString charVal = charKey + charset;
-    if (envChar.isEmpty()) {
-      env.append(charVal);
-    } else {
-      env.replaceInStrings(envChar.first(), charVal);
-    }
-  }
+  setEnvVar(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="),
+            passConfig.Characters[sel]);
+
   exec.setEnvironment(env);
 }
 

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -48,18 +48,20 @@ Pass::Pass() : wrapperRunning(false), env(QProcess::systemEnvironment()) {
       QStringLiteral("PASSWORD_STORE_DIR/p"),
       QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w"),
       QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")};
-  QStringList existing = env.filter(QStringLiteral("WSLENV="));
-  if (existing.isEmpty()) {
-    env.append(QStringLiteral("WSLENV=") + wslenvVars.join(':'));
+  const QString wslenvPrefix = QStringLiteral("WSLENV=");
+  auto it = std::find_if(env.begin(), env.end(), [&](const QString &s) {
+    return s.startsWith(wslenvPrefix);
+  });
+  if (it == env.end()) {
+    env.append(wslenvPrefix + wslenvVars.join(':'));
   } else {
-    QString current = existing.first();
     QStringList parts =
-        current.mid(7).split(':', Qt::SkipEmptyParts); // skip "WSLENV="
+        it->mid(wslenvPrefix.size()).split(':', Qt::SkipEmptyParts);
     for (const QString &v : wslenvVars) {
       if (!parts.contains(v))
         parts.append(v);
     }
-    env.replaceInStrings(current, QStringLiteral("WSLENV=") + parts.join(':'));
+    *it = wslenvPrefix + parts.join(':');
   }
 }
 

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -53,12 +53,13 @@ Pass::Pass() : wrapperRunning(false), env(QProcess::systemEnvironment()) {
     env.append(QStringLiteral("WSLENV=") + wslenvVars.join(':'));
   } else {
     QString current = existing.first();
-    QString val = current.mid(7); // skip "WSLENV="
+    QStringList parts =
+        current.mid(7).split(':', Qt::SkipEmptyParts); // skip "WSLENV="
     for (const QString &v : wslenvVars) {
-      if (!val.contains(v))
-        val += ':' + v;
+      if (!parts.contains(v))
+        parts.append(v);
     }
-    env.replaceInStrings(current, QStringLiteral("WSLENV=") + val);
+    env.replaceInStrings(current, QStringLiteral("WSLENV=") + parts.join(':'));
   }
 }
 

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -43,7 +43,8 @@ Pass::Pass() : wrapperRunning(false), env(QProcess::systemEnvironment()) {
   //        SIGNAL(error(QProcess::ProcessError)));
 
   connect(&exec, &Executor::starting, this, &Pass::startingExecuteWrapper);
-  env.append("WSLENV=PASSWORD_STORE_DIR/p");
+  env.append("WSLENV=PASSWORD_STORE_DIR/p:PASSWORD_STORE_GENERATED_LENGTH/"
+             "w:PASSWORD_STORE_CHARACTER_SET/w");
 }
 
 /**
@@ -519,12 +520,18 @@ void Pass::updateEnv() {
   } else {
     env.replaceInStrings(envLen.first(), lenVal);
   }
-  // put PASSWORD_STORE_CHARACTER_SET in env
-  QString charset = passConfig.Characters[passConfig.selected];
-  if (!charset.isEmpty()) {
-    QString charKey = QStringLiteral("PASSWORD_STORE_CHARACTER_SET=");
+  // put PASSWORD_STORE_CHARACTER_SET in env (clamp selected to valid range)
+  int sel = passConfig.selected;
+  if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
+    sel = PasswordConfiguration::ALLCHARS;
+  QString charset = passConfig.Characters[sel];
+  QString charKey = QStringLiteral("PASSWORD_STORE_CHARACTER_SET=");
+  QStringList envChar = env.filter(charKey);
+  if (charset.isEmpty()) {
+    for (const QString &entry : envChar)
+      env.removeAll(entry);
+  } else {
     QString charVal = charKey + charset;
-    QStringList envChar = env.filter(charKey);
     if (envChar.isEmpty()) {
       env.append(charVal);
     } else {

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -500,15 +500,11 @@ void Pass::finished(int id, int exitCode, const QString &out,
 // matching so the '=' anchors the lookup to avoid collisions with longer names.
 void Pass::setEnvVar(const QString &key, const QString &value) {
   Q_ASSERT(key.endsWith('='));
-  QStringList existing = env.filter(key);
-  if (value.isEmpty()) {
-    for (const QString &entry : existing)
-      env.removeAll(entry);
-  } else if (existing.isEmpty()) {
+  const QStringList existing = env.filter(key);
+  for (const QString &entry : std::as_const(existing))
+    env.removeAll(entry);
+  if (!value.isEmpty())
     env.append(key + value);
-  } else {
-    env.replaceInStrings(existing.first(), key + value);
-  }
 }
 
 void Pass::updateEnv() {

--- a/src/pass.h
+++ b/src/pass.h
@@ -220,6 +220,12 @@ protected:
    * @return Random number.
    */
   auto boundedRandom(quint32 bound) -> quint32;
+  /**
+   * @brief Set or remove an environment variable.
+   * @param key Variable name including trailing '='.
+   * @param value New value; empty string removes the variable.
+   */
+  void setEnvVar(const QString &key, const QString &value);
 
   /**
    * @brief Execute wrapper with input.

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1519,15 +1519,17 @@ void tst_util::setEnvVarNoopOnMissingRemove() {
 
 void tst_util::updateEnvSetsExpectedVars() {
   TestPass pass;
+  QTemporaryDir tmpDir;
+  QVERIFY(tmpDir.isValid());
   PassStoreGuard storeGuard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(QStringLiteral("/tmp/test-store"));
+  QtPassSettings::setPassStore(tmpDir.path());
 
   QStringList env = pass.environment();
   QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_DIR=")).size() == 1,
            "updateEnv should set PASSWORD_STORE_DIR");
   QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_DIR="))
                .first()
-               .contains(QStringLiteral("test-store")),
+               .contains(tmpDir.path()),
            "updateEnv should set PASSWORD_STORE_DIR to configured store path");
   QVERIFY2(
       env.filter(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH=")).size() ==
@@ -1540,14 +1542,15 @@ void tst_util::updateEnvSetsExpectedVars() {
 
 void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
   TestPass pass;
-  PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
-  config.selected = PasswordConfiguration::CUSTOM;
-  config.Characters[PasswordConfiguration::CUSTOM] = QString();
-  QtPassSettings::setPasswordConfiguration(config);
+  PasswordConfiguration original = QtPassSettings::getPasswordConfiguration();
   struct ConfigRollback {
     PasswordConfiguration value;
     ~ConfigRollback() { QtPassSettings::setPasswordConfiguration(value); }
-  } rollback{QtPassSettings::getPasswordConfiguration()};
+  } rollback{original};
+
+  PasswordConfiguration config = original;
+  config.selected = PasswordConfiguration::CUSTOM;
+  config.Characters[PasswordConfiguration::CUSTOM] = QString();
   QtPassSettings::setPasswordConfiguration(config);
 
   QStringList env = pass.environment();

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -44,6 +44,14 @@ private:
   };
 
   // Thin subclass that exposes protected members needed by env tests.
+  // NOTE: environment() calls updateEnv(), which adds PASSWORD_STORE_* entries
+  // to the internal env list and forwards it to exec via setEnvironment().
+  // Because Pass::setEnvVar removes all matching entries before appending,
+  // repeated calls to environment() are idempotent for PASSWORD_STORE_* vars.
+  // Tests that call callSetEnvVar() directly work on the same env list, so
+  // any subsequent environment() call will re-run updateEnv() and may
+  // overwrite those entries — use callSetEnvVar() and environment() in the
+  // same test only when the keys don't overlap with PASSWORD_STORE_*.
   class TestPass : public ImitatePass {
   public:
     void callSetEnvVar(const QString &key, const QString &value) {
@@ -1567,16 +1575,20 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
 
 void tst_util::updateEnvWslenvContainsRequiredVars() {
   TestPass pass;
-  QStringList env = pass.environment();
-  QStringList wslenvEntries = env.filter(QStringLiteral("WSLENV="));
-  QVERIFY2(wslenvEntries.size() == 1, "Exactly one WSLENV entry expected");
+  const QStringList env = pass.environment();
+  // Use startsWith to avoid substring false-positives (e.g. MY_WSLENV=).
+  const QStringList wslenvEntries =
+      env.filter(QRegularExpression(QStringLiteral("^WSLENV=")));
+  QVERIFY2(!wslenvEntries.isEmpty(),
+           "At least one WSLENV entry expected after Pass construction");
+  // Verify Pass::Pass() merged all required keys with correct WSL flags.
   const QString wslenv = wslenvEntries.first();
-  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_DIR")),
-           "WSLENV should include PASSWORD_STORE_DIR");
-  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH")),
-           "WSLENV should include PASSWORD_STORE_GENERATED_LENGTH");
-  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
-           "WSLENV should include PASSWORD_STORE_CHARACTER_SET");
+  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_DIR/p")),
+           "WSLENV should include PASSWORD_STORE_DIR/p");
+  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w")),
+           "WSLENV should include PASSWORD_STORE_GENERATED_LENGTH/w");
+  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")),
+           "WSLENV should include PASSWORD_STORE_CHARACTER_SET/w");
 }
 
 QTEST_MAIN(tst_util)

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -530,6 +530,13 @@ void tst_util::createGpgIdFileEmptyKeys() {
 }
 
 void tst_util::generateRandomPassword() {
+  bool origUsePwgen = QtPassSettings::isUsePwgen();
+  QtPassSettings::setUsePwgen(false);
+  struct PwgenRollback {
+    bool value;
+    ~PwgenRollback() { QtPassSettings::setUsePwgen(value); }
+  } pwgenRollback{origUsePwgen};
+
   ImitatePass pass;
   QString charset = "abcdefghijklmnopqrstuvwxyz";
   QString result = pass.generatePassword(10, charset);
@@ -583,6 +590,13 @@ void tst_util::generateRandomPassword() {
 }
 
 void tst_util::boundedRandom() {
+  bool origUsePwgen = QtPassSettings::isUsePwgen();
+  QtPassSettings::setUsePwgen(false);
+  struct PwgenRollback {
+    bool value;
+    ~PwgenRollback() { QtPassSettings::setUsePwgen(value); }
+  } pwgenRollback{origUsePwgen};
+
   ImitatePass pass;
 
   QVector<quint32> counts(10, 0);
@@ -638,6 +652,13 @@ void tst_util::configIsValid() {
   QVERIFY2(tempDir.isValid(), "Temporary directory should be created");
 
   PassStoreGuard guard(QtPassSettings::getPassStore());
+
+  bool origUsePass = QtPassSettings::isUsePass();
+  QtPassSettings::setUsePass(false);
+  struct UsePassRollback {
+    bool value;
+    ~UsePassRollback() { QtPassSettings::setUsePass(value); }
+  } usePassRollback{origUsePass};
 
   // No .gpg-id in this store => config must be invalid.
   QtPassSettings::setPassStore(tempDir.path());

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -43,6 +43,16 @@ private:
     ~PassStoreGuard() { QtPassSettings::setPassStore(original); }
   };
 
+  template <typename T, void (*Setter)(const T &)> struct SettingGuard {
+    T original;
+    SettingGuard(T orig, const T &newVal) : original(std::move(orig)) {
+      Setter(newVal);
+    }
+    ~SettingGuard() { Setter(original); }
+    SettingGuard(const SettingGuard &) = delete;
+    SettingGuard &operator=(const SettingGuard &) = delete;
+  };
+
 private Q_SLOTS:
   void cleanupTestCase();
   void normalizeFolderPath();
@@ -530,12 +540,8 @@ void tst_util::createGpgIdFileEmptyKeys() {
 }
 
 void tst_util::generateRandomPassword() {
-  bool origUsePwgen = QtPassSettings::isUsePwgen();
-  QtPassSettings::setUsePwgen(false);
-  struct PwgenRollback {
-    bool value;
-    ~PwgenRollback() { QtPassSettings::setUsePwgen(value); }
-  } pwgenRollback{origUsePwgen};
+  SettingGuard<bool, QtPassSettings::setUsePwgen> pwgenGuard{
+      QtPassSettings::isUsePwgen(), false};
 
   ImitatePass pass;
   QString charset = "abcdefghijklmnopqrstuvwxyz";
@@ -590,12 +596,8 @@ void tst_util::generateRandomPassword() {
 }
 
 void tst_util::boundedRandom() {
-  bool origUsePwgen = QtPassSettings::isUsePwgen();
-  QtPassSettings::setUsePwgen(false);
-  struct PwgenRollback {
-    bool value;
-    ~PwgenRollback() { QtPassSettings::setUsePwgen(value); }
-  } pwgenRollback{origUsePwgen};
+  SettingGuard<bool, QtPassSettings::setUsePwgen> pwgenGuard{
+      QtPassSettings::isUsePwgen(), false};
 
   ImitatePass pass;
 
@@ -653,12 +655,8 @@ void tst_util::configIsValid() {
 
   PassStoreGuard guard(QtPassSettings::getPassStore());
 
-  bool origUsePass = QtPassSettings::isUsePass();
-  QtPassSettings::setUsePass(false);
-  struct UsePassRollback {
-    bool value;
-    ~UsePassRollback() { QtPassSettings::setUsePass(value); }
-  } usePassRollback{origUsePass};
+  SettingGuard<bool, QtPassSettings::setUsePass> usePassGuard{
+      QtPassSettings::isUsePass(), false};
 
   // No .gpg-id in this store => config must be invalid.
   QtPassSettings::setPassStore(tempDir.path());
@@ -673,13 +671,9 @@ void tst_util::configIsValid() {
   gpgIdFile.write("test@example.com\n");
   gpgIdFile.close();
 
-  QString originalGpgExecutable = QtPassSettings::getGpgExecutable();
-  struct GpgRollback {
-    QString value;
-    ~GpgRollback() { QtPassSettings::setGpgExecutable(value); }
-  } gpgRollback{originalGpgExecutable};
+  SettingGuard<QString, QtPassSettings::setGpgExecutable> gpgGuard{
+      QtPassSettings::getGpgExecutable(), QString()};
 
-  QtPassSettings::setGpgExecutable(QString());
   isValid = Util::configIsValid();
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is missing");

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -43,6 +43,18 @@ private:
     ~PassStoreGuard() { QtPassSettings::setPassStore(original); }
   };
 
+  // Thin subclass that exposes protected members needed by env tests.
+  class TestPass : public ImitatePass {
+  public:
+    void callSetEnvVar(const QString &key, const QString &value) {
+      setEnvVar(key, value);
+    }
+    QStringList environment() {
+      updateEnv();
+      return exec.environment();
+    }
+  };
+
   template <typename T, void (*Setter)(const T &)> struct SettingGuard {
     T original;
     SettingGuard(T orig, const T &newVal) : original(std::move(orig)) {
@@ -127,6 +139,13 @@ private Q_SLOTS:
   void findBinaryInPathWithConstQStringRef();
   void findBinaryInPathEmptyString();
   void findBinaryInPathStringLiteral();
+  void setEnvVarAdds();
+  void setEnvVarUpdates();
+  void setEnvVarRemoves();
+  void setEnvVarNoopOnMissingRemove();
+  void updateEnvSetsExpectedVars();
+  void updateEnvEmptyCustomCharsetFallsBackToAllChars();
+  void updateEnvWslenvContainsRequiredVars();
 };
 
 /**
@@ -1459,6 +1478,102 @@ void tst_util::findBinaryInPathStringLiteral() {
 #else
   QSKIP("Unix-only test");
 #endif
+}
+
+void tst_util::setEnvVarAdds() {
+  TestPass pass;
+  pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("hello"));
+  QStringList env = pass.environment();
+  QVERIFY2(env.contains(QStringLiteral("TEST_KEY=hello")),
+           "setEnvVar should append key=value when absent");
+}
+
+void tst_util::setEnvVarUpdates() {
+  TestPass pass;
+  pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("first"));
+  pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("second"));
+  QStringList env = pass.environment();
+  QVERIFY2(env.contains(QStringLiteral("TEST_KEY=second")),
+           "setEnvVar should update existing entry");
+  QVERIFY2(!env.contains(QStringLiteral("TEST_KEY=first")),
+           "setEnvVar should remove old value");
+  QCOMPARE(env.filter(QStringLiteral("TEST_KEY=")).size(), 1);
+}
+
+void tst_util::setEnvVarRemoves() {
+  TestPass pass;
+  pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("value"));
+  pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QString());
+  QStringList env = pass.environment();
+  QVERIFY2(env.filter(QStringLiteral("TEST_KEY=")).isEmpty(),
+           "setEnvVar with empty value should remove the entry");
+}
+
+void tst_util::setEnvVarNoopOnMissingRemove() {
+  TestPass pass;
+  QStringList before = pass.environment();
+  pass.callSetEnvVar(QStringLiteral("NONEXISTENT_KEY="), QString());
+  QStringList after = pass.environment();
+  QCOMPARE(before, after);
+}
+
+void tst_util::updateEnvSetsExpectedVars() {
+  TestPass pass;
+  PassStoreGuard storeGuard(QtPassSettings::getPassStore());
+  QtPassSettings::setPassStore(QStringLiteral("/tmp/test-store"));
+
+  QStringList env = pass.environment();
+  QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_DIR=")).size() == 1,
+           "updateEnv should set PASSWORD_STORE_DIR");
+  QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_DIR="))
+               .first()
+               .contains(QStringLiteral("test-store")),
+           "updateEnv should set PASSWORD_STORE_DIR to configured store path");
+  QVERIFY2(
+      env.filter(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH=")).size() ==
+          1,
+      "updateEnv should set PASSWORD_STORE_GENERATED_LENGTH");
+  QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_CHARACTER_SET=")).size() ==
+               1,
+           "updateEnv should set PASSWORD_STORE_CHARACTER_SET");
+}
+
+void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
+  TestPass pass;
+  PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
+  config.selected = PasswordConfiguration::CUSTOM;
+  config.Characters[PasswordConfiguration::CUSTOM] = QString();
+  QtPassSettings::setPasswordConfiguration(config);
+  struct ConfigRollback {
+    PasswordConfiguration value;
+    ~ConfigRollback() { QtPassSettings::setPasswordConfiguration(value); }
+  } rollback{QtPassSettings::getPasswordConfiguration()};
+  QtPassSettings::setPasswordConfiguration(config);
+
+  QStringList env = pass.environment();
+  QStringList charsetEntries =
+      env.filter(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="));
+  QVERIFY2(
+      charsetEntries.size() == 1,
+      "PASSWORD_STORE_CHARACTER_SET should be set even when CUSTOM is empty");
+  QString val = charsetEntries.first().mid(
+      QStringLiteral("PASSWORD_STORE_CHARACTER_SET=").size());
+  QVERIFY2(!val.isEmpty(),
+           "charset should fall back to ALLCHARS, not be empty");
+}
+
+void tst_util::updateEnvWslenvContainsRequiredVars() {
+  TestPass pass;
+  QStringList env = pass.environment();
+  QStringList wslenvEntries = env.filter(QStringLiteral("WSLENV="));
+  QVERIFY2(wslenvEntries.size() == 1, "Exactly one WSLENV entry expected");
+  const QString wslenv = wslenvEntries.first();
+  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_DIR")),
+           "WSLENV should include PASSWORD_STORE_DIR");
+  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH")),
+           "WSLENV should include PASSWORD_STORE_GENERATED_LENGTH");
+  QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
+           "WSLENV should include PASSWORD_STORE_CHARACTER_SET");
 }
 
 QTEST_MAIN(tst_util)


### PR DESCRIPTION
## **User description**
<!-- kody-pr-summary:start -->
This pull request improves the integration with the `pass` command-line utility by:

*   **Passing Password Generation Settings to `pass`:** `QtPass` now sets the `PASSWORD_STORE_GENERATED_LENGTH` and `PASSWORD_STORE_CHARACTER_SET` environment variables when invoking the `pass` binary. This ensures that `pass` uses the password generation length and character set configured within `QtPass` when generating new passwords.
*   **Disabling `pass`-managed UI Controls:** When the `pass` backend is selected, the password generation configuration controls within `QtPass`'s settings (including password length, character template selector, and specific character rule checkboxes) are now disabled and greyed out. This visually indicates that these settings are managed by the `pass` binary itself, preventing redundant configuration and potential conflicts.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-generation parameters are exported to external backends; process environment can be inspected for verification.

* **Bug Fixes**
  * Password-generation UI reliably enables/disables when switching backends.
  * Environment handling now merges/deduplicates relevant variables, removes empty entries, and falls back to a full charset when a custom charset is empty.

* **Tests**
  * Tests added for environment-variable composition, updates, removal behavior, and automatic settings restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Pass now uses the configured password settings, and pass mode hides controls it manages itself**

### What Changed
- Generated passwords now use the saved length and character set when the pass backend is selected
- Password settings are now passed into the WSL environment so they work when pass runs there
- If a custom character set is empty or invalid, the app falls back to a usable character set instead of leaving password generation broken
- When pass is selected, password length and character-set controls are disabled and greyed out so users don’t change settings that pass controls
- Added tests for environment updates, charset fallback, and settings behavior

### Impact
`✅ Pass-generated passwords match the saved settings`
`✅ Fewer broken password generations with empty custom character sets`
`✅ Clearer pass mode settings with disabled unsupported controls`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=tlLOx30yMXgZ8TQeiCz9Cy_q0tj59Hglg4e7ETzGE2E&org=IJHack)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
