### PR TITLE
fix: show user-friendly error when GPG key is expired or invalid

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -129,7 +129,8 @@ void ImitatePass::Insert(QString file, QString newValue, bool overwrite) {
                      "file missing or invalid."));
     return;
   }
-  QStringList args = {"--batch", "-eq", "--output", pgpg(file)};
+  QStringList args = {"--batch", "--status-fd", "2",
+                      "-eq",     "--output",    pgpg(file)};
   for (auto &r : recipients) {
     args.append("-r");
     args.append(r);

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -512,7 +512,8 @@ void Pass::finished(int id, int exitCode, const QString &out,
         // Strip machine-readable [GNUPG:] status lines before showing raw
         // output; they are only useful for detection, not for display.
         QStringList humanLines;
-        for (const QString &line : err.split('\n')) {
+        for (QString line : err.split('\n')) {
+          line.remove('\r');
           if (!line.startsWith(QLatin1String("[GNUPG:]")))
             humanLines.append(line);
         }

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -449,12 +449,13 @@ auto Pass::listKeys(const QString &keystring, bool secret) -> QList<UserInfo> {
  */
 auto gpgErrorMessage(const QString &err) -> QString {
   // Machine-readable status tokens added by --status-fd 2
-  if (err.contains(QStringLiteral("[GNUPG:] KEY_EXPIRED")))
+  if (err.contains(QStringLiteral("[GNUPG:] KEYEXPIRED")) ||
+      err.contains(QStringLiteral("[GNUPG:] INV_RECP 5 ")))
     return QCoreApplication::translate("Pass",
                                        "Encryption failed: GPG key has expired."
                                        " Please renew or replace it.");
-  if (err.contains(QStringLiteral("[GNUPG:] KEY_REVOKED")) ||
-      err.contains(QStringLiteral("[GNUPG:] REVKEYSIG")))
+  if (err.contains(QStringLiteral("[GNUPG:] KEYREVOKED")) ||
+      err.contains(QStringLiteral("[GNUPG:] INV_RECP 4 ")))
     return QCoreApplication::translate(
         "Pass", "Encryption failed: GPG key has been revoked.");
   if (err.contains(QStringLiteral("[GNUPG:] NO_PUBKEY")) ||

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -5,6 +5,7 @@
 #include "helpers.h"
 #include "qtpasssettings.h"
 #include "util.h"
+#include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
 #include <QProcess>
@@ -436,6 +437,61 @@ auto Pass::listKeys(const QString &keystring, bool secret) -> QList<UserInfo> {
 }
 
 /**
+ * @brief Maps GPG stderr (which may include --status-fd 2 tokens) to a
+ * user-friendly encryption error string.
+ *
+ * Checked in order: machine-readable [GNUPG:] status tokens first (locale-
+ * independent), then case-insensitive substring fallbacks for GPG builds that
+ * don't emit status tokens.
+ *
+ * @param err Raw stderr from GPG
+ * @return Translated human-readable error, or empty string if not recognised
+ */
+auto gpgErrorMessage(const QString &err) -> QString {
+  // Machine-readable status tokens added by --status-fd 2
+  if (err.contains(QStringLiteral("[GNUPG:] KEY_EXPIRED")))
+    return QCoreApplication::translate("Pass",
+                                       "Encryption failed: GPG key has expired."
+                                       " Please renew or replace it.");
+  if (err.contains(QStringLiteral("[GNUPG:] KEY_REVOKED")) ||
+      err.contains(QStringLiteral("[GNUPG:] REVKEYSIG")))
+    return QCoreApplication::translate(
+        "Pass", "Encryption failed: GPG key has been revoked.");
+  if (err.contains(QStringLiteral("[GNUPG:] NO_PUBKEY")) ||
+      err.contains(QStringLiteral("[GNUPG:] INV_RECP")))
+    return QCoreApplication::translate(
+        "Pass", "Encryption failed: recipient GPG key not found or invalid."
+                " Check that the key ID in .gpg-id is correct and imported.");
+  if (err.contains(QStringLiteral("[GNUPG:] FAILURE")))
+    return QCoreApplication::translate(
+        "Pass", "Encryption failed. Check that your GPG key is valid.");
+
+  // Locale-dependent fallbacks for GPG versions / configurations that don't
+  // emit status tokens
+  const QString lower = err.toLower();
+  if (lower.contains(QLatin1String("key has expired")) ||
+      lower.contains(QLatin1String("key expired")))
+    return QCoreApplication::translate("Pass",
+                                       "Encryption failed: GPG key has expired."
+                                       " Please renew or replace it.");
+  if (lower.contains(QLatin1String("key has been revoked")) ||
+      lower.contains(QLatin1String("revoked")))
+    return QCoreApplication::translate(
+        "Pass", "Encryption failed: GPG key has been revoked.");
+  if (lower.contains(QLatin1String("no public key")) ||
+      lower.contains(QLatin1String("unusable public key")) ||
+      lower.contains(QLatin1String("no secret key")))
+    return QCoreApplication::translate(
+        "Pass", "Encryption failed: recipient GPG key not found or invalid."
+                " Check that the key ID in .gpg-id is correct and imported.");
+  if (lower.contains(QLatin1String("encryption failed")))
+    return QCoreApplication::translate(
+        "Pass", "Encryption failed. Check that your GPG key is valid.");
+
+  return {};
+}
+
+/**
  * @brief Pass::processFinished reemits specific signal based on what process
  * has finished
  * @param id    id of Pass process that was scheduled and finished
@@ -449,6 +505,23 @@ void Pass::finished(int id, int exitCode, const QString &out,
                     const QString &err) {
   auto pid = static_cast<PROCESS>(id);
   if (exitCode != 0) {
+    if (pid == PASS_INSERT) {
+      const QString friendly = gpgErrorMessage(err);
+      if (!friendly.isEmpty()) {
+        // Strip machine-readable [GNUPG:] status lines before showing raw
+        // output; they are only useful for detection, not for display.
+        QStringList humanLines;
+        for (const QString &line : err.split('\n')) {
+          if (!line.startsWith(QLatin1String("[GNUPG:]")))
+            humanLines.append(line);
+        }
+        const QString humanErr = humanLines.join('\n').trimmed();
+        emit processErrorExit(exitCode, humanErr.isEmpty()
+                                            ? friendly
+                                            : friendly + "\n\n" + humanErr);
+        return;
+      }
+    }
     emit processErrorExit(exitCode, err);
     return;
   }

--- a/src/pass.h
+++ b/src/pass.h
@@ -332,4 +332,18 @@ signals:
   void finishedGenerateGPGKeys(const QString &, const QString &);
 };
 
+/**
+ * @brief Maps GPG stderr (which may include --status-fd 2 tokens) to a
+ * translated user-friendly encryption error string.
+ *
+ * Checks machine-readable [GNUPG:] status tokens first (locale-independent),
+ * then falls back to case-insensitive substring matching for GPG builds that
+ * do not emit status tokens. Returns an empty string when no known pattern
+ * matches.
+ *
+ * Declared here so it can be exercised by unit tests without linking the full
+ * Pass object.
+ */
+QString gpgErrorMessage(const QString &err);
+
 #endif // SRC_PASS_H_

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -154,6 +154,17 @@ private Q_SLOTS:
   void updateEnvSetsExpectedVars();
   void updateEnvEmptyCustomCharsetFallsBackToAllChars();
   void updateEnvWslenvContainsRequiredVars();
+  void gpgErrorMessageKeyExpiredStatusToken();
+  void gpgErrorMessageKeyRevokedStatusToken();
+  void gpgErrorMessageNoPubkeyStatusToken();
+  void gpgErrorMessageInvRecpStatusToken();
+  void gpgErrorMessageFailureStatusToken();
+  void gpgErrorMessageKeyExpiredFallback();
+  void gpgErrorMessageRevokedFallback();
+  void gpgErrorMessageNoPubkeyFallback();
+  void gpgErrorMessageEncryptionFailedFallback();
+  void gpgErrorMessageUnknownReturnsEmpty();
+  void gpgErrorMessageStatusTokenTakesPriorityOverFallback();
 };
 
 /**
@@ -1589,6 +1600,109 @@ void tst_util::updateEnvWslenvContainsRequiredVars() {
            "WSLENV should include PASSWORD_STORE_GENERATED_LENGTH/w");
   QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")),
            "WSLENV should include PASSWORD_STORE_CHARACTER_SET/w");
+}
+
+// --- gpgErrorMessage tests ---
+
+void tst_util::gpgErrorMessageKeyExpiredStatusToken() {
+  QString err = "[GNUPG:] KEY_EXPIRED 1234567890\n"
+                "gpg: key DEADBEEF: key has expired\n"
+                "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise KEY_EXPIRED status token");
+  QVERIFY2(msg.contains("expired", Qt::CaseInsensitive),
+           qPrintable("Expected 'expired' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageKeyRevokedStatusToken() {
+  QString err = "[GNUPG:] KEY_REVOKED\n"
+                "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise KEY_REVOKED status token");
+  QVERIFY2(msg.contains("revoked", Qt::CaseInsensitive),
+           qPrintable("Expected 'revoked' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageNoPubkeyStatusToken() {
+  QString err = "[GNUPG:] NO_PUBKEY DEADBEEFDEADBEEF\n"
+                "gpg: DEADBEEF: skipped: No public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise NO_PUBKEY status token");
+  QVERIFY2(msg.contains("not found", Qt::CaseInsensitive) ||
+               msg.contains("invalid", Qt::CaseInsensitive),
+           qPrintable("Expected 'not found' or 'invalid' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageInvRecpStatusToken() {
+  QString err = "[GNUPG:] INV_RECP 10 DEADBEEF\n"
+                "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise INV_RECP status token");
+  QVERIFY2(msg.contains("not found", Qt::CaseInsensitive) ||
+               msg.contains("invalid", Qt::CaseInsensitive),
+           qPrintable("Expected 'not found' or 'invalid' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageFailureStatusToken() {
+  QString err = "[GNUPG:] FAILURE encrypt 67108949";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise FAILURE status token");
+  QVERIFY2(msg.contains("failed", Qt::CaseInsensitive),
+           qPrintable("Expected 'failed' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageKeyExpiredFallback() {
+  QString err = "gpg: key DEADBEEF: key has expired\n"
+                "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise 'key has expired' fallback");
+  QVERIFY2(msg.contains("expired", Qt::CaseInsensitive),
+           qPrintable("Expected 'expired' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageRevokedFallback() {
+  QString err = "gpg: key DEADBEEF: key has been revoked\n"
+                "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise 'key has been revoked' fallback");
+  QVERIFY2(msg.contains("revoked", Qt::CaseInsensitive),
+           qPrintable("Expected 'revoked' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageNoPubkeyFallback() {
+  QString err = "gpg: DEADBEEF: skipped: No public key\n"
+                "gpg: [stdin]: encryption failed: No public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(), "Should recognise 'No public key' fallback");
+  QVERIFY2(msg.contains("not found", Qt::CaseInsensitive) ||
+               msg.contains("invalid", Qt::CaseInsensitive),
+           qPrintable("Expected 'not found' or 'invalid' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageEncryptionFailedFallback() {
+  QString err = "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(!msg.isEmpty(),
+           "Should recognise generic 'encryption failed' fallback");
+  QVERIFY2(msg.contains("failed", Qt::CaseInsensitive),
+           qPrintable("Expected 'failed' in: " + msg));
+}
+
+void tst_util::gpgErrorMessageUnknownReturnsEmpty() {
+  QString err = "some unrelated process error output";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(msg.isEmpty(),
+           "Should return empty string for unrecognised GPG output");
+}
+
+void tst_util::gpgErrorMessageStatusTokenTakesPriorityOverFallback() {
+  // KEY_EXPIRED token present alongside a generic "encryption failed" line —
+  // the specific expired message should be returned, not the generic fallback.
+  QString err = "[GNUPG:] KEY_EXPIRED 1234567890\n"
+                "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msg = gpgErrorMessage(err);
+  QVERIFY2(msg.contains("expired", Qt::CaseInsensitive),
+           "KEY_EXPIRED token should take priority and mention 'expired'");
 }
 
 QTEST_MAIN(tst_util)

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1605,20 +1605,20 @@ void tst_util::updateEnvWslenvContainsRequiredVars() {
 // --- gpgErrorMessage tests ---
 
 void tst_util::gpgErrorMessageKeyExpiredStatusToken() {
-  QString err = "[GNUPG:] KEY_EXPIRED 1234567890\n"
+  QString err = "[GNUPG:] KEYEXPIRED 1234567890\n"
                 "gpg: key DEADBEEF: key has expired\n"
                 "gpg: [stdin]: encryption failed: Unusable public key";
   QString msg = gpgErrorMessage(err);
-  QVERIFY2(!msg.isEmpty(), "Should recognise KEY_EXPIRED status token");
+  QVERIFY2(!msg.isEmpty(), "Should recognise KEYEXPIRED status token");
   QVERIFY2(msg.contains("expired", Qt::CaseInsensitive),
            qPrintable("Expected 'expired' in: " + msg));
 }
 
 void tst_util::gpgErrorMessageKeyRevokedStatusToken() {
-  QString err = "[GNUPG:] KEY_REVOKED\n"
+  QString err = "[GNUPG:] KEYREVOKED\n"
                 "gpg: [stdin]: encryption failed: Unusable public key";
   QString msg = gpgErrorMessage(err);
-  QVERIFY2(!msg.isEmpty(), "Should recognise KEY_REVOKED status token");
+  QVERIFY2(!msg.isEmpty(), "Should recognise KEYREVOKED status token");
   QVERIFY2(msg.contains("revoked", Qt::CaseInsensitive),
            qPrintable("Expected 'revoked' in: " + msg));
 }
@@ -1634,13 +1634,30 @@ void tst_util::gpgErrorMessageNoPubkeyStatusToken() {
 }
 
 void tst_util::gpgErrorMessageInvRecpStatusToken() {
-  QString err = "[GNUPG:] INV_RECP 10 DEADBEEF\n"
-                "gpg: [stdin]: encryption failed: Unusable public key";
-  QString msg = gpgErrorMessage(err);
-  QVERIFY2(!msg.isEmpty(), "Should recognise INV_RECP status token");
-  QVERIFY2(msg.contains("not found", Qt::CaseInsensitive) ||
-               msg.contains("invalid", Qt::CaseInsensitive),
-           qPrintable("Expected 'not found' or 'invalid' in: " + msg));
+  // reason code 5 = expired
+  QString errExpired = "[GNUPG:] INV_RECP 5 DEADBEEF\n"
+                       "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msgExpired = gpgErrorMessage(errExpired);
+  QVERIFY2(!msgExpired.isEmpty(), "Should recognise INV_RECP 5 (expired)");
+  QVERIFY2(msgExpired.contains("expired", Qt::CaseInsensitive),
+           qPrintable("Expected 'expired' for INV_RECP 5: " + msgExpired));
+
+  // reason code 4 = revoked
+  QString errRevoked = "[GNUPG:] INV_RECP 4 DEADBEEF\n"
+                       "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msgRevoked = gpgErrorMessage(errRevoked);
+  QVERIFY2(!msgRevoked.isEmpty(), "Should recognise INV_RECP 4 (revoked)");
+  QVERIFY2(msgRevoked.contains("revoked", Qt::CaseInsensitive),
+           qPrintable("Expected 'revoked' for INV_RECP 4: " + msgRevoked));
+
+  // generic reason code
+  QString errGeneric = "[GNUPG:] INV_RECP 10 DEADBEEF\n"
+                       "gpg: [stdin]: encryption failed: Unusable public key";
+  QString msgGeneric = gpgErrorMessage(errGeneric);
+  QVERIFY2(!msgGeneric.isEmpty(), "Should recognise INV_RECP status token");
+  QVERIFY2(msgGeneric.contains("not found", Qt::CaseInsensitive) ||
+               msgGeneric.contains("invalid", Qt::CaseInsensitive),
+           qPrintable("Expected 'not found' or 'invalid' in: " + msgGeneric));
 }
 
 void tst_util::gpgErrorMessageFailureStatusToken() {
@@ -1696,13 +1713,13 @@ void tst_util::gpgErrorMessageUnknownReturnsEmpty() {
 }
 
 void tst_util::gpgErrorMessageStatusTokenTakesPriorityOverFallback() {
-  // KEY_EXPIRED token present alongside a generic "encryption failed" line —
+  // KEYEXPIRED token present alongside a generic "encryption failed" line —
   // the specific expired message should be returned, not the generic fallback.
-  QString err = "[GNUPG:] KEY_EXPIRED 1234567890\n"
+  QString err = "[GNUPG:] KEYEXPIRED 1234567890\n"
                 "gpg: [stdin]: encryption failed: Unusable public key";
   QString msg = gpgErrorMessage(err);
   QVERIFY2(msg.contains("expired", Qt::CaseInsensitive),
-           "KEY_EXPIRED token should take priority and mention 'expired'");
+           "KEYEXPIRED token should take priority and mention 'expired'");
 }
 
 QTEST_MAIN(tst_util)


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request improves the user experience by providing more descriptive and user-friendly error messages when GPG encryption fails.

Key changes include:
- **Enhanced GPG Error Parsing**: The application now explicitly requests machine-readable status output from GPG using the `--status-fd 2` flag during password insertion.
- **User-Friendly Error Translation**: A new function `gpgErrorMessage` has been introduced to parse GPG's standard error output. It prioritizes machine-readable `[GNUPG:]` status tokens to identify specific issues like expired, revoked, or missing GPG keys.
- **Fallback for Older GPG Versions**: For GPG versions or configurations that do not emit status tokens, the function includes case-insensitive substring matching to still provide translated error messages.
- **Improved Error Display**: When an encryption error occurs during password insertion, the application now displays a clear, translated message to the user. It also cleans up the raw GPG error output by stripping internal status lines, making any additional GPG details more readable if presented.

This ensures that users receive actionable feedback when GPG keys are expired, revoked, or otherwise invalid, rather than cryptic technical messages.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encryption now returns translated, user-friendly error messages for specific issues (expired/revoked keys, missing public keys, general encryption failures).

* **Improvements**
  * Error reporting prioritizes machine-readable status when present and cleans noisy output before display.

* **Tests**
  * Added comprehensive unit tests covering status-token parsing, fallback text matching, precedence, and unknown-output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->