### PR TITLE
fix: pass.cpp robustness — WSL case-insensitive, explicit lambda capture, safer loop, include algorithm

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -613,10 +613,11 @@ void Pass::handleGrepError(int exitCode, const QString &err) {
 auto Pass::formatInsertError(const QString &friendly, const QString &err)
     -> QString {
   QStringList humanLines;
-  for (QString line : err.split('\n')) {
-    line.remove('\r');
-    if (!line.startsWith(QLatin1String("[GNUPG:]")))
-      humanLines.append(line);
+  for (const QString &line : err.split('\n')) {
+    QString cleanedLine = line;
+    cleanedLine.remove('\r');
+    if (!cleanedLine.startsWith(QLatin1String("[GNUPG:]")))
+      humanLines.append(cleanedLine);
   }
   const QString humanErr = humanLines.join('\n').trimmed();
   return humanErr.isEmpty() ? friendly : friendly + "\n\n" + humanErr;

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -500,8 +500,7 @@ auto gpgErrorMessage(const QString &err) -> QString {
         "Pass", "Encryption failed. Check that your GPG key is valid.");
 
   // Locale-dependent fallbacks
-  if (containsAnyCaseInsensitive(err, {QLatin1String("key has expired"),
-                                       QLatin1String("key expired")}))
+  if (containsAnyCaseInsensitive(err, {QLatin1String("key has expired")}))
     return QCoreApplication::translate(
         "Pass", "Encryption failed: GPG key has expired. Please renew or "
                 "replace it.");

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -357,7 +357,8 @@ auto Pass::resolveGpgconfCommand(const QString &gpgPath)
   }
 
   const QString first = parts.first();
-  if (first == "wsl" || first == "wsl.exe") {
+  if (first.compare("wsl", Qt::CaseInsensitive) == 0 ||
+      first.compare("wsl.exe", Qt::CaseInsensitive) == 0) {
     if (parts.size() >= 2 && parts.at(1).startsWith("sh")) {
       return {"gpgconf", {}};
     }

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -375,7 +375,7 @@ auto Pass::resolveGpgconfCommand(const QString &gpgPath)
     return {"gpgconf", {}};
   }
 
-  QString gpgconfPath = findGpgconfInGpgDir(gpgPath);
+  QString gpgconfPath = findGpgconfInGpgDir(first);
   if (!gpgconfPath.isEmpty()) {
     return {gpgconfPath, {}};
   }

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -51,7 +51,7 @@ Pass::Pass() : wrapperRunning(false), env(QProcess::systemEnvironment()) {
       QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w"),
       QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")};
   const QString wslenvPrefix = QStringLiteral("WSLENV=");
-  auto it = std::find_if(env.begin(), env.end(), [&](const QString &s) {
+  auto it = std::find_if(env.begin(), env.end(), [&wslenvPrefix](const QString &s) {
     return s.startsWith(wslenvPrefix);
   });
   if (it == env.end()) {

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -11,6 +11,7 @@
 #include <QProcess>
 #include <QRandomGenerator>
 #include <QRegularExpression>
+#include <algorithm>
 #include <utility>
 
 #ifdef QT_DEBUG
@@ -51,9 +52,10 @@ Pass::Pass() : wrapperRunning(false), env(QProcess::systemEnvironment()) {
       QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w"),
       QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")};
   const QString wslenvPrefix = QStringLiteral("WSLENV=");
-  auto it = std::find_if(env.begin(), env.end(), [&wslenvPrefix](const QString &s) {
-    return s.startsWith(wslenvPrefix);
-  });
+  auto it =
+      std::find_if(env.begin(), env.end(), [&wslenvPrefix](const QString &s) {
+        return s.startsWith(wslenvPrefix);
+      });
   if (it == env.end()) {
     env.append(wslenvPrefix + wslenvVars.join(':'));
   } else {
@@ -376,7 +378,7 @@ auto Pass::resolveGpgconfCommand(const QString &gpgPath)
     return {"gpgconf", {}};
   }
 
-  QString gpgconfPath = findGpgconfInGpgDir(first);
+  QString gpgconfPath = findGpgconfInGpgDir(gpgPath);
   if (!gpgconfPath.isEmpty()) {
     return {gpgconfPath, {}};
   }
@@ -501,7 +503,8 @@ auto gpgErrorMessage(const QString &err) -> QString {
         "Pass", "Encryption failed. Check that your GPG key is valid.");
 
   // Locale-dependent fallbacks
-  if (containsAnyCaseInsensitive(err, {QLatin1String("key has expired")}))
+  if (containsAnyCaseInsensitive(err, {QLatin1String("key has expired"),
+                                       QLatin1String("key expired")}))
     return QCoreApplication::translate(
         "Pass", "Encryption failed: GPG key has expired. Please renew or "
                 "replace it.");


### PR DESCRIPTION
## **User description**
<!-- kody-pr-summary:start -->
This pull request introduces several refinements and potential fixes to the `src/pass.cpp` file, primarily focusing on improving robustness, accuracy, and code quality.

Key changes include:

*   **Case-Insensitive WSL Detection:** The `resolveGpgconfCommand` function now performs a case-insensitive comparison when checking for "wsl" or "wsl.exe" as the command, making the detection of Windows Subsystem for Linux more robust.
*   **Improved `gpgconf` Path Resolution:** The logic for finding the `gpgconf` executable in `resolveGpgconfCommand` has been updated to pass the base command name (e.g., "gpg" or "wsl") to `findGpgconfInGpgDir`, ensuring more accurate path resolution.
*   **Refined GPG Key Expiration Error Detection:** The `gpgErrorMessage` function now specifically checks for the phrase "key has expired" to identify expired GPG keys, removing a less precise check for "key expired."
*   **Code Quality Enhancements:**
    *   The lambda in the `Pass` constructor now explicitly captures `wslenvPrefix` by reference, improving clarity and potentially minor efficiency.
    *   The `formatInsertError` function has been updated to use a constant reference for iterating through lines and a separate mutable copy for cleaning each line, enhancing code safety and readability.
<!-- kody-pr-summary:end -->


___

## **CodeAnt-AI Description**
**Fix GPG command detection and keep expired-key errors readable**

### What Changed
- WSL command detection now works even when the command name uses different letter casing.
- Error messages for expired GPG keys keep the shorter “key expired” fallback, so older versions and some locales still show a specific expiry message instead of a generic one.
- Insert error output continues to show readable non-GPG lines while filtering out GnuPG status lines.

### Impact
`✅ Fewer misdetected WSL setups`
`✅ Clearer expired-key errors`
`✅ Less generic import failure messages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=YP0sU3-8vlUVV01ZpWEQJRosSqWoSnZpf6NdQJpJ-1I&org=IJHack)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
