### PR TITLE
fix: Більше української магії

### DIFF
--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -203,7 +203,7 @@
     </message>
     <message>
         <source>Use git</source>
-        <translation type="vanished">Use git</translation>
+        <translation type="vanished">Використовувати git</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="512"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -175,7 +175,7 @@
     </message>
     <message>
         <source>Use pwgen</source>
-        <translation type="vanished">Use pwgen</translation>
+        <translation type="vanished">Використовувати pwgen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -36,7 +36,7 @@
     </message>
     <message>
         <source>Password Behaviour:</source>
-        <translation type="vanished">Password Behaviour:</translation>
+        <translation type="vanished">Поведінка пароля:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -266,7 +266,7 @@
     </message>
     <message>
         <source>Nati&amp;ve git/gpg</source>
-        <translation type="vanished">Nati&amp;ve git/gpg</translation>
+        <translation type="vanished">Вбудований git/gpg</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -227,7 +227,7 @@
     </message>
     <message>
         <source>Use pass otp extension</source>
-        <translation type="vanished">Use pass otp extension</translation>
+        <translation type="vanished">Використовувати розширення pass otp</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="617"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the Ukrainian localization file (`localization_uk_UA.ts`) to provide proper translations for several UI strings that were previously untranslated or had identical English translations.

Specifically, the following phrases now have correct Ukrainian translations:
- "Password Behaviour:"
- "Use pwgen"
- "Use git"
- "Use pass otp extension"
- "Nati&amp;ve git/gpg"

This improves the user experience for Ukrainian-speaking users by making the application's interface more consistent in their language.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Ukrainian language support expanded with translations for password behavior settings, including configuration options for pwgen utility, git version control integration, pass otp extension features, and native git/gpg support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->