### PR TITLE
chore: Readability of parameter names

### DIFF
--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -66,7 +66,8 @@ public:
    * @param source_parent Parent index in source model.
    * @return true if row should be displayed.
    */
-  [[nodiscard]] auto filterAcceptsRow(int, const QModelIndex &) const
+  [[nodiscard]] auto filterAcceptsRow(int source_row,
+                                      const QModelIndex &source_parent) const
       -> bool override;
 
   /**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Renamed the parameters of the `filterAcceptsRow` method in `StoreModel` from generic types to more descriptive names (`source_row` and `source_parent`). This change enhances code readability and clarity without altering the method's functionality.
<!-- kody-pr-summary:end -->