### PR TITLE
fix: add missing Turkish translations and correct German typos

### DIFF
--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -129,7 +129,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
         <source>Exclude capital letters</source>
-        <translation>Großbuchstaben Ausschließen</translation>
+        <translation>Großbuchstaben ausschließen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="453"/>
@@ -613,7 +613,7 @@ Sie können die Benutzerliste nicht ändern!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation>Schreibzugrif auf .gpg-id fehlgeschlagen.</translation>
+        <translation>Schreibzugriff auf .gpg-id fehlgeschlagen.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="274"/>
@@ -731,7 +731,7 @@ Hiermit können keine neu hinzugefügefügten Kennwörter entschlüsselt werden!
     <message>
         <location filename="../src/keygendialog.ui" line="210"/>
         <source>Repeat pass</source>
-        <translation>Repetier pass</translation>
+        <translation>Wiederhole Passphrase</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="227"/>
@@ -1542,7 +1542,7 @@ Fortfahren?</translation>
     <message>
         <location filename="../src/usersdialog.ui" line="20"/>
         <source>Read access users</source>
-        <translation>Benutzer mit Lese-Zugrif</translation>
+        <translation>Benutzer mit Lese-Zugriff</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="45"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -191,12 +191,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="592"/>
         <source>Enable content search (pass grep)</source>
-        <translation type="unfinished"></translation>
+        <translation>İçerik aramayı etkinleştir (pass grep)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="595"/>
         <source>Allow searching inside password file contents. Requires decrypting every file and can be slow on large stores.</source>
-        <translation type="unfinished"></translation>
+        <translation>Parola dosyası içeriklerinde aramaya izin ver. Her dosyanın şifresinin çözülmesini gerektirir ve büyük depolarda yavaş olabilir.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="617"/>
@@ -315,7 +315,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="945"/>
         <source>Profile name, used to identify this configuration profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu yapılandırma profilini tanımlamak için kullanılan profil adı</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="950"/>
@@ -325,7 +325,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="953"/>
         <source>Path to the password store directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Parola deposu dizininin yolu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="958"/>
@@ -430,7 +430,7 @@ e-posta</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="654"/>
         <source>Select recipients for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 için alıcıları seçin</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="672"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses localization issues by:

*   **Adding missing Turkish translations:** Several previously untranslated strings related to configuration options (e.g., content search, profile name, password store path) and recipient selection have been translated into Turkish.
*   **Correcting German typos and improving translations:** Typographical errors in German translations such as "Ausschließen" (capitalization), "Schreibzugrif" to "Schreibzugriff", and "Lese-Zugrif" to "Lese-Zugriff" have been fixed. Additionally, the translation for "Repeat pass" has been improved from "Repetier pass" to "Wiederhole Passphrase".
<!-- kody-pr-summary:end -->