### PR TITLE
docs: Contributing explanantion on qt6 qmake 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ To add a new language:
 
 - Add your language code to `src/qtpass.pro` under TRANSLATIONS
 - If you have an existing build, run `make distclean` first (prevents stale generated files like `ui_*.h` from being included)
-- Run `qmake6` (or `qmake` if your Qt 6 installation exposes that name; run `qmake -v` to confirm it shows Qt version 6.x.x) to prepare the build files
+- Run `qmake6` to prepare the build files.
+- If your Qt 6 installation exposes `qmake` instead of `qmake6`, use `qmake`. Run `qmake -v` to confirm it shows Qt version 6.x.x.
 - Run `lupdate src/src.pro` to generate/update the translation `.ts` files
 - Edit the `.ts` file with Qt Linguist: `linguist localization/qtpass_xx_YY.ts`
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refined the instructions in `CONTRIBUTING.md` for adding a new language. The steps for running `qmake` to prepare build files have been clarified, separating the primary instruction to use `qmake6` from the conditional instruction to use `qmake` if `qmake6` is not exposed by the Qt 6 installation. This improves the clarity and readability of the contribution guidelines.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with clarified build file preparation instructions to improve developer experience. Enhanced documentation now provides comprehensive guidance for contributors working with varying system environments, ensuring consistent setup procedures and better clarity for contributors of all levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->