### PR TITLE
fix: pass QModelIndex by const ref, reorder MIME check, fix camelCase typo

### DIFF
--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -81,7 +81,7 @@ auto QtPassSettings::getPasswordConfiguration() -> PasswordConfiguration {
   }
   config.selected = static_cast<PasswordConfiguration::characterSet>(
       getInstance()
-          ->value(SettingsConstants::passwordCharsselection, 0)
+          ->value(SettingsConstants::passwordCharsSelection, 0)
           .toInt());
   config.Characters[PasswordConfiguration::CUSTOM] =
       getInstance()
@@ -692,9 +692,9 @@ void QtPassSettings::setUseSymbols(const bool &useSymbols) {
 void QtPassSettings::setPasswordLength(const int &passwordLength) {
   getInstance()->setValue(SettingsConstants::passwordLength, passwordLength);
 }
-void QtPassSettings::setPasswordCharsselection(
+void QtPassSettings::setPasswordCharsSelection(
     const int &passwordCharsSelection) {
-  getInstance()->setValue(SettingsConstants::passwordCharsselection,
+  getInstance()->setValue(SettingsConstants::passwordCharsSelection,
                           passwordCharsSelection);
 }
 void QtPassSettings::setPasswordChars(const QString &passwordChars) {

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -94,7 +94,7 @@ auto QtPassSettings::getPasswordConfiguration() -> PasswordConfiguration {
 void QtPassSettings::setPasswordConfiguration(
     const PasswordConfiguration &config) {
   getInstance()->setValue(SettingsConstants::passwordLength, config.length);
-  getInstance()->setValue(SettingsConstants::passwordCharsselection,
+  getInstance()->setValue(SettingsConstants::passwordCharsSelection,
                           config.selected);
   getInstance()->setValue(SettingsConstants::passwordChars,
                           config.Characters[PasswordConfiguration::CUSTOM]);

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -695,7 +695,7 @@ public:
    * @brief Save password character selection mode.
    * @param passwordCharsSelection Password character selection mode.
    */
-  static void setPasswordCharsselection(const int &passwordCharsSelection);
+  static void setPasswordCharsSelection(const int &passwordCharsSelection);
   /**
    * @brief Save custom password characters.
    * @param passwordChars Custom characters used for password generation.

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -71,7 +71,7 @@ const QString SettingsConstants::avoidNumbers = "avoidNumbers";
 const QString SettingsConstants::lessRandom = "lessRandom";
 const QString SettingsConstants::useSymbols = "useSymbols";
 const QString SettingsConstants::passwordLength = "passwordLength";
-const QString SettingsConstants::passwordCharsselection =
+const QString SettingsConstants::passwordCharsSelection =
     "passwordCharsselection";
 const QString SettingsConstants::passwordChars = "passwordChars";
 const QString SettingsConstants::useTrayIcon = "useTrayIcon";

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -72,7 +72,7 @@ const QString SettingsConstants::lessRandom = "lessRandom";
 const QString SettingsConstants::useSymbols = "useSymbols";
 const QString SettingsConstants::passwordLength = "passwordLength";
 const QString SettingsConstants::passwordCharsSelection =
-    "passwordCharsselection";
+    "passwordCharsselection"; // stored key kept lowercase for backward compat
 const QString SettingsConstants::passwordChars = "passwordChars";
 const QString SettingsConstants::useTrayIcon = "useTrayIcon";
 const QString SettingsConstants::hideOnClose = "hideOnClose";

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -64,7 +64,7 @@ public:
   static const QString lessRandom;
   static const QString useSymbols;
   static const QString passwordLength;
-  static const QString passwordCharsselection;
+  static const QString passwordCharsSelection;
   static const QString passwordChars;
   static const QString useTrayIcon;
   static const QString hideOnClose;

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -101,7 +101,7 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
 
 void StoreModel::setStore(const QString &passStore) {
   store = passStore;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
   beginFilterChange();
 #else
   invalidateFilter();

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -216,17 +216,25 @@ auto StoreModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
   Q_UNUSED(row)
 #endif
 
-  if (!data->hasFormat("application/vnd+qtpass.dragAndDropInfoPasswordStore")) {
+  if (data == nullptr ||
+      !data->hasFormat("application/vnd+qtpass.dragAndDropInfoPasswordStore")) {
+    return false;
+  }
+
+  QByteArray encodedData =
+      data->data("application/vnd+qtpass.dragAndDropInfoPasswordStore");
+  if (encodedData.isEmpty()) {
+    return false;
+  }
+  QDataStream stream(&encodedData, QIODevice::ReadOnly);
+  dragAndDropInfoPasswordStore info;
+  stream >> info;
+  if (stream.status() != QDataStream::Ok) {
     return false;
   }
 
   QModelIndex useIndex =
       this->index(parent.row(), parent.column(), parent.parent());
-  QByteArray encodedData =
-      data->data("application/vnd+qtpass.dragAndDropInfoPasswordStore");
-  QDataStream stream(&encodedData, QIODevice::ReadOnly);
-  dragAndDropInfoPasswordStore info;
-  stream >> info;
 
   if (column > 0) {
     return false;
@@ -269,10 +277,15 @@ auto StoreModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
   }
   QByteArray encodedData =
       data->data("application/vnd+qtpass.dragAndDropInfoPasswordStore");
-
+  if (encodedData.isEmpty()) {
+    return false;
+  }
   QDataStream stream(&encodedData, QIODevice::ReadOnly);
   dragAndDropInfoPasswordStore info;
   stream >> info;
+  if (stream.status() != QDataStream::Ok) {
+    return false;
+  }
   QModelIndex destIndex =
       this->index(parent.row(), parent.column(), parent.parent());
   QFileInfo destFileinfo = fs->fileInfo(mapToSource(destIndex));

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -101,9 +101,8 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
 
 void StoreModel::setStore(const QString &passStore) {
   store = passStore;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   beginFilterChange();
-  endFilterChange();
 #else
   invalidateFilter();
 #endif

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -101,11 +101,10 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
 
 void StoreModel::setStore(const QString &passStore) {
   store = passStore;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-  beginFilterChange();
-#else
+  QT_WARNING_PUSH
+  QT_WARNING_DISABLE_DEPRECATED
   invalidateFilter();
-#endif
+  QT_WARNING_POP
 }
 
 /**

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -57,7 +57,7 @@ auto StoreModel::filterAcceptsRow(int sourceRow,
  * @param index
  * @return
  */
-auto StoreModel::showThis(const QModelIndex index) const -> bool {
+auto StoreModel::showThis(const QModelIndex &index) const -> bool {
   bool retVal = false;
   if (fs == nullptr) {
     return retVal;
@@ -218,6 +218,10 @@ auto StoreModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
   Q_UNUSED(row)
 #endif
 
+  if (!data->hasFormat("application/vnd+qtpass.dragAndDropInfoPasswordStore")) {
+    return false;
+  }
+
   QModelIndex useIndex =
       this->index(parent.row(), parent.column(), parent.parent());
   QByteArray encodedData =
@@ -225,9 +229,6 @@ auto StoreModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
   QDataStream stream(&encodedData, QIODevice::ReadOnly);
   dragAndDropInfoPasswordStore info;
   stream >> info;
-  if (!data->hasFormat("application/vnd+qtpass.dragAndDropInfoPasswordStore")) {
-    return false;
-  }
 
   if (column > 0) {
     return false;

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -55,7 +55,7 @@ public:
    * @param index Model index to check.
    * @return true if index should be visible.
    */
-  [[nodiscard]] auto showThis(const QModelIndex) const -> bool;
+  [[nodiscard]] auto showThis(const QModelIndex &index) const -> bool;
 
   /**
    * @brief Initialize model with source model and store path.

--- a/tests/auto/passwordconfig/tst_passwordconfig.cpp
+++ b/tests/auto/passwordconfig/tst_passwordconfig.cpp
@@ -21,7 +21,7 @@ private Q_SLOTS:
 void tst_passwordconfig::initTestCase() {
   // Reset any leftover test settings to ensure clean state
   QtPassSettings::setPasswordChars(QString());
-  QtPassSettings::setPasswordCharsselection(PasswordConfiguration::ALLCHARS);
+  QtPassSettings::setPasswordCharsSelection(PasswordConfiguration::ALLCHARS);
 }
 
 void tst_passwordconfig::passwordConfigurationDefaults() {
@@ -36,19 +36,19 @@ void tst_passwordconfig::passwordConfigurationDefaults() {
 void tst_passwordconfig::passwordConfigurationSetters() {
   // Reset any previous test settings to ensure clean state
   QtPassSettings::setPasswordChars(QString());
-  QtPassSettings::setPasswordCharsselection(PasswordConfiguration::ALLCHARS);
+  QtPassSettings::setPasswordCharsSelection(PasswordConfiguration::ALLCHARS);
 
   QtPassSettings::setPasswordLength(24);
-  QtPassSettings::setPasswordCharsselection(
+  QtPassSettings::setPasswordCharsSelection(
       PasswordConfiguration::ALPHANUMERIC);
-  QtPassSettings::setPasswordCharsselection(3);
+  QtPassSettings::setPasswordCharsSelection(3);
 
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(config.length, 24);
   QCOMPARE(config.selected, 3);
 
   // Reset after test
-  QtPassSettings::setPasswordCharsselection(PasswordConfiguration::ALLCHARS);
+  QtPassSettings::setPasswordCharsSelection(PasswordConfiguration::ALLCHARS);
   QtPassSettings::setPasswordChars(QString());
 }
 

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -454,7 +454,7 @@ void tst_settings::setAndGetDialogMaximized() {
 }
 
 void tst_settings::setAndGetPasswordCharsSelection() {
-  QtPassSettings::setPasswordCharsselection(
+  QtPassSettings::setPasswordCharsSelection(
       PasswordConfiguration::ALPHABETICAL);
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(config.selected, PasswordConfiguration::ALPHABETICAL);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several code quality improvements and a typo fix:

*   **Fixes camelCase typo:** Corrected the setting key and related function names from `passwordCharsselection` to `passwordCharsSelection` for consistency.
*   **Optimizes `QModelIndex` passing:** The `showThis` method in `StoreModel` now passes `QModelIndex` by `const&` instead of by value, improving efficiency.
*   **Enhances MIME data handling robustness:** In `StoreModel::canDropMimeData`, the check for the required MIME format (`application/vnd+qtpass.dragAndDropInfoPasswordStore`) is now performed before attempting to access the data, preventing potential issues if the format is not present.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop validation to avoid processing invalid payloads.
  * Fixed persistence for the password character-set selection so changes reliably save and load.

* **Refactor**
  * Renamed the password-character-selection API for consistent naming.
  * Adjusted a model method to avoid unnecessary copying and improve performance.

* **Tests**
  * Updated tests to align with the renamed API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->