### PR TITLE
fix: Turkish localization — add missing search strings and plural forms

### DIFF
--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1009,7 +1009,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
         <source>Searching…</source>
-        <translation type="unfinished"></translation>
+        <translation>Aranıyor…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="701"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1026,6 +1026,7 @@ Expire-Date: 0
         <source>Found %n match(es) in %1 entr(ies).</source>
         <translation type="unfinished">
             <numerusform>%1 girdide %n eşleşme bulundu.</numerusform>
+            <numerusform>%1 girdide %n eşleşme bulundu.</numerusform>
         </translation>
     </message>
     <message>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1014,7 +1014,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="701"/>
         <source>Search content (regex)</source>
-        <translation type="unfinished"></translation>
+        <translation>İçerikte ara (düzenli ifade)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="747"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1019,7 +1019,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="747"/>
         <source>No matches found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Eşleşme bulunamadı.</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="770"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the Turkish localization file (`localization_tr_TR.ts`) to complete several previously untranslated strings related to the search functionality.

Specifically, it provides Turkish translations for:
*   "Searching…"
*   "Search content (regex)"
*   "No matches found."

Additionally, it addresses a potential issue with the plural form for "Found %n match(es) in %1 entr(ies)." by ensuring both plural forms are explicitly defined.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Turkish translations for search interface strings including "Searching…," "Search content (regex)," "No matches found," and search result match count messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->