### PR TITLE
refactor: rename single-letter parameters in setLength and setPasswordCharTemplate

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -227,10 +227,10 @@ void PasswordDialog::setLength(int l) { ui->spinBox_pwdLength->setValue(l); }
 /**
  * @brief PasswordDialog::setPasswordCharTemplate
  * PasswordDialog::setPasswordCharTemplate chose the template style.
- * @param t
+ * @param templateIndex
  */
-void PasswordDialog::setPasswordCharTemplate(int t) {
-  ui->passwordTemplateSwitch->setCurrentIndex(t);
+void PasswordDialog::setPasswordCharTemplate(int templateIndex) {
+  ui->passwordTemplateSwitch->setCurrentIndex(templateIndex);
 }
 
 /**

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -220,9 +220,9 @@ void PasswordDialog::templateAll(bool templateAll) {
 /**
  * @brief PasswordDialog::setLength
  * PasswordDialog::setLength password length.
- * @param l
+ * @param length
  */
-void PasswordDialog::setLength(int l) { ui->spinBox_pwdLength->setValue(l); }
+void PasswordDialog::setLength(int length) { ui->spinBox_pwdLength->setValue(length); }
 
 /**
  * @brief PasswordDialog::setPasswordCharTemplate

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -222,7 +222,9 @@ void PasswordDialog::templateAll(bool templateAll) {
  * PasswordDialog::setLength password length.
  * @param length
  */
-void PasswordDialog::setLength(int length) { ui->spinBox_pwdLength->setValue(length); }
+void PasswordDialog::setLength(int length) {
+  ui->spinBox_pwdLength->setValue(length);
+}
 
 /**
  * @brief PasswordDialog::setPasswordCharTemplate

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -110,8 +110,8 @@ public:
   void setTemplate(const QString &rawFields, bool useTemplate);
 
   void templateAll(bool templateAll);
-  void setLength(int l);
-  void setPasswordCharTemplate(int t);
+  void setLength(int length);
+  void setPasswordCharTemplate(int templateIndex);
   void usePwgen(bool usePwgen);
 
 public slots:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactored parameter names in the `PasswordDialog` class for improved code clarity and readability.

Specifically:
- Renamed the `l` parameter to `length` in the `PasswordDialog::setLength` method.
- Renamed the `t` parameter to `templateIndex` in the `PasswordDialog::setPasswordCharTemplate` method.

These changes enhance code maintainability by using more descriptive parameter names without altering the functional behavior of the application.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal clarity of the password dialog by renaming parameters used in length and template setters; no behavioral changes. This enhances maintainability and readability for developers while leaving user-facing functionality and UI behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->