### PR TITLE
fix: modernise passworddialog — typo fix, isEmpty, range-for loop

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -187,7 +187,7 @@ void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
 
   if (m_templating) {
     QWidget *previous = ui->checkBoxShow;
-    foreach (QString field, m_fields) {
+    for (const QString &field : m_fields) {
       if (field.isEmpty()) {
         continue;
       }

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -187,7 +187,7 @@ void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
 
   if (m_templating) {
     QWidget *previous = ui->checkBoxShow;
-    for (const QString &field : m_fields) {
+    for (const QString &field : std::as_const(m_fields)) {
       if (field.isEmpty()) {
         continue;
       }

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -98,7 +98,7 @@ void PasswordDialog::on_createPasswordButton_clicked() {
       static_cast<unsigned int>(ui->spinBox_pwdLength->value()),
       m_passConfig.Characters[static_cast<PasswordConfiguration::characterSet>(
           ui->passwordTemplateSwitch->currentIndex())]);
-  if (newPass.length() > 0) {
+  if (!newPass.isEmpty()) {
     ui->lineEditPassword->setText(newPass);
   }
   ui->widget->setEnabled(true);

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -90,7 +90,7 @@ void PasswordDialog::on_checkBoxShow_stateChanged(int arg1) {
 
 /**
  * @brief PasswordDialog::on_createPasswordButton_clicked generate a random
- * passwords.
+ * password.
  */
 void PasswordDialog::on_createPasswordButton_clicked() {
   ui->widget->setEnabled(false);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactored `PasswordDialog` to enhance code quality and readability. This includes:

*   Updating the check for an empty generated password from `length() > 0` to `!isEmpty()` for improved clarity.
*   Modernizing a loop iterating over fields from a Qt-style `foreach` to a C++11 range-based for loop.
*   Correcting a minor typo in a comment.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code quality and modernized internal implementation patterns in password dialog handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->