### PR TITLE
docs: Comments on Qt6.10 specials

### DIFF
--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -121,7 +121,8 @@ void StoreModel::setStore(const QString &passStore) {
   endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
   // Older Qt versions do not provide the begin/end filter change API, so we
-  // update the store and manually invalidate the filter as a compatibility path.
+  // update the store and manually invalidate the filter as a compatibility
+  // path.
   store = passStore;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   QSortFilterProxyModel::invalidateFilter();

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -114,10 +114,14 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
 
 void StoreModel::setStore(const QString &passStore) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+  // Qt 6.10+ provides beginFilterChange()/endFilterChange(), which is the
+  // preferred API for scoped and more efficient filter updates.
   beginFilterChange();
   store = passStore;
   endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
+  // Older Qt versions do not provide the begin/end filter change API, so we
+  // update the store and manually invalidate the filter as a compatibility path.
   store = passStore;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   QSortFilterProxyModel::invalidateFilter();

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -114,15 +114,17 @@ void StoreModel::setModelAndStore(QFileSystemModel *sourceModel,
 
 void StoreModel::setStore(const QString &passStore) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-  // Qt 6.10+ provides beginFilterChange()/endFilterChange(), which is the
-  // preferred API for scoped and more efficient filter updates.
+  // beginFilterChange() is available since Qt 6.9, but the Direction-scoped
+  // endFilterChange(QSortFilterProxyModel::Direction) overload is only
+  // available since Qt 6.10, which is the preferred API for scoped and more
+  // efficient filter updates.
   beginFilterChange();
   store = passStore;
   endFilterChange(QSortFilterProxyModel::Direction::Rows);
 #else
-  // Older Qt versions do not provide the begin/end filter change API, so we
-  // update the store and manually invalidate the filter as a compatibility
-  // path.
+  // Direction-scoped filter changes are unavailable before Qt 6.10, so older
+  // Qt versions must manually invalidate filters. We update the store and
+  // manually invalidate the filter as a compatibility path.
   store = passStore;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   QSortFilterProxyModel::invalidateFilter();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds comments to the `StoreModel::setStore` method to clarify the conditional logic for updating filters based on the Qt version.

The comments explain that:
*   For Qt versions 6.10 and newer, `beginFilterChange()` and `endFilterChange()` are used for preferred, scoped, and more efficient filter updates.
*   For older Qt versions, the `store` is updated, and `invalidateFilter()` is manually called as a compatibility path.

This change improves code readability and maintainability by explaining the rationale behind the different filter update mechanisms.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved filter-change notification behavior on newer Qt releases while preserving explicit filter invalidation for older releases; enhances stability and responsiveness of filtered views without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->