### PR TITLE
docs: remove stale @todo comments

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -549,7 +549,6 @@ void ConfigDialog::on_checkBoxAutoclear_clicked() {
 /**
  * @brief ConfigDialog::genKey tunnel function to make MainWindow generate a
  * gpg key pair.
- * @todo refactor the process to not be entangled so much.
  * @param batch
  * @param dialog
  */
@@ -768,7 +767,6 @@ auto ConfigDialog::isPassOtpAvailable() -> bool {
 
 /**
  * @brief ConfigDialog::wizard first-time use wizard.
- * @todo make this thing more reliable.
  */
 void ConfigDialog::wizard() {
   (void)Util::configIsValid();

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -91,7 +91,6 @@ void PasswordDialog::on_checkBoxShow_stateChanged(int arg1) {
 /**
  * @brief PasswordDialog::on_createPasswordButton_clicked generate a random
  * passwords.
- * @todo refactor when process is untangled from MainWindow class.
  */
 void PasswordDialog::on_createPasswordButton_clicked() {
   ui->widget->setEnabled(false);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removed stale `@todo` comments from `src/configdialog.cpp` and `src/passworddialog.cpp`. These comments were related to:
- Refactoring the GPG key generation process.
- Improving the reliability of the first-time use wizard.
- Refactoring the password generation process.

This change cleans up the codebase by removing outdated internal documentation without affecting application functionality.
<!-- kody-pr-summary:end -->