### PR TITLE
fix: address Coverity scan issues

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -1155,9 +1155,10 @@ void ImitatePass::Grep(QString pattern, bool caseInsensitive) {
         Qt::QueuedConnection);
   };
 
-  QThread *thread = QThread::create([gpgExe, storeDir, env, rx, emitResults]() {
-    emitResults(grepScanStore(env, gpgExe, storeDir, rx));
-  });
+  QThread *thread = QThread::create(
+      [gpgExe, storeDir, env, rx, emitResults = std::move(emitResults)]() {
+        std::move(emitResults)(grepScanStore(env, gpgExe, storeDir, rx));
+      });
 
   m_grepThreads.append(thread);
   connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -422,7 +422,10 @@ void Pass::GenerateGPGKeys(QString batch) {
     killArgs << "--kill";
     killArgs << "gpg-agent";
     // Use same environment as key generation to target correct gpg-agent
-    Executor::executeBlocking(env, resolvedGpgconf.program, killArgs);
+    if (Executor::executeBlocking(env, resolvedGpgconf.program, killArgs) !=
+        0) {
+      qWarning() << "Failed to kill gpg-agent";
+    }
   }
 
   executeWrapper(GPG_GENKEYS, gpgPath, {"--gen-key", "--no-tty", "--batch"},

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1479,7 +1479,7 @@ void tst_util::reencryptPathAbsolutePath() {
   QVERIFY2(tempDir.isValid(), "Temporary directory should be created");
 
   QString tempPath = tempDir.path();
-  QDir(tempPath).mkdir("testdir");
+  QVERIFY(QDir(tempPath).mkdir("testdir"));
   QString relativePathFromTemp = tempPath + "/testdir";
   QDir dir;
   QString result = QDir::cleanPath(QDir(relativePathFromTemp).absolutePath());


### PR DESCRIPTION
## Summary
Address 3 of 4 Coverity scan findings:
- **CID 503296**: Check return value of `mkdir()` in `tst_util.cpp`
- **CID 503297**: Check return value of `executeBlocking()` in `pass.cpp`
- **CID 503294**: Use `std::move(emitResults)` to avoid unnecessary copy
Note: CID 503295 (QPointer copy) is a false positive - `QPointer` is already a lightweight wrapper where copying is optimal.
## Testing
- Built successfully with `qmake6 && make -j4`
- Test `tst_util::reencryptPathAbsolutePath` passes with offscreen Qt platform