### PR TITLE
docs: Hint for qmake usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To add a new language:
 
 - Add your language code to `src/qtpass.pro` under TRANSLATIONS
 - If you have an existing build, run `make distclean` first (prevents stale generated files like `ui_*.h` from being included)
-- Run `qmake6` to generate the translation files
+- Run `qmake6` (or `qmake` if your Qt 6 installation exposes that name; run `qmake -v` to confirm it shows Qt version 6.x.x) to generate the translation files
 - Edit the `.ts` file with Qt Linguist: `linguist localization/qtpass_xx_YY.ts`
 
 Qt Linguist has helpful [in-context translation options](https://doc.qt.io/qt-5/linguist-translators.html).


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates the `CONTRIBUTING.md` file to clarify the command for generating translation files. The instructions for adding a new language now specify using `qmake6` or `qmake` (if exposed by the Qt 6 installation) to generate translation files, improving guidance for contributors.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contributing instructions for generating translation files: prefer the Qt 6 build tool (recommend qmake6; qmake is acceptable if it resolves to Qt 6) and verify the Qt 6 version before generating translations.
  * Preserved existing notes about file end-of-line state and license reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->