### PR TITLE
fix: Claude should be more modern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ When CodeRabbit/AI flags a PR issue: verify it, fix if real, push, comment with 
 - Use `QCoreApplication::arguments()` instead of raw `argv[]` for CLI argument parsing
 - Wrap all user-facing strings with `tr()`
 - Use `QDir::cleanPath()` for cross-platform path normalization
-- Use `std::as_const()` instead of deprecated `qAsConst()` in Qt iterations
+- Use `std::as_const()` (project is C++17); `qAsConst()` is a legacy pre-C++17 fallback and should not be introduced in this codebase, including Qt 5.15 builds
 - Store indices (not pointers) in `Qt::UserRole` data on model items
 - Use `QPalette` colors instead of hardcoded values for theme-aware UI
 - Check for null from `screenAt()` before dereferencing


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the code quality guideline in `CLAUDE.md` to clarify the preferred use of `std::as_const()` over `qAsConst()`. The update explains that `qAsConst()` is a legacy pre-C++17 fallback and should not be introduced in this C++17 codebase, even with Qt 5.15 builds.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated project coding conventions documentation to explicitly specify C++17 as the required language standard and refined code style guidance for standard library usage across all supported build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->