### PR TITLE
fix: address code quality findings in pass.cpp and storemodel.cpp

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -707,8 +707,10 @@ void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
 // key must include the trailing '=' (e.g. "FOO="); env.filter() does substring
 // matching so the '=' anchors the lookup to avoid collisions with longer names.
 void Pass::setEnvVar(const QString &key, const QString &value) {
-  Q_ASSERT(key.endsWith('='));
-  if (!key.endsWith('=')) {
+  const bool hasEq = key.endsWith('=');
+  Q_ASSERT_X(hasEq, "Pass::setEnvVar",
+             "called with malformed key (missing '=')");
+  if (!hasEq) {
     qWarning() << "Pass::setEnvVar called with malformed key (missing '='):"
                << key;
     return;

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -41,8 +41,9 @@ auto effectiveCharset(const PasswordConfiguration &passConfig) -> QString {
   int sel = passConfig.selected;
   if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
     sel = PasswordConfiguration::ALLCHARS;
-  return fallbackCharset(passConfig.Characters[sel],
-                         passConfig.Characters[PasswordConfiguration::ALLCHARS]);
+  return fallbackCharset(
+      passConfig.Characters[sel],
+      passConfig.Characters[PasswordConfiguration::ALLCHARS]);
 }
 } // namespace
 

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -33,17 +33,16 @@ using Enums::PASS_REMOVE;
 using Enums::PASS_SHOW;
 
 namespace {
-auto fallbackCharset(const QString &input) -> QString {
-  return input.isEmpty() ? QtPassSettings::getPasswordConfiguration()
-                               .Characters[PasswordConfiguration::ALLCHARS]
-                         : input;
+auto fallbackCharset(const QString &input, const QString &fallback) -> QString {
+  return input.isEmpty() ? fallback : input;
 }
 
 auto effectiveCharset(const PasswordConfiguration &passConfig) -> QString {
   int sel = passConfig.selected;
   if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
     sel = PasswordConfiguration::ALLCHARS;
-  return fallbackCharset(passConfig.Characters[sel]);
+  return fallbackCharset(passConfig.Characters[sel],
+                         passConfig.Characters[PasswordConfiguration::ALLCHARS]);
 }
 } // namespace
 
@@ -176,7 +175,9 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
   } else {
     // Validate charset - if CUSTOM is selected but chars are empty,
     // fall back to ALLCHARS to prevent weak passwords (issue #780)
-    const QString cs = fallbackCharset(charset);
+    const QString cs = fallbackCharset(
+        charset, QtPassSettings::getPasswordConfiguration()
+                     .Characters[PasswordConfiguration::ALLCHARS]);
     if (cs.length() > 0) {
       passwd = generateRandomPassword(cs, length);
     } else {

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -138,6 +138,11 @@ void Pass::init() {
  */
 auto Pass::generatePassword(unsigned int length, const QString &charset)
     -> QString {
+  if (length == 0) {
+    emit critical(tr("Invalid password length"),
+                  tr("Can't generate password with zero length."));
+    return {};
+  }
   QString passwd;
   if (QtPassSettings::isUsePwgen()) {
     // --secure goes first as it overrides --no-* otherwise
@@ -172,10 +177,7 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
     // Validate charset - if CUSTOM is selected but chars are empty,
     // fall back to ALLCHARS to prevent weak passwords (issue #780)
     const QString cs = fallbackCharset(charset);
-    if (length == 0) {
-      emit critical(tr("Invalid password length"),
-                    tr("Can't generate password with zero length."));
-    } else if (cs.length() > 0) {
+    if (cs.length() > 0) {
       passwd = generateRandomPassword(cs, length);
     } else {
       emit critical(

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -33,14 +33,17 @@ using Enums::PASS_REMOVE;
 using Enums::PASS_SHOW;
 
 namespace {
-QString effectiveCharset(const PasswordConfiguration &passConfig) {
+auto fallbackCharset(const QString &input) -> QString {
+  return input.isEmpty() ? QtPassSettings::getPasswordConfiguration()
+                               .Characters[PasswordConfiguration::ALLCHARS]
+                         : input;
+}
+
+auto effectiveCharset(const PasswordConfiguration &passConfig) -> QString {
   int sel = passConfig.selected;
   if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
     sel = PasswordConfiguration::ALLCHARS;
-  QString charset = passConfig.Characters[sel];
-  if (charset.isEmpty())
-    charset = passConfig.Characters[PasswordConfiguration::ALLCHARS];
-  return charset;
+  return fallbackCharset(passConfig.Characters[sel]);
 }
 } // namespace
 
@@ -168,11 +171,7 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
   } else {
     // Validate charset - if CUSTOM is selected but chars are empty,
     // fall back to ALLCHARS to prevent weak passwords (issue #780)
-    QString cs = charset;
-    if (cs.isEmpty()) {
-      cs = QtPassSettings::getPasswordConfiguration()
-               .Characters[PasswordConfiguration::ALLCHARS];
-    }
+    const QString cs = fallbackCharset(charset);
     if (length == 0) {
       emit critical(tr("Invalid password length"),
                     tr("Can't generate password with zero length."));

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -31,6 +31,18 @@ using Enums::PASS_OTP_GENERATE;
 using Enums::PASS_REMOVE;
 using Enums::PASS_SHOW;
 
+namespace {
+QString effectiveCharset(const PasswordConfiguration &passConfig) {
+  int sel = passConfig.selected;
+  if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
+    sel = PasswordConfiguration::ALLCHARS;
+  QString charset = passConfig.Characters[sel];
+  if (charset.isEmpty())
+    charset = passConfig.Characters[PasswordConfiguration::ALLCHARS];
+  return charset;
+}
+} // namespace
+
 /**
  * @brief Pass::Pass wrapper for using either pass or the pass imitation
  */
@@ -155,13 +167,16 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
   } else {
     // Validate charset - if CUSTOM is selected but chars are empty,
     // fall back to ALLCHARS to prevent weak passwords (issue #780)
-    QString effectiveCharset = charset;
-    if (effectiveCharset.isEmpty()) {
-      effectiveCharset = QtPassSettings::getPasswordConfiguration()
-                             .Characters[PasswordConfiguration::ALLCHARS];
+    QString cs = charset;
+    if (cs.isEmpty()) {
+      cs = QtPassSettings::getPasswordConfiguration()
+               .Characters[PasswordConfiguration::ALLCHARS];
     }
-    if (effectiveCharset.length() > 0) {
-      passwd = generateRandomPassword(effectiveCharset, length);
+    if (length == 0) {
+      emit critical(tr("Invalid password length"),
+                    tr("Can't generate password with zero length."));
+    } else if (cs.length() > 0) {
+      passwd = generateRandomPassword(cs, length);
     } else {
       emit critical(
           tr("No characters chosen"),
@@ -272,6 +287,9 @@ QString findGpgconfInGpgDir(const QString &gpgPath) {
   return QString();
 }
 
+// Compatibility shim for Qt < 5.15 where QProcess::splitCommand is not
+// available. Keep this fallback while supporting pre-5.15 builds; remove once
+// the project's minimum supported Qt version is raised to 5.15 or newer.
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 /**
  * @brief Splits a command string into arguments while respecting quotes and
@@ -688,6 +706,11 @@ void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
 // matching so the '=' anchors the lookup to avoid collisions with longer names.
 void Pass::setEnvVar(const QString &key, const QString &value) {
   Q_ASSERT(key.endsWith('='));
+  if (!key.endsWith('=')) {
+    qWarning() << "Pass::setEnvVar called with malformed key (missing '='):"
+               << key;
+    return;
+  }
   const QStringList existing = env.filter(key);
   for (const QString &entry : existing)
     env.removeAll(entry);
@@ -705,13 +728,8 @@ void Pass::updateEnv() {
   setEnvVar(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH="),
             QString::number(passConfig.length));
 
-  int sel = passConfig.selected;
-  if (sel < 0 || sel >= PasswordConfiguration::CHARSETS_COUNT)
-    sel = PasswordConfiguration::ALLCHARS;
-  QString charset = passConfig.Characters[sel];
-  if (charset.isEmpty())
-    charset = passConfig.Characters[PasswordConfiguration::ALLCHARS];
-  setEnvVar(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="), charset);
+  setEnvVar(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="),
+            effectiveCharset(passConfig));
 
   exec.setEnvironment(env);
 }
@@ -798,11 +816,14 @@ auto Pass::boundedRandom(quint32 bound) -> quint32 {
   }
 
   quint32 randval;
-  // Rejection-sampling threshold to avoid modulo bias:
-  // In quint32 arithmetic, (1 + ~bound) wraps to (2^32 - bound), so
-  // (1 + ~bound) % bound == 2^32 % bound.
-  // Values randval < rejectionThreshold are rejected; accepted values
-  // produce a uniform distribution when reduced with (randval % bound).
+  // Rejection-sampling threshold to avoid modulo bias.
+  // This follows the well-known "arc4random_uniform"-style approach:
+  // reject values in the low range [0, min), where
+  //   min = 2^32 % bound
+  // so that the remaining range size is an exact multiple of `bound`.
+  //
+  // In quint32 arithmetic, (1 + ~bound) wraps to (2^32 - bound), therefore
+  //   (1 + ~bound) % bound == 2^32 % bound.
   const quint32 rejectionThreshold = (1 + ~bound) % bound;
 
   do {

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -6,6 +6,7 @@
 #include "qtpasssettings.h"
 #include "util.h"
 #include <QCoreApplication>
+#include <QDebug>
 #include <QDir>
 #include <QFileInfo>
 #include <QProcess>

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -203,12 +203,14 @@ auto StoreModel::mimeData(const QModelIndexList &indexes) const -> QMimeData * {
   QModelIndex index = indexes.at(0);
   if (index.isValid()) {
     QModelIndex useIndex = mapToSource(index);
+    const QFileInfo fileInfo = fs->fileInfo(useIndex);
 
-    if (fs->fileInfo(useIndex).isDir())
+    if (fileInfo.isDir()) {
       info.kind = dragAndDropInfoPasswordStore::ItemKind::Directory;
-    else if (fs->fileInfo(useIndex).isFile())
+    } else if (fileInfo.isFile()) {
       info.kind = dragAndDropInfoPasswordStore::ItemKind::File;
-    info.path = fs->fileInfo(useIndex).absoluteFilePath();
+    }
+    info.path = fileInfo.absoluteFilePath();
     QDataStream stream(&encodedData, QIODevice::WriteOnly);
     stream << info;
   }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses several code quality findings and improves robustness in `pass.cpp` and `storemodel.cpp`.

Key changes include:

*   **Password Generation Enhancements:**
    *   Introduced a new helper function to centralize the logic for determining the effective character set, reducing code duplication.
    *   Added a check to prevent the generation of passwords with a length of zero, emitting a critical error if attempted.
    *   Ensured that if a custom character set is selected but empty, the password generation falls back to using all available characters.
*   **Improved Environment Variable Handling:**
    *   Enhanced the `Pass::setEnvVar` function to gracefully handle malformed environment variable keys (missing '='), logging a warning and preventing potential issues.
*   **Code Optimization and Readability:**
    *   Refactored `StoreModel::mimeData` to cache `QFileInfo` results, avoiding redundant file system calls and improving performance.
    *   Clarified comments in `Pass::boundedRandom` to better explain the rejection-sampling method for preventing modulo bias.
    *   Added a comment to explain a Qt version compatibility shim for `QProcess::splitCommand`.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-length password requests now fail with a clear error; empty or out-of-range character selections fall back safely or emit a clear "No characters chosen" message.
  * Malformed environment-variable keys are rejected at runtime and log a warning instead of causing undefined behavior.

* **Refactor**
  * Consolidated charset selection and clamping when updating the environment.
  * Reduced redundant file-info lookups by caching file info.

* **Documentation**
  * Clarified internal comments and runtime warning text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->