### PR TITLE
fix: replace isDir/isFile bools with ItemKind enum in dragAndDropInfoPasswordStore

### DIFF
--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -11,14 +11,12 @@
 #include <QMimeData>
 #include <QRegularExpression>
 #include <QtGlobal>
-#include <utility>
 
 auto operator<<(
     QDataStream &out,
     const dragAndDropInfoPasswordStore &dragAndDropInfoPasswordStore)
     -> QDataStream & {
-  out << dragAndDropInfoPasswordStore.isDir
-      << dragAndDropInfoPasswordStore.isFile
+  out << static_cast<quint8>(dragAndDropInfoPasswordStore.kind)
       << dragAndDropInfoPasswordStore.path;
   return out;
 }
@@ -26,8 +24,10 @@ auto operator<<(
 auto operator>>(QDataStream &in,
                 dragAndDropInfoPasswordStore &dragAndDropInfoPasswordStore)
     -> QDataStream & {
-  in >> dragAndDropInfoPasswordStore.isDir >>
-      dragAndDropInfoPasswordStore.isFile >> dragAndDropInfoPasswordStore.path;
+  quint8 k;
+  in >> k >> dragAndDropInfoPasswordStore.path;
+  dragAndDropInfoPasswordStore.kind =
+      static_cast<dragAndDropInfoPasswordStore::ItemKind>(k);
   return in;
 }
 
@@ -94,10 +94,10 @@ auto StoreModel::showThis(const QModelIndex &index) const -> bool {
  * @param passStore
  */
 void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
-                                  QString passStore) {
+                                  const QString &passStore) {
   setSourceModel(sourceModel);
   fs = sourceModel;
-  store = std::move(passStore);
+  store = passStore;
 }
 
 void StoreModel::setStore(const QString &passStore) {
@@ -192,8 +192,10 @@ auto StoreModel::mimeData(const QModelIndexList &indexes) const -> QMimeData * {
   if (index.isValid()) {
     QModelIndex useIndex = mapToSource(index);
 
-    info.isDir = fs->fileInfo(useIndex).isDir();
-    info.isFile = fs->fileInfo(useIndex).isFile();
+    if (fs->fileInfo(useIndex).isDir())
+      info.kind = dragAndDropInfoPasswordStore::ItemKind::Directory;
+    else if (fs->fileInfo(useIndex).isFile())
+      info.kind = dragAndDropInfoPasswordStore::ItemKind::File;
     info.path = fs->fileInfo(useIndex).absoluteFilePath();
     QDataStream stream(&encodedData, QIODevice::WriteOnly);
     stream << info;
@@ -248,16 +250,18 @@ auto StoreModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
     return false;
   }
 
+  using IK = dragAndDropInfoPasswordStore::ItemKind;
   // you can drop a folder on a folder
-  if (fs->fileInfo(mapToSource(useIndex)).isDir() && info.isDir) {
+  if (fs->fileInfo(mapToSource(useIndex)).isDir() &&
+      info.kind == IK::Directory) {
     return true;
   }
   // you can drop a file on a folder
-  if (fs->fileInfo(mapToSource(useIndex)).isDir() && info.isFile) {
+  if (fs->fileInfo(mapToSource(useIndex)).isDir() && info.kind == IK::File) {
     return true;
   }
   // you can drop a file on a file
-  if (fs->fileInfo(mapToSource(useIndex)).isFile() && info.isFile) {
+  if (fs->fileInfo(mapToSource(useIndex)).isFile() && info.kind == IK::File) {
     return true;
   }
 
@@ -326,7 +330,7 @@ auto StoreModel::executeDropAction(const dragAndDropInfoPasswordStore &info,
   QString cleanedSrc = QDir::cleanPath(srcFileInfo.absoluteFilePath());
   QString cleanedDest = QDir::cleanPath(destFileinfo.absoluteFilePath());
 
-  if (info.isDir) {
+  if (info.kind == dragAndDropInfoPasswordStore::ItemKind::Directory) {
     return handleDirDrop(cleanedSrc, destFileinfo, srcFileInfo, action);
   }
   return handleFileDrop(cleanedSrc, cleanedDest, destFileinfo, action);

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -26,8 +26,20 @@ auto operator>>(QDataStream &in,
     -> QDataStream & {
   quint8 k;
   in >> k >> dragAndDropInfoPasswordStore.path;
-  dragAndDropInfoPasswordStore.kind =
-      static_cast<dragAndDropInfoPasswordStore::ItemKind>(k);
+  switch (k) {
+  case static_cast<quint8>(dragAndDropInfoPasswordStore::ItemKind::Directory):
+    dragAndDropInfoPasswordStore.kind =
+        dragAndDropInfoPasswordStore::ItemKind::Directory;
+    break;
+  case static_cast<quint8>(dragAndDropInfoPasswordStore::ItemKind::File):
+    dragAndDropInfoPasswordStore.kind =
+        dragAndDropInfoPasswordStore::ItemKind::File;
+    break;
+  default:
+    dragAndDropInfoPasswordStore.kind =
+        dragAndDropInfoPasswordStore::ItemKind::Unknown;
+    break;
+  }
   return in;
 }
 
@@ -330,10 +342,15 @@ auto StoreModel::executeDropAction(const dragAndDropInfoPasswordStore &info,
   QString cleanedSrc = QDir::cleanPath(srcFileInfo.absoluteFilePath());
   QString cleanedDest = QDir::cleanPath(destFileinfo.absoluteFilePath());
 
-  if (info.kind == dragAndDropInfoPasswordStore::ItemKind::Directory) {
+  switch (info.kind) {
+  case dragAndDropInfoPasswordStore::ItemKind::Directory:
     return handleDirDrop(cleanedSrc, destFileinfo, srcFileInfo, action);
+  case dragAndDropInfoPasswordStore::ItemKind::File:
+    return handleFileDrop(cleanedSrc, cleanedDest, destFileinfo, action);
+  default:
+    qWarning() << "executeDropAction: unexpected ItemKind, ignoring drop";
+    return false;
   }
-  return handleFileDrop(cleanedSrc, cleanedDest, destFileinfo, action);
 }
 
 auto StoreModel::handleDirDrop(const QString &cleanedSrc,

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -82,7 +82,8 @@ public:
    * @param sourceModel Filesystem model to wrap.
    * @param passStore Root path of password store.
    */
-  void setModelAndStore(QFileSystemModel *sourceModel, QString passStore);
+  void setModelAndStore(QFileSystemModel *sourceModel,
+                        const QString &passStore);
 
   /**
    * @brief Update the store path used for filtering without changing the source

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -24,9 +24,14 @@ class QFileSystemModel;
  * @brief Holds information for drag and drop operations in the password store.
  */
 struct dragAndDropInfoPasswordStore {
-  bool isDir;   /**< true if dragged item is a directory */
-  bool isFile;  /**< true if dragged item is a file */
-  QString path; /**< Full path to the dragged item */
+  enum class ItemKind {
+    Unknown,   /**< Item type has not been determined yet */
+    Directory, /**< Dragged item is a directory */
+    File       /**< Dragged item is a file */
+  };
+
+  ItemKind kind{ItemKind::Unknown}; /**< Type of dragged item */
+  QString path;                     /**< Full path to the dragged item */
 };
 
 class StoreModel : public QSortFilterProxyModel {


### PR DESCRIPTION
## **User description**
<!-- kody-pr-summary:start -->
Refactored the `dragAndDropInfoPasswordStore` struct to use an `enum class ItemKind` for clearer and more robust identification of dragged items (directory, file, or unknown), replacing separate boolean flags. Additionally, optimized the `setModelAndStore` method signature by passing the `passStore` parameter as a constant reference (`const QString &`) to improve performance by avoiding unnecessary string copies.
<!-- kody-pr-summary:end -->


___

## **CodeAnt-AI Description**
**Fix drag-and-drop item handling in the password store**

### What Changed
- Dragged items are now identified as a file, folder, or unknown instead of using separate yes/no checks
- Drag-and-drop acceptance now uses the item type consistently, so folders and files are matched to the right drop targets
- Saving the selected store path now avoids an extra copy when the store is set

### Impact
`✅ Fewer drag-and-drop errors`
`✅ More reliable folder and file moves`
`✅ Slightly lighter store path updates`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=IoVu_eJW_X5qceJ58cCn9SQAEGI29bWQltTWHiXHnjs&org=IJHack)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved drag-and-drop item typing for stronger type safety and more predictable behavior.
  * Optimized store model initialization to reduce unnecessary copying.

* **Bug Fix**
  * More robust handling of unknown or unexpected drag items — such drops are now rejected with clearer logging to avoid silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->