### PR TITLE
fix: Turkish localization — correct system tray, integrity, and re-encrypt translations

### DIFF
--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -1425,10 +1425,10 @@ Blue entries have a secret key available, select one of these to be able to decr
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
         <translation>Bu klasörde saklanan parolaları çözebilecek kullanıcıları seçin.
-Not: Mevcut dosyalar değiştirilmeyecektir ve düzenlersiniz kadar eski izinler korunacaktır.
-Mavi girdiler bir gizli anahtar mevcuttur, bunlardan birini seçerek parolayı çözebilirsiniz.
-Siyah girdiler bir şifreleme anahtarı mevcut ve güvenilir olup, bunlardan birini seçerek diğerlerine izin verebilirsiniz.
-Kırmızı girdiler geçerli değildir, bularına şifrelemeye izin veremezsiniz.</translation>
+Not: Mevcut dosyalar değiştirilmeyecektir ve siz onları düzenleyene kadar eski izinleri koruyacaktır.
+Mavi girdilerde kullanılabilir bir gizli anahtar vardır; parolaları çözebilmek için bunlardan birini seçin.
+Siyah girdilerde kullanılabilir ve güvenilir bir şifreleme anahtarı vardır; başkalarının şifre çözebilmesine izin vermek için bunlardan birini seçin.
+Kırmızı girdiler geçerli değildir; bunlara şifreleme yapamazsınız.</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="70"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -335,7 +335,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="961"/>
         <source>Optional: GPG key to sign .gpg-id files for integrity verification. Leave empty unless you need to protect the user list from tampering.</source>
-        <translation>Seçmeli: GPG, dürüstlük doğrulaması için .gpg-id dosyalarını imzalamak üzere anahtar. Kullanıcı listesini kurcalamaya karşı korumanız gerekmedikçe boş bırakın.</translation>
+        <translation>Seçmeli: GPG, bütünlük doğrulaması için .gpg-id dosyalarını imzalamak üzere anahtar. Kullanıcı listesini kurcalamaya karşı korumanız gerekmedikçe boş bırakın.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="971"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -206,7 +206,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="629"/>
         <source>Use TrayIcon</source>
-        <translation>Sistem Tepsisini Kullan simgesi</translation>
+        <translation>Sistem Tepsisi Simgesini Kullan</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="636"/>

--- a/localization/localization_tr_TR.ts
+++ b/localization/localization_tr_TR.ts
@@ -626,7 +626,7 @@ Yeni eklenen parolaların hiçbirinin şifresini çözemeyeceksiniz!</translatio
     <message>
         <location filename="../src/imitatepass.cpp" line="770"/>
         <source>Failed to re-encrypt %1</source>
-        <translation>Şifreyi yeniden tanımlamak için başarısız oldu %1</translation>
+        <translation>%1 yeniden şifrelenemedi</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="776"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the Turkish (tr_TR) localization file to improve the clarity, grammar, and accuracy of several translated strings.

Key improvements include:
*   Correcting the translation for "Use TrayIcon".
*   Refining the term used for "integrity verification".
*   Providing a more accurate translation for "Failed to re-encrypt %1".
*   Enhancing the readability and grammatical correctness of the multi-line explanation regarding user selection for password decryption and key types in the users dialog.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced Turkish translations across the entire application with improved terminology and phrasing
  * Corrected and refined UI element descriptions and cryptographic operation terminology for accuracy
  * Refined error messages to provide clearer guidance and better user understanding
  * Improved explanatory text regarding file permissions with enhanced grammatical structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->