### PR TITLE
fix: address additional Coverity scan issues

### DIFF
--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -901,6 +901,10 @@ void tst_util::userInfoCreatedAndExpiry() {
   ui.name = "Test User";
   ui.key_id = "ABCDEF12";
 
+  // Verify fields were set correctly
+  QVERIFY2(ui.name == "Test User", "UserInfo name field should be set.");
+  QVERIFY2(ui.key_id == "ABCDEF12", "UserInfo key_id field should be set.");
+
   QVERIFY(!ui.created.isValid());
   QVERIFY(!ui.expiry.isValid());
 
@@ -1129,9 +1133,11 @@ void tst_util::isValidKeyIdWithEmail() {
 }
 
 void tst_util::isValidKeyIdInvalid() {
+  constexpr int MAX_KEY_ID_LENGTH = 40;
+  constexpr int TOO_LONG_KEY_ID_LENGTH = MAX_KEY_ID_LENGTH + 1;
   QVERIFY(!Util::isValidKeyId(""));
   QVERIFY(!Util::isValidKeyId("short"));
-  QVERIFY(!Util::isValidKeyId(QString(41, 'a')));
+  QVERIFY(!Util::isValidKeyId(QString(TOO_LONG_KEY_ID_LENGTH, 'a')));
   QVERIFY(!Util::isValidKeyId("invalidchars!"));
   QVERIFY(!Util::isValidKeyId("space in key"));
 }
@@ -1321,8 +1327,9 @@ void tst_util::findBinaryInPathTempExecutableInTempDir() {
     QSKIP("Cannot find 'sh' to determine a writable PATH directory");
   }
   const QString pathDir = QFileInfo(shPath).absolutePath();
-  const QString uniqueName = QStringLiteral("qtpass_test_exec_") +
-                             QUuid::createUuid().toString(QUuid::WithoutBraces);
+  const QString uniqueName =
+      QStringLiteral("qtpass_test_exec_") +
+      QUuid::createUuid().toString().remove('{').remove('}');
   const QString uniquePath = pathDir + QDir::separator() + uniqueName;
 
   QFile exec(uniquePath);


### PR DESCRIPTION
## Summary

Address 4 Coverity scan findings in tests/auto/util/tst_util.cpp:

1. **Verify struct fields**: Added assertions to verify `name` and `key_id` fields are set correctly in `userInfoCreatedAndExpiry()`
2. **Magic number**: Replaced `41` with named constants `MAX_KEY_ID_LENGTH + 1` for clarity
3. **Qt compatibility**: Use `QUuid::toString().remove('{').remove('}')` instead of `QUuid::WithoutBraces` (added in Qt 5.11) for Qt 5.10 compatibility

Note: The metatype registration verification was not added as `QMetaType::type()` is deprecated in Qt 6.x and would introduce warnings.

## Testing

- Built successfully with `qmake6 && make -j4`
- Tests pass: `userInfoCreatedAndExpiry`, `isValidKeyIdInvalid`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness with explicit validation assertions for user information fields.
  * Improved test maintainability by replacing hardcoded values with computed constants.
  * Updated test implementation for UUID string formatting.

*Note: These are internal test improvements with no direct impact on end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->