### PR TITLE
fix: Ukrainian localization — remove stray spaces in format strings and HTML

### DIFF
--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -433,7 +433,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="874"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>Хочете створити сховище паролів в % 1?</translation>
+        <translation>Хочете створити сховище паролів в %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="879"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -488,7 +488,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="813"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation>Будь ласка, встановіть GnuPG у вашій системі. &lt;br&gt; Встановіть &lt;strong&gt; Ubuntu &lt;/strong&gt; із магазину Microsoft &lt;br&gt; або &lt;a href = &quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;завантажте&lt;/a&gt; його з GnuPG.org</translation>
+        <translation>Будь ласка, встановіть GnuPG у вашій системі. &lt;br&gt; Встановіть &lt;strong&gt;Ubuntu&lt;/strong&gt; із магазину Microsoft &lt;br&gt; або &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;завантажте&lt;/a&gt; його з GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="436"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -483,7 +483,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="808"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store to get it.&lt;br&gt;If you already did so, make sure you started it once and&lt;br&gt;click &quot;Autodetect&quot; in the next dialog.</source>
-        <translation>Будь ласка, встановіть GnuPG у вашій системі. &lt;br&gt; Встановіть &lt;strong&gt; Ubuntu &lt;/strong&gt; з магазину Microsoft, щоб отримати його. &lt;br&gt; Якщо ви вже це зробили, переконайтеся, що запустили його один раз, і натисніть «Автовизначити» у наступному діалоговому вікні.</translation>
+        <translation>Будь ласка, встановіть GnuPG у вашій системі. &lt;br&gt; Встановіть &lt;strong&gt;Ubuntu&lt;/strong&gt; з магазину Microsoft, щоб отримати його. &lt;br&gt; Якщо ви вже це зробили, переконайтеся, що запустили його один раз, і натисніть «Автовизначити» у наступному діалоговому вікні.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="813"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrected minor formatting issues in the Ukrainian translation file (`localization_uk_UA.ts`). This includes:
- Removed an extraneous space before the `%1` placeholder in a message about creating a password store.
- Eliminated unnecessary spaces around `<strong>Ubuntu</strong>` tags in two messages related to GnuPG installation instructions.
- Removed a space around the `href` attribute in an `<a>` tag within a GnuPG download instruction message.

These changes improve the consistency and correctness of the Ukrainian localization strings.
<!-- kody-pr-summary:end -->