### PR TITLE
fix: clear stale selection and update proxy filter on profile change

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -905,9 +905,10 @@ void MainWindow::on_profileBox_currentTextChanged(const QString &name) {
 
   QtPassSettings::getPass()->updateEnv();
 
-  ui->treeView->selectionModel()->clear();
+  proxyModel.setStore(QtPassSettings::getPassStore());
   ui->treeView->setRootIndex(proxyModel.mapFromSource(
       model.setRootPath(QtPassSettings::getPassStore())));
+  ui->treeView->setCurrentIndex(QModelIndex());
 
   ui->actionEdit->setEnabled(false);
   ui->actionDelete->setEnabled(false);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -301,9 +301,11 @@ void MainWindow::config() {
       applyWindowFlagsSettings();
 
       updateProfileBox();
-      proxyModel.setStore(QtPassSettings::getPassStore());
-      ui->treeView->setRootIndex(proxyModel.mapFromSource(
-          model.setRootPath(QtPassSettings::getPassStore())));
+      const QString passStore = QtPassSettings::getPassStore();
+      proxyModel.setStore(passStore);
+      ui->treeView->setRootIndex(
+          proxyModel.mapFromSource(model.setRootPath(passStore)));
+      deselect();
       ui->treeView->setCurrentIndex(QModelIndex());
 
       if (m_qtPass->isFreshStart() && !Util::configIsValid()) {
@@ -911,10 +913,8 @@ void MainWindow::on_profileBox_currentTextChanged(const QString &name) {
   proxyModel.setStore(passStore);
   ui->treeView->setRootIndex(
       proxyModel.mapFromSource(model.setRootPath(passStore)));
+  deselect();
   ui->treeView->setCurrentIndex(QModelIndex());
-
-  ui->actionEdit->setEnabled(false);
-  ui->actionDelete->setEnabled(false);
 }
 
 /**

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -301,8 +301,10 @@ void MainWindow::config() {
       applyWindowFlagsSettings();
 
       updateProfileBox();
+      proxyModel.setStore(QtPassSettings::getPassStore());
       ui->treeView->setRootIndex(proxyModel.mapFromSource(
           model.setRootPath(QtPassSettings::getPassStore())));
+      ui->treeView->setCurrentIndex(QModelIndex());
 
       if (m_qtPass->isFreshStart() && !Util::configIsValid()) {
         config();
@@ -905,9 +907,10 @@ void MainWindow::on_profileBox_currentTextChanged(const QString &name) {
 
   QtPassSettings::getPass()->updateEnv();
 
-  proxyModel.setStore(QtPassSettings::getPassStore());
-  ui->treeView->setRootIndex(proxyModel.mapFromSource(
-      model.setRootPath(QtPassSettings::getPassStore())));
+  const QString passStore = QtPassSettings::getPassStore();
+  proxyModel.setStore(passStore);
+  ui->treeView->setRootIndex(
+      proxyModel.mapFromSource(model.setRootPath(passStore)));
   ui->treeView->setCurrentIndex(QModelIndex());
 
   ui->actionEdit->setEnabled(false);

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -98,6 +98,11 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
   store = std::move(passStore);
 }
 
+void StoreModel::setStore(const QString &passStore) {
+  store = passStore;
+  invalidateFilter();
+}
+
 /**
  * @brief StoreModel::data don't show the .gpg at the end of a file.
  * @param index

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -65,6 +65,13 @@ public:
   void setModelAndStore(QFileSystemModel *sourceModel, QString passStore);
 
   /**
+   * @brief Update the store path used for filtering without changing the source
+   * model.
+   * @param passStore New root path of password store.
+   */
+  void setStore(const QString &passStore);
+
+  /**
    * @brief Get display data for index.
    * @param index Model index.
    * @param role Data role (e.g., Qt::DisplayRole).


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request implements the following changes to improve the user experience when switching profiles:

*   **Updates Proxy Filter on Profile Change:** When a user changes the active profile, the proxy model's filter is now explicitly updated with the new password store path. This ensures that the tree view correctly displays and filters items relevant to the newly selected profile, preventing stale data from being shown.
*   **Clears Tree View Selection:** Upon a profile change, any previously selected item in the tree view is now deselected, providing a clean and unambiguous state for the newly loaded profile.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store switching now updates the view more directly, improving responsiveness when changing profiles.

* **Bug Fixes**
  * Fixed inconsistent tree selection and edit/delete enablement when switching stores or reloading configuration; selection is now reliably cleared and UI state reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->