### PR TITLE
fix: Більше виправлень перекладу

### DIFF
--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -730,7 +730,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/keygendialog.ui" line="210"/>
         <source>Repeat pass</source>
-        <translation>Повторіть pass</translation>
+        <translation>Повторіть пароль</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="227"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -792,7 +792,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>
         <source>Invalid email</source>
-        <translation>Неправильна електронна скринька</translation>
+        <translation>Неправильна адреса електронної пошти</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="181"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the Ukrainian localization (`uk_UA.ts`) to improve the accuracy and clarity of two translated strings:
-   Changed the translation for "Repeat pass" from "Повторіть pass" to "Повторіть пароль" (Repeat password).
-   Changed the translation for "Invalid email" from "Неправильна електронна скринька" (Invalid email box) to "Неправильна адреса електронної пошти" (Invalid email address).
<!-- kody-pr-summary:end -->