### PR TITLE
fix: redundant as_const

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -678,7 +678,7 @@ void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
 void Pass::setEnvVar(const QString &key, const QString &value) {
   Q_ASSERT(key.endsWith('='));
   const QStringList existing = env.filter(key);
-  for (const QString &entry : std::as_const(existing))
+  for (const QString &entry : existing)
     env.removeAll(entry);
   if (!value.isEmpty())
     env.append(key + value);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removes a redundant `std::as_const` call from a range-based for loop within the `Pass::setEnvVar` function. This change simplifies the code without altering its functional behavior, as the loop variable was already a constant reference and the container was not modified.
<!-- kody-pr-summary:end -->