### PR TITLE
fix: guard against out-of-bounds index in password character set selection

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -94,10 +94,17 @@ void PasswordDialog::on_checkBoxShow_stateChanged(int arg1) {
  */
 void PasswordDialog::on_createPasswordButton_clicked() {
   ui->widget->setEnabled(false);
+  const int currentIndex = ui->passwordTemplateSwitch->currentIndex();
+  if (currentIndex < 0 ||
+      currentIndex >= static_cast<int>(m_passConfig.Characters.size())) {
+    ui->widget->setEnabled(true);
+    return;
+  }
+
   QString newPass = QtPassSettings::getPass()->generatePassword(
       static_cast<unsigned int>(ui->spinBox_pwdLength->value()),
       m_passConfig.Characters[static_cast<PasswordConfiguration::characterSet>(
-          ui->passwordTemplateSwitch->currentIndex())]);
+          currentIndex)]);
   if (!newPass.isEmpty()) {
     ui->lineEditPassword->setText(newPass);
   }

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -96,7 +96,7 @@ void PasswordDialog::on_createPasswordButton_clicked() {
   ui->widget->setEnabled(false);
   const int currentIndex = ui->passwordTemplateSwitch->currentIndex();
   if (currentIndex < 0 ||
-      currentIndex >= static_cast<int>(m_passConfig.Characters.size())) {
+      currentIndex >= static_cast<int>(PasswordConfiguration::CHARSETS_COUNT)) {
     ui->widget->setEnabled(true);
     return;
   }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds a bounds check to the `on_createPasswordButton_clicked` function to prevent potential crashes.

The change validates the index retrieved from `ui->passwordTemplateSwitch` before using it to access `m_passConfig.Characters`. If the index is out of bounds, the password generation process is halted, and the UI is re-enabled, ensuring the application handles unexpected or invalid selections gracefully.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to the password generation dialog to ensure character set selections are properly verified before generating passwords, preventing potential errors from invalid selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->