### PR TITLE
fix: Swedish localization — capitalisation, word order, and spacing corrections

### DIFF
--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -445,7 +445,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="813"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation>Installera GnuPG på ditt system.&lt;br&gt;Installera &lt;strong&gt;Ubuntu&lt;/strong&gt; från Microsoft Store&lt;br&gt;eller &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot; &gt;ladda&lt;/a&gt; det från GnuPG.org ner</translation>
+        <translation>Installera GnuPG på ditt system.&lt;br&gt;Installera &lt;strong&gt;Ubuntu&lt;/strong&gt; från Microsoft Store&lt;br&gt;eller &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot; &gt;ladda ner&lt;/a&gt; det från GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="879"/>

--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -440,7 +440,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="808"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store to get it.&lt;br&gt;If you already did so, make sure you started it once and&lt;br&gt;click &quot;Autodetect&quot; in the next dialog.</source>
-        <translation>Installera GnuPG på ditt system. &lt;br&gt; installera &lt;strong&gt; Ubuntu &lt;/strong&gt; från Microsoft Store för att få det. &lt;br&gt; om du redan gjorde det, se till att du startade den en gång och &lt;br&gt; Klicka på &quot;Autodetektera&quot; i nästa dialogruta.</translation>
+        <translation>Installera GnuPG på ditt system. &lt;br&gt; Installera &lt;strong&gt; Ubuntu &lt;/strong&gt; från Microsoft Store för att få det. &lt;br&gt; om du redan gjorde det, se till att du startade den en gång och &lt;br&gt; Klicka på &quot;Autodetektera&quot; i nästa dialogruta.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="813"/>

--- a/localization/localization_sv_SE.ts
+++ b/localization/localization_sv_SE.ts
@@ -460,7 +460,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="912"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Mappen% 1 verkar inte vara ett lösenordslager eller har ännu inte initialiserats.</translation>
+        <translation>Mappen %1 verkar inte vara ett lösenordslager eller har ännu inte initialiserats.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="436"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrected several minor issues in the Swedish localization file (`localization_sv_SE.ts`).

The changes include:
*   Adjusted capitalization for "Installera" in a GnuPG installation message.
*   Corrected the phrasing and link structure for "ladda ner" (download) in another GnuPG installation message, ensuring "ner" is part of the clickable link.
*   Added a missing space before the `%1` placeholder in a message about an uninitialized password store, improving readability.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed capitalization, spacing, and formatting inconsistencies in Swedish translations for installation prompts and error messages to improve readability and consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->