### PR TITLE
fix: Swedish localization — use 'tillägg' for Pass OTP extension

### DIFF
--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -399,7 +399,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="93"/>
         <source>Pass OTP extension needs to be installed</source>
-        <translation>Pass OTP förlängning måste installeras</translation>
+        <translation>Pass OTP tillägg måste installeras</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="98"/>

--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -480,7 +480,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="581"/>
         <source>Use pass-otp extension</source>
-        <translation>Använd pass-otp förlängning</translation>
+        <translation>Använd pass-otp-tillägg</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="702"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the Swedish localization (`sv_SE.ts`) to replace "förlängning" with "tillägg" when referring to the "Pass OTP extension". This change improves the accuracy and consistency of the translation for software extensions and includes a hyphen for correct Swedish compound word formation.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Swedish language translations for the Pass OTP feature with refined terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->