### PR TITLE
docs: improve CLAUDE.md and fix skill inaccuracies

### DIFF
--- a/.opencode/skills/qtpass-docs/SKILL.md
+++ b/.opencode/skills/qtpass-docs/SKILL.md
@@ -65,7 +65,7 @@ doxygen Doxyfile
 # Or use project-specific docs command
 
 # View
-open html/index.html
+open docs/index.html
 ```
 
 ## Linting
@@ -127,8 +127,8 @@ Update:
 # Generate with doxygen
 doxygen Doxyfile
 
-# Output goes to docs/html/
-ls docs/html/index.html
+# Output goes to docs/
+ls docs/index.html
 ```
 
 ## Common Pitfalls
@@ -194,16 +194,16 @@ When adding new public APIs, every public symbol in a header needs a Doxygen doc
  */
 ```
 
-The CI enforces **zero Doxygen warnings** via `docs.yml`. `WARN_AS_ERROR = YES` in `Doxyfile` causes the step to fail on any undocumented public symbol.
+The CI enforces **zero Doxygen warnings** via `docs.yml`. `WARN_AS_ERROR = FAIL_ON_WARNINGS` in `Doxyfile` causes the step to fail on any undocumented public symbol.
 
 #### Enforced Doxyfile settings
 
-| Setting            | Value            | Purpose                                           |
-| ------------------ | ---------------- | ------------------------------------------------- |
-| `FILE_PATTERNS`    | `*.cpp *.h *.md` | Includes cpp, header, and Markdown files          |
-| `EXTRACT_ALL`      | `NO`             | Required for `WARN_NO_PARAMDOC` to work           |
-| `WARN_NO_PARAMDOC` | `YES`            | Requires `@param`/`@return` on all public symbols |
-| `WARN_AS_ERROR`    | `YES`            | Fails CI on any warning                           |
+| Setting            | Value              | Purpose                                           |
+| ------------------ | ------------------ | ------------------------------------------------- |
+| `FILE_PATTERNS`    | `*.cpp *.h *.md`   | Includes cpp, header, and Markdown files          |
+| `EXTRACT_ALL`      | `NO`               | Required for `WARN_NO_PARAMDOC` to work           |
+| `WARN_NO_PARAMDOC` | `YES`              | Requires `@param`/`@return` on all public symbols |
+| `WARN_AS_ERROR`    | `FAIL_ON_WARNINGS` | Fails CI on any warning                           |
 
 #### Run locally before pushing
 

--- a/.opencode/skills/qtpass-fixing/SKILL.md
+++ b/.opencode/skills/qtpass-fixing/SKILL.md
@@ -206,20 +206,15 @@ for (const auto &user : m_userList) {
 for (int i = 0; i < m_userList.size(); ++i) {
     item->setData(Qt::UserRole, QVariant::fromValue(i));
 }
-```
 
-// Good - store index
-for (int i = 0; i < m_userList.size(); ++i) {
-item->setData(Qt::UserRole, QVariant::fromValue(i));
-}
 
 // Later, lookup by index
 bool success = false;
 const int index = item->data(Qt::UserRole).toInt(&success);
 if (success && index >= 0 && index < m_userList.size()) {
-m_userList[index].enabled = item->checkState() == Qt::Checked;
+    m_userList[index].enabled = item->checkState() == Qt::Checked;
 }
-}
+```
 
 ### Theme-Aware Colors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,22 @@ Both inherit from `Pass` (`src/pass.h`), an abstract base exposing the password 
 
 **Signal/slot flow:** `MainWindow` calls `Pass` methods → `Pass` queues commands via `Executor` → `Executor` emits signals with stdout/stderr → `Pass` processes output and emits higher-level signals → `MainWindow` updates the UI.
 
+## Git Workflow
+
+```bash
+git checkout -b fix/description
+git commit -S -m "description"          # always sign commits
+git push -u origin branch-name
+gh pr create --title "..." --body "## Summary\n- ..."
+# Before merge: rebase onto main
+git fetch origin && git pull origin main --rebase
+```
+
+When CodeRabbit/AI flags a PR issue: verify it, fix if real, push, comment with resolution. If false positive, explain and mark resolved.
+
 ## Key Conventions
 
+- Use `QCoreApplication::arguments()` instead of raw `argv[]` for CLI argument parsing
 - Wrap all user-facing strings with `tr()`
 - Use `QDir::cleanPath()` for cross-platform path normalization
 - Use `std::as_const()` instead of deprecated `qAsConst()` in Qt iterations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ git commit -S -m "description"          # always sign commits
 git push -u origin branch-name
 gh pr create --title "..." --body "## Summary\n- ..."
 # Before merge: rebase onto main
-git fetch origin && git pull origin main --rebase
+git pull --rebase origin main
 ```
 
 When CodeRabbit/AI flags a PR issue: verify it, fix if real, push, comment with resolution. If false positive, explain and mark resolved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Both inherit from `Pass` (`src/pass.h`), an abstract base exposing the password 
 ```bash
 git checkout -b fix/description
 git commit -S -m "description"          # always sign commits
-git push -u origin branch-name
+git push -u origin fix/description
 gh pr create --title "..." --body "## Summary\n- ..."
 # Before merge: rebase onto main
 git pull --rebase origin main


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request improves documentation and skill guides by:

*   **Updating Doxygen Documentation Paths and Settings:** Corrects the expected output directory for Doxygen-generated documentation from `docs/html/` to `docs/` in the `qtpass-docs` skill guide. It also updates the `WARN_AS_ERROR` Doxygen setting value from `YES` to `FAIL_ON_WARNINGS` for accuracy.
*   **Refining Code Examples:** Streamlines a code example in the `qtpass-fixing` skill guide by removing a redundant code block and improving indentation for clarity.
*   **Enhancing `CLAUDE.md`:**
    *   Adds a new "Git Workflow" section detailing standard Git commands for branching, committing, pushing, creating pull requests, and rebasing.
    *   Includes guidance on how to address feedback from CodeRabbit/AI during pull request reviews.
    *   Expands the "Key Conventions" section with two new best practices: using `QCoreApplication::arguments()` for CLI argument parsing and `std::as_const()` instead of `qAsConst()` for Qt iterations.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation paths and adjusted CI warning-to-fail wording and accompanying table formatting.
  * Removed a duplicated code example and fixed snippet fencing/indentation for clarity.
  * Added a Git workflow section with signed-commit and pre-merge rebase guidance, plus steps for handling flagged PR issues.
  * Introduced a recommendation to use the framework's argument-parsing API instead of raw argv usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->