### PR TITLE
fix: use QString() for proper comparison in test assertions

### DIFF
--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -902,8 +902,10 @@ void tst_util::userInfoCreatedAndExpiry() {
   ui.key_id = "ABCDEF12";
 
   // Verify fields were set correctly
-  QVERIFY2(ui.name == "Test User", "UserInfo name field should be set.");
-  QVERIFY2(ui.key_id == "ABCDEF12", "UserInfo key_id field should be set.");
+  QVERIFY2(ui.name == QString("Test User"),
+           "UserInfo name field should be set.");
+  QVERIFY2(ui.key_id == QString("ABCDEF12"),
+           "UserInfo key_id field should be set.");
 
   QVERIFY(!ui.created.isValid());
   QVERIFY(!ui.expiry.isValid());


### PR DESCRIPTION
## Summary

Use explicit `QString()` in QVERIFY2 assertions to ensure proper QString comparison instead of implicit `const char*` comparison in `tests/auto/util/tst_util.cpp`.

This fixes the Coverity finding about string comparison in the `userInfoCreatedAndExpiry` test.

## Testing

- Built successfully with `qmake6 && make -j4`
- Test `userInfoCreatedAndExpiry` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validation logic for UserInfo field comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->