### PR TITLE
Fix code quality findings

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -896,7 +896,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
         <source>Configuration</source>
-        <translation type="unfinished">වින්‍යාසය</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="449"/>

--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -1143,9 +1143,9 @@ Expire-Date: 0
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="770"/>
         <source>Found %n match(es) in %1 entr(ies).</source>
-        <translation>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation type="unfinished">
+            <numerusform type="unfinished"></numerusform>
+            <numerusform type="unfinished"></numerusform>
         </translation>
     </message>
     <message>

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -103,7 +103,7 @@ void StoreModel::setStore(const QString &passStore) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
   beginFilterChange();
   store = passStore;
-  endFilterChange();
+  endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
   store = passStore;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -100,11 +100,17 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
 }
 
 void StoreModel::setStore(const QString &passStore) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+  beginFilterChange();
+  store = passStore;
+  endFilterChange();
+#else
   store = passStore;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   QSortFilterProxyModel::invalidateFilter();
 #else
   invalidateFilter();
+#endif
 #endif
 }
 

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -78,6 +78,7 @@ void tst_settings::cleanupTestCase() {
   // This ensures make check doesn't change user's live config
   if (m_isPortableMode && !m_settingsBackupPath.isEmpty()) {
     QString settingsFile = QtPassSettings::getInstance()->fileName();
+    QtPassSettings::getInstance()->sync();
     QVERIFY2(QFile::remove(settingsFile) || !QFile::exists(settingsFile),
              "Failed to remove current settings file before restore");
     QVERIFY2(QFile::copy(m_settingsBackupPath, settingsFile),

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -78,12 +78,12 @@ void tst_settings::cleanupTestCase() {
   // This ensures make check doesn't change user's live config
   if (m_isPortableMode && !m_settingsBackupPath.isEmpty()) {
     QString settingsFile = QtPassSettings::getInstance()->fileName();
-    QFile::remove(settingsFile);
     QVERIFY2(QFile::remove(settingsFile) || !QFile::exists(settingsFile),
              "Failed to remove current settings file before restore");
     QVERIFY2(QFile::copy(m_settingsBackupPath, settingsFile),
              "Failed to restore settings file from backup");
-    QFile::remove(m_settingsBackupPath);
+    QVERIFY2(QFile::remove(m_settingsBackupPath),
+             "Failed to remove temporary settings backup file");
   }
 }
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactored the `StoreModel::setStore` method to conditionally use `beginFilterChange()` and `endFilterChange()` for filter invalidation when compiling with Qt versions 6.10.0 and newer. This change adapts the filter update mechanism to leverage newer Qt APIs while maintaining compatibility with older Qt versions.

Additionally, several localization entries were marked as unfinished:
*   The Sinhala (si_LK) translation for "Configuration" was reset.
*   The Swedish (sv_SE) plural forms for "Found %n match(es) in %1 entr(ies)." were reset.
<!-- kody-pr-summary:end -->