### PR TITLE
feat: add integration tests for edge cases

### DIFF
--- a/tests/auto/filecontent/tst_filecontent.cpp
+++ b/tests/auto/filecontent/tst_filecontent.cpp
@@ -23,6 +23,10 @@ private Q_SLOTS:
   void parseOtpauthHiddenLine();
   void parseColonInValue();
   void parseTemplateFieldsCaseSensitive();
+  void parseMultiplePasswordLines();
+  void parseWhitespaceOnlyContent();
+  void parseOnlyNamedFields();
+  void parseTemplateFieldsWithEmptyValues();
 };
 
 void tst_filecontent::parsePlainPassword() {
@@ -177,6 +181,52 @@ void tst_filecontent::parseTemplateFieldsCaseSensitive() {
   QVERIFY(nv.isEmpty());
   QVERIFY2(fc.getRemainingData().contains("User: value"),
            "unmatched case should be in remaining data");
+}
+
+void tst_filecontent::parseMultiplePasswordLines() {
+  QString content = "first_password\nsecond_line";
+  FileContent fc = FileContent::parse(content, QStringList(), false);
+  QVERIFY2(fc.getPassword() == "first_password",
+           "first line should be password");
+  QVERIFY2(fc.getRemainingData().contains("second_line"),
+           "remaining should contain second line");
+}
+
+void tst_filecontent::parseWhitespaceOnlyContent() {
+  QString content = "   \n  \n  ";
+  FileContent fc = FileContent::parse(content, QStringList(), false);
+  QVERIFY2(fc.getPassword().trimmed().isEmpty(),
+           "whitespace-only first line should be trimmed to empty password");
+}
+
+void tst_filecontent::parseOnlyNamedFields() {
+  QString content = "url: https://example.com\nusername: test";
+  QStringList templateFields = {"url", "username"};
+  FileContent fc = FileContent::parse(content, templateFields, false);
+  QVERIFY2(fc.getPassword() == "url: https://example.com",
+           "first line becomes password even if it looks like named field");
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY2(
+      nv.size() == 1,
+      qPrintable(
+          QString("expected 1 named value (username), got %1").arg(nv.size())));
+}
+
+void tst_filecontent::parseTemplateFieldsWithEmptyValues() {
+  QString content = "secret\nurl: \nusername: ";
+  QStringList templateFields = {"url", "username"};
+  FileContent fc = FileContent::parse(content, templateFields, false);
+  QVERIFY2(fc.getPassword() == "secret", "password should be 'secret'");
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY2(nv.size() == 2, "should have 2 named values");
+  if (nv.size() >= 1) {
+    QVERIFY2(nv[0].name == "url", "first field should be url");
+    QVERIFY2(nv[0].value.isEmpty(), "url value should be empty");
+  }
+  if (nv.size() >= 2) {
+    QVERIFY2(nv[1].name == "username", "second field should be username");
+    QVERIFY2(nv[1].value.isEmpty(), "username value should be empty");
+  }
 }
 
 QTEST_MAIN(tst_filecontent)

--- a/tests/auto/filecontent/tst_filecontent.cpp
+++ b/tests/auto/filecontent/tst_filecontent.cpp
@@ -196,7 +196,7 @@ void tst_filecontent::parseWhitespaceOnlyContent() {
   QString content = "   \n  \n  ";
   FileContent fc = FileContent::parse(content, QStringList(), false);
   QVERIFY2(fc.getPassword().trimmed().isEmpty(),
-           "whitespace-only first line should be trimmed to empty password");
+           "FileContent::parse preserves whitespace; trimmed() is empty");
 }
 
 void tst_filecontent::parseOnlyNamedFields() {

--- a/tests/auto/filecontent/tst_filecontent.cpp
+++ b/tests/auto/filecontent/tst_filecontent.cpp
@@ -188,8 +188,8 @@ void tst_filecontent::parseMultiplePasswordLines() {
   FileContent fc = FileContent::parse(content, QStringList(), false);
   QVERIFY2(fc.getPassword() == "first_password",
            "first line should be password");
-  QVERIFY2(fc.getRemainingData().contains("second_line"),
-           "remaining should contain second line");
+  QVERIFY2(fc.getRemainingData() == "second_line",
+           "remaining should be exactly second_line");
 }
 
 void tst_filecontent::parseWhitespaceOnlyContent() {
@@ -210,6 +210,10 @@ void tst_filecontent::parseOnlyNamedFields() {
       nv.size() == 1,
       qPrintable(
           QString("expected 1 named value (username), got %1").arg(nv.size())));
+  if (nv.size() == 1) {
+    QVERIFY2(nv[0].name == "username", "field name should be username");
+    QVERIFY2(nv[0].value == "test", "field value should be test");
+  }
 }
 
 void tst_filecontent::parseTemplateFieldsWithEmptyValues() {

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -148,22 +148,23 @@ class tst_integration : public QObject {
   }
 
   // Initialize a temporary pass store with an .gpg-id file and ImitatePass.
-  void initImitateStore(QTemporaryDir &storeDir, ImitatePass &pass) {
-    QVERIFY(storeDir.isValid());
+  // Returns true on success, false on failure.
+  bool initImitateStore(QTemporaryDir &storeDir, ImitatePass &pass) {
+    if (!storeDir.isValid())
+      return false;
     QtPassSettings::setPassStore(storeDir.path());
     {
       QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-      QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+      if (!gpgId.open(QIODevice::WriteOnly | QIODevice::Text))
+        return false;
       QByteArray payload = (m_keyFingerprint + "\n").toUtf8();
       qint64 bytesWritten = gpgId.write(payload);
-      QVERIFY2(
-          bytesWritten == payload.size(),
-          qPrintable(QString("failed to write .gpg-id, wrote %1 of %2 bytes")
-                         .arg(bytesWritten)
-                         .arg(payload.size())));
+      if (bytesWritten != payload.size())
+        return false;
     }
     pass.init();
     pass.updateEnv();
+    return true;
   }
 
   static auto gpgInsertErrorMsg(const QSignalSpy &errorSpy) -> QByteArray {
@@ -318,7 +319,7 @@ void tst_integration::cleanupTestCase() {
 void tst_integration::imitatePass_insertAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   const QString entryName = QStringLiteral("test/password");
   const QString entryContent = QStringLiteral("hunter2\nuser: testuser\n");
@@ -350,7 +351,7 @@ void tst_integration::imitatePass_insertAndShow() {
 void tst_integration::imitatePass_insertAndGrep() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QVERIFY(QDir(storeDir.path()).mkpath("work"));
 
@@ -377,7 +378,7 @@ void tst_integration::imitatePass_insertAndGrep() {
 void tst_integration::imitatePass_insertMoveAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -403,7 +404,7 @@ void tst_integration::imitatePass_insertMoveAndShow() {
 void tst_integration::imitatePass_insertCopyAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -428,7 +429,7 @@ void tst_integration::imitatePass_insertCopyAndShow() {
 void tst_integration::imitatePass_insertAndRemove() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -446,7 +447,7 @@ void tst_integration::imitatePass_insertAndRemove() {
 void tst_integration::imitatePass_nestedDirectoryInsertAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QVERIFY(QDir(storeDir.path()).mkpath("level1/level2/level3"));
 
@@ -481,7 +482,7 @@ void tst_integration::imitatePass_editExistingEntry() {
 
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   // Insert initial entry
   const QString entryName = QStringLiteral("editme");
@@ -528,7 +529,7 @@ void tst_integration::imitatePass_gitInitAndCommit() {
 
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QProcess gitInit;
   gitInit.setWorkingDirectory(storeDir.path());
@@ -741,7 +742,7 @@ void tst_integration::imitatePass_otpGenerate() {
 void tst_integration::imitatePass_grepCaseInsensitive() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QVERIFY(QDir(storeDir.path()).mkpath("accounts"));
 
@@ -787,7 +788,7 @@ void tst_integration::imitatePass_grepCaseInsensitive() {
 void tst_integration::imitatePass_specialCharactersInPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   const QString specialPw = QStringLiteral(
       "p@ssw0rd!#$%^&*()\nurl: https://example.com\nuser: admin");
@@ -812,7 +813,7 @@ void tst_integration::imitatePass_specialCharactersInPassword() {
 void tst_integration::imitatePass_emptyPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -833,7 +834,7 @@ void tst_integration::imitatePass_emptyPassword() {
 void tst_integration::imitatePass_utf8Characters() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   const QString utf8Pw =
       QString::fromUtf8("pässwörd\nurl: https://exämplë.com\nuser: ädmin");
@@ -858,7 +859,7 @@ void tst_integration::imitatePass_utf8Characters() {
 void tst_integration::imitatePass_longPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   const QString longPw = QString(500, 'x');
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
@@ -884,7 +885,7 @@ void tst_integration::imitatePass_longPassword() {
 void tst_integration::imitatePass_multilineContent() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  initImitateStore(storeDir, pass);
+  QVERIFY(initImitateStore(storeDir, pass));
 
   const QString multilinePw =
       QStringLiteral("secret\nnote: line 1\nnote: line 2\nnote: line 3");

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -36,9 +36,11 @@ Q_DECLARE_METATYPE(GrepResults)
 
 #define INIT_IMITATE_STORE_OR_FAIL(storeDir, pass)                             \
   do {                                                                         \
-    QString err = initImitateStore(storeDir, pass);                            \
-    if (!err.isEmpty())                                                        \
-      QFAIL(qPrintable(err));                                                  \
+    /* Note: storeDir and pass must be lvalues (not parenthesized) because     \
+       initImitateStore takes non-const references. */                         \
+    QString _initImitateStoreErr = initImitateStore(storeDir, pass);           \
+    if (!_initImitateStoreErr.isEmpty())                                       \
+      QFAIL(qPrintable(_initImitateStoreErr));                                 \
   } while (0)
 
 // ---------------------------------------------------------------------------
@@ -855,12 +857,12 @@ void tst_integration::imitatePass_utf8Characters() {
   QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
 
   const QString decrypted = showSpy[0][0].toString();
-  QVERIFY2(decrypted.contains("pässwörd"),
-           "decrypted should contain UTF-8 password characters");
-  QVERIFY2(decrypted.contains("https://exämplë.com"),
-           "decrypted should contain UTF-8 URL");
-  QVERIFY2(decrypted.contains("ädmin"),
-           "decrypted should contain UTF-8 username");
+  QVERIFY2(
+      decrypted == utf8Pw,
+      qPrintable(
+          QString("UTF-8 content should match exactly, expected:\n%1\ngot:\n%2")
+              .arg(utf8Pw)
+              .arg(decrypted)));
 }
 
 void tst_integration::imitatePass_longPassword() {

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -34,6 +34,13 @@
 using GrepResults = QList<QPair<QString, QStringList>>;
 Q_DECLARE_METATYPE(GrepResults)
 
+#define INIT_IMITATE_STORE_OR_FAIL(storeDir, pass)                             \
+  do {                                                                         \
+    QString err = initImitateStore(storeDir, pass);                            \
+    if (!err.isEmpty())                                                        \
+      QFAIL(qPrintable(err));                                                  \
+  } while (0)
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -319,9 +326,7 @@ void tst_integration::cleanupTestCase() {
 void tst_integration::imitatePass_insertAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   const QString entryName = QStringLiteral("test/password");
   const QString entryContent = QStringLiteral("hunter2\nuser: testuser\n");
@@ -353,9 +358,7 @@ void tst_integration::imitatePass_insertAndShow() {
 void tst_integration::imitatePass_insertAndGrep() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QVERIFY(QDir(storeDir.path()).mkpath("work"));
 
@@ -382,9 +385,7 @@ void tst_integration::imitatePass_insertAndGrep() {
 void tst_integration::imitatePass_insertMoveAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -410,9 +411,7 @@ void tst_integration::imitatePass_insertMoveAndShow() {
 void tst_integration::imitatePass_insertCopyAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -437,9 +436,7 @@ void tst_integration::imitatePass_insertCopyAndShow() {
 void tst_integration::imitatePass_insertAndRemove() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -457,9 +454,7 @@ void tst_integration::imitatePass_insertAndRemove() {
 void tst_integration::imitatePass_nestedDirectoryInsertAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QVERIFY(QDir(storeDir.path()).mkpath("level1/level2/level3"));
 
@@ -494,9 +489,7 @@ void tst_integration::imitatePass_editExistingEntry() {
 
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   // Insert initial entry
   const QString entryName = QStringLiteral("editme");
@@ -543,9 +536,7 @@ void tst_integration::imitatePass_gitInitAndCommit() {
 
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QProcess gitInit;
   gitInit.setWorkingDirectory(storeDir.path());
@@ -758,9 +749,7 @@ void tst_integration::imitatePass_otpGenerate() {
 void tst_integration::imitatePass_grepCaseInsensitive() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QVERIFY(QDir(storeDir.path()).mkpath("accounts"));
 
@@ -806,9 +795,7 @@ void tst_integration::imitatePass_grepCaseInsensitive() {
 void tst_integration::imitatePass_specialCharactersInPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   const QString specialPw = QStringLiteral(
       "p@ssw0rd!#$%^&*()\nurl: https://example.com\nuser: admin");
@@ -833,9 +820,7 @@ void tst_integration::imitatePass_specialCharactersInPassword() {
 void tst_integration::imitatePass_emptyPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -856,9 +841,7 @@ void tst_integration::imitatePass_emptyPassword() {
 void tst_integration::imitatePass_utf8Characters() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   const QString utf8Pw =
       QString::fromUtf8("pässwörd\nurl: https://exämplë.com\nuser: ädmin");
@@ -883,9 +866,7 @@ void tst_integration::imitatePass_utf8Characters() {
 void tst_integration::imitatePass_longPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   const QString longPw = QString(500, 'x');
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
@@ -911,9 +892,7 @@ void tst_integration::imitatePass_longPassword() {
 void tst_integration::imitatePass_multilineContent() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QString err = initImitateStore(storeDir, pass);
-  if (!err.isEmpty())
-    QFAIL(qPrintable(err));
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
   const QString multilinePw =
       QStringLiteral("secret\nnote: line 1\nnote: line 2\nnote: line 3");

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -147,6 +147,19 @@ class tst_integration : public QObject {
     pass.updateEnv();
   }
 
+  // Initialize a temporary pass store with an .gpg-id file and ImitatePass.
+  void initImitateStore(QTemporaryDir &storeDir, ImitatePass &pass) {
+    QVERIFY(storeDir.isValid());
+    QtPassSettings::setPassStore(storeDir.path());
+    {
+      QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+      QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+      gpgId.write((m_keyFingerprint + "\n").toUtf8());
+    }
+    pass.init();
+    pass.updateEnv();
+  }
+
   static auto gpgInsertErrorMsg(const QSignalSpy &errorSpy) -> QByteArray {
     if (errorSpy.count() > 0)
       return QString("GPG Insert error (rc=%1): %2")
@@ -800,18 +813,8 @@ void tst_integration::imitatePass_otpGenerate() {
 
 void tst_integration::imitatePass_grepCaseInsensitive() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QVERIFY(QDir(storeDir.path()).mkpath("accounts"));
 
@@ -856,18 +859,8 @@ void tst_integration::imitatePass_grepCaseInsensitive() {
 
 void tst_integration::imitatePass_specialCharactersInPassword() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   const QString specialPw = QStringLiteral(
       "p@ssw0rd!#$%^&*()\nurl: https://example.com\nuser: admin");
@@ -891,18 +884,8 @@ void tst_integration::imitatePass_specialCharactersInPassword() {
 
 void tst_integration::imitatePass_emptyPassword() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -922,18 +905,8 @@ void tst_integration::imitatePass_emptyPassword() {
 
 void tst_integration::imitatePass_utf8Characters() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   const QString utf8Pw =
       QString::fromUtf8("pässwörd\nurl: https://exämplë.com\nuser: ädmin");
@@ -957,18 +930,8 @@ void tst_integration::imitatePass_utf8Characters() {
 
 void tst_integration::imitatePass_longPassword() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   const QString longPw = QString(500, 'x');
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
@@ -993,18 +956,8 @@ void tst_integration::imitatePass_longPassword() {
 
 void tst_integration::imitatePass_multilineContent() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   const QString multilinePw =
       QStringLiteral("secret\nnote: line 1\nnote: line 2\nnote: line 3");

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -148,23 +148,23 @@ class tst_integration : public QObject {
   }
 
   // Initialize a temporary pass store with an .gpg-id file and ImitatePass.
-  // Returns true on success, false on failure.
-  bool initImitateStore(QTemporaryDir &storeDir, ImitatePass &pass) {
+  // Returns empty QString on success, or an error message on failure.
+  auto initImitateStore(QTemporaryDir &storeDir, ImitatePass &pass) -> QString {
     if (!storeDir.isValid())
-      return false;
+      return QStringLiteral("temp dir invalid");
     QtPassSettings::setPassStore(storeDir.path());
     {
       QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
       if (!gpgId.open(QIODevice::WriteOnly | QIODevice::Text))
-        return false;
+        return QStringLiteral("failed to open .gpg-id");
       QByteArray payload = (m_keyFingerprint + "\n").toUtf8();
       qint64 bytesWritten = gpgId.write(payload);
       if (bytesWritten != payload.size())
-        return false;
+        return QStringLiteral("failed to write .gpg-id");
     }
     pass.init();
     pass.updateEnv();
-    return true;
+    return QString();
   }
 
   static auto gpgInsertErrorMsg(const QSignalSpy &errorSpy) -> QByteArray {
@@ -319,7 +319,9 @@ void tst_integration::cleanupTestCase() {
 void tst_integration::imitatePass_insertAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   const QString entryName = QStringLiteral("test/password");
   const QString entryContent = QStringLiteral("hunter2\nuser: testuser\n");
@@ -351,7 +353,9 @@ void tst_integration::imitatePass_insertAndShow() {
 void tst_integration::imitatePass_insertAndGrep() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QVERIFY(QDir(storeDir.path()).mkpath("work"));
 
@@ -378,7 +382,9 @@ void tst_integration::imitatePass_insertAndGrep() {
 void tst_integration::imitatePass_insertMoveAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -404,7 +410,9 @@ void tst_integration::imitatePass_insertMoveAndShow() {
 void tst_integration::imitatePass_insertCopyAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -429,7 +437,9 @@ void tst_integration::imitatePass_insertCopyAndShow() {
 void tst_integration::imitatePass_insertAndRemove() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -447,7 +457,9 @@ void tst_integration::imitatePass_insertAndRemove() {
 void tst_integration::imitatePass_nestedDirectoryInsertAndShow() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QVERIFY(QDir(storeDir.path()).mkpath("level1/level2/level3"));
 
@@ -482,7 +494,9 @@ void tst_integration::imitatePass_editExistingEntry() {
 
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   // Insert initial entry
   const QString entryName = QStringLiteral("editme");
@@ -529,7 +543,9 @@ void tst_integration::imitatePass_gitInitAndCommit() {
 
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QProcess gitInit;
   gitInit.setWorkingDirectory(storeDir.path());
@@ -742,7 +758,9 @@ void tst_integration::imitatePass_otpGenerate() {
 void tst_integration::imitatePass_grepCaseInsensitive() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QVERIFY(QDir(storeDir.path()).mkpath("accounts"));
 
@@ -788,7 +806,9 @@ void tst_integration::imitatePass_grepCaseInsensitive() {
 void tst_integration::imitatePass_specialCharactersInPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   const QString specialPw = QStringLiteral(
       "p@ssw0rd!#$%^&*()\nurl: https://example.com\nuser: admin");
@@ -813,7 +833,9 @@ void tst_integration::imitatePass_specialCharactersInPassword() {
 void tst_integration::imitatePass_emptyPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -834,7 +856,9 @@ void tst_integration::imitatePass_emptyPassword() {
 void tst_integration::imitatePass_utf8Characters() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   const QString utf8Pw =
       QString::fromUtf8("pässwörd\nurl: https://exämplë.com\nuser: ädmin");
@@ -859,7 +883,9 @@ void tst_integration::imitatePass_utf8Characters() {
 void tst_integration::imitatePass_longPassword() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   const QString longPw = QString(500, 'x');
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
@@ -885,7 +911,9 @@ void tst_integration::imitatePass_longPassword() {
 void tst_integration::imitatePass_multilineContent() {
   QTemporaryDir storeDir;
   ImitatePass pass;
-  QVERIFY(initImitateStore(storeDir, pass));
+  QString err = initImitateStore(storeDir, pass);
+  if (!err.isEmpty())
+    QFAIL(qPrintable(err));
 
   const QString multilinePw =
       QStringLiteral("secret\nnote: line 1\nnote: line 2\nnote: line 3");

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -780,16 +780,24 @@ void tst_integration::imitatePass_grepCaseInsensitive() {
   for (const auto &result : results) {
     const QStringList lines = result.second;
     bool hasEmail = false;
+    bool hasUser = false;
     for (const QString &line : lines) {
       if (line.toLower().contains("email:")) {
         hasEmail = true;
-        break;
+      }
+      if (line.toLower().contains("user")) {
+        hasUser = true;
       }
     }
     QVERIFY2(
         hasEmail,
         qPrintable(QStringLiteral(
                        "Result should contain 'email:' (case-insensitive): %1")
+                       .arg(result.first)));
+    QVERIFY2(
+        hasUser,
+        qPrintable(QStringLiteral(
+                       "Result should contain 'user' (case-insensitive): %1")
                        .arg(result.first)));
   }
 }

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -184,7 +184,17 @@ private Q_SLOTS:
   void imitatePass_insertAndRemove();
   void imitatePass_nestedDirectoryInsertAndShow();
   void imitatePass_editExistingEntry();
+  void imitatePass_grepCaseInsensitive();
+  void imitatePass_specialCharactersInPassword();
+  void imitatePass_emptyPassword();
   void imitatePass_gitInitAndCommit();
+
+  // UTF-8 and unicode handling
+  void imitatePass_utf8Characters();
+
+  // Edge cases
+  void imitatePass_longPassword();
+  void imitatePass_multilineContent();
 
   // RealPass backend (skipped if `pass` not installed)
   void realPass_insertAndShow();
@@ -293,7 +303,7 @@ void tst_integration::imitatePass_insertAndShow() {
   QtPassSettings::setPassStore(storeDir.path());
 
   {
-    QFile gpgId(storeDir.path() + "/.gpg-id");
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
     QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
     gpgId.write((m_keyFingerprint + "\n").toUtf8());
   }
@@ -335,7 +345,7 @@ void tst_integration::imitatePass_insertAndGrep() {
   QtPassSettings::setPassStore(storeDir.path());
 
   {
-    QFile gpgId(storeDir.path() + "/.gpg-id");
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
     QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
     gpgId.write((m_keyFingerprint + "\n").toUtf8());
   }
@@ -372,7 +382,7 @@ void tst_integration::imitatePass_insertMoveAndShow() {
   QtPassSettings::setPassStore(storeDir.path());
 
   {
-    QFile gpgId(storeDir.path() + "/.gpg-id");
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
     QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
     gpgId.write((m_keyFingerprint + "\n").toUtf8());
   }
@@ -408,7 +418,7 @@ void tst_integration::imitatePass_insertCopyAndShow() {
   QtPassSettings::setPassStore(storeDir.path());
 
   {
-    QFile gpgId(storeDir.path() + "/.gpg-id");
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
     QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
     gpgId.write((m_keyFingerprint + "\n").toUtf8());
   }
@@ -443,7 +453,7 @@ void tst_integration::imitatePass_insertAndRemove() {
   QtPassSettings::setPassStore(storeDir.path());
 
   {
-    QFile gpgId(storeDir.path() + "/.gpg-id");
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
     QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
     gpgId.write((m_keyFingerprint + "\n").toUtf8());
   }
@@ -471,7 +481,7 @@ void tst_integration::imitatePass_nestedDirectoryInsertAndShow() {
   QtPassSettings::setPassStore(storeDir.path());
 
   {
-    QFile gpgId(storeDir.path() + "/.gpg-id");
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
     QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
     gpgId.write((m_keyFingerprint + "\n").toUtf8());
   }
@@ -786,6 +796,236 @@ void tst_integration::imitatePass_otpGenerate() {
            qPrintable("OTP token should be 6 digits, got: " + token));
 
   QtPassSettings::setUsePass(false);
+}
+
+void tst_integration::imitatePass_grepCaseInsensitive() {
+  QTemporaryDir storeDir;
+  QVERIFY(storeDir.isValid());
+
+  QtPassSettings::setPassStore(storeDir.path());
+
+  {
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+    gpgId.write((m_keyFingerprint + "\n").toUtf8());
+  }
+
+  ImitatePass pass;
+  setupPass(pass);
+
+  QVERIFY(QDir(storeDir.path()).mkpath("accounts"));
+
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("accounts/Google"),
+              QStringLiteral("pass123\nemail: user@google.com\n"), false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  insertSpy.clear();
+  insertErrorSpy.clear();
+  pass.Insert(QStringLiteral("accounts/Amazon"),
+              QStringLiteral("pass456\nemail: user@amazon.com\n"), false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  QSignalSpy grepSpy(&pass, &Pass::finishedGrep);
+  pass.Grep(QStringLiteral("USER"), true);
+  QVERIFY2(waitForSignal(grepSpy, 20000), "finishedGrep not emitted");
+
+  const auto results = grepSpy[0][0].value<GrepResults>();
+  QVERIFY2(results.size() == 2,
+           qPrintable(QStringLiteral("case-insensitive grep should find 2 "
+                                     "entries, got: %1")
+                          .arg(results.size())));
+
+  for (const auto &result : results) {
+    const QStringList lines = result.second;
+    bool hasEmail = false;
+    for (const QString &line : lines) {
+      if (line.toLower().contains("email:")) {
+        hasEmail = true;
+        break;
+      }
+    }
+    QVERIFY2(
+        hasEmail,
+        qPrintable(QStringLiteral(
+                       "Result should contain 'email:' (case-insensitive): %1")
+                       .arg(result.first)));
+  }
+}
+
+void tst_integration::imitatePass_specialCharactersInPassword() {
+  QTemporaryDir storeDir;
+  QVERIFY(storeDir.isValid());
+
+  QtPassSettings::setPassStore(storeDir.path());
+
+  {
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+    gpgId.write((m_keyFingerprint + "\n").toUtf8());
+  }
+
+  ImitatePass pass;
+  setupPass(pass);
+
+  const QString specialPw = QStringLiteral(
+      "p@ssw0rd!#$%^&*()\nurl: https://example.com\nuser: admin");
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("special"), specialPw, false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  QSignalSpy showSpy(&pass, &Pass::finishedShow);
+  pass.Show(QStringLiteral("special"));
+  QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
+
+  const QString decrypted = showSpy[0][0].toString();
+  QVERIFY2(decrypted.contains("p@ssw0rd!#$%^&*()"),
+           "decrypted should contain special characters");
+  QVERIFY2(decrypted.contains("https://example.com"),
+           "decrypted should contain URL field");
+  QVERIFY2(decrypted.contains("user: admin"),
+           "decrypted should contain user field");
+}
+
+void tst_integration::imitatePass_emptyPassword() {
+  QTemporaryDir storeDir;
+  QVERIFY(storeDir.isValid());
+
+  QtPassSettings::setPassStore(storeDir.path());
+
+  {
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+    gpgId.write((m_keyFingerprint + "\n").toUtf8());
+  }
+
+  ImitatePass pass;
+  setupPass(pass);
+
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("empty"), QStringLiteral("\n"), false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  QSignalSpy showSpy(&pass, &Pass::finishedShow);
+  pass.Show(QStringLiteral("empty"));
+  QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
+
+  const QString decrypted = showSpy[0][0].toString();
+  QVERIFY2(
+      decrypted == "\n",
+      qPrintable(QString("empty password should be preserved as '\\n', got: %1")
+                     .arg(decrypted)));
+}
+
+void tst_integration::imitatePass_utf8Characters() {
+  QTemporaryDir storeDir;
+  QVERIFY(storeDir.isValid());
+
+  QtPassSettings::setPassStore(storeDir.path());
+
+  {
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+    gpgId.write((m_keyFingerprint + "\n").toUtf8());
+  }
+
+  ImitatePass pass;
+  setupPass(pass);
+
+  const QString utf8Pw =
+      QString::fromUtf8("pässwörd\nurl: https://exämplë.com\nuser: ädmin");
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("utf8"), utf8Pw, false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  QSignalSpy showSpy(&pass, &Pass::finishedShow);
+  pass.Show(QStringLiteral("utf8"));
+  QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
+
+  const QString decrypted = showSpy[0][0].toString();
+  QVERIFY2(decrypted.contains("pässwörd"),
+           "decrypted should contain UTF-8 password characters");
+  QVERIFY2(decrypted.contains("https://exämplë.com"),
+           "decrypted should contain UTF-8 URL");
+  QVERIFY2(decrypted.contains("ädmin"),
+           "decrypted should contain UTF-8 username");
+}
+
+void tst_integration::imitatePass_longPassword() {
+  QTemporaryDir storeDir;
+  QVERIFY(storeDir.isValid());
+
+  QtPassSettings::setPassStore(storeDir.path());
+
+  {
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+    gpgId.write((m_keyFingerprint + "\n").toUtf8());
+  }
+
+  ImitatePass pass;
+  setupPass(pass);
+
+  const QString longPw = QString(500, 'x');
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("long"), longPw, false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  QSignalSpy showSpy(&pass, &Pass::finishedShow);
+  pass.Show(QStringLiteral("long"));
+  QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
+
+  const QString decrypted = showSpy[0][0].toString();
+  QVERIFY2(
+      decrypted.length() == 500,
+      qPrintable(
+          QString(
+              "long password should be preserved, expected 500 chars, got: %1")
+              .arg(decrypted.length())));
+  QVERIFY2(decrypted == longPw,
+           "decrypted should match original long password");
+}
+
+void tst_integration::imitatePass_multilineContent() {
+  QTemporaryDir storeDir;
+  QVERIFY(storeDir.isValid());
+
+  QtPassSettings::setPassStore(storeDir.path());
+
+  {
+    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
+    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
+    gpgId.write((m_keyFingerprint + "\n").toUtf8());
+  }
+
+  ImitatePass pass;
+  setupPass(pass);
+
+  const QString multilinePw =
+      QStringLiteral("secret\nnote: line 1\nnote: line 2\nnote: line 3");
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("multiline"), multilinePw, false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  QSignalSpy showSpy(&pass, &Pass::finishedShow);
+  pass.Show(QStringLiteral("multiline"));
+  QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
+
+  const QString decrypted = showSpy[0][0].toString();
+  QVERIFY2(decrypted.startsWith("secret"),
+           "decrypted should start with password");
+  QVERIFY2(decrypted.contains("note: line 1"),
+           "decrypted should contain first note");
+  QVERIFY2(decrypted.contains("note: line 2"),
+           "decrypted should contain second note");
+  QVERIFY2(decrypted.contains("note: line 3"),
+           "decrypted should contain third note");
 }
 
 QTEST_MAIN(tst_integration)

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -317,18 +317,8 @@ void tst_integration::cleanupTestCase() {
 
 void tst_integration::imitatePass_insertAndShow() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   const QString entryName = QStringLiteral("test/password");
   const QString entryContent = QStringLiteral("hunter2\nuser: testuser\n");
@@ -359,18 +349,8 @@ void tst_integration::imitatePass_insertAndShow() {
 
 void tst_integration::imitatePass_insertAndGrep() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QVERIFY(QDir(storeDir.path()).mkpath("work"));
 
@@ -396,18 +376,8 @@ void tst_integration::imitatePass_insertAndGrep() {
 
 void tst_integration::imitatePass_insertMoveAndShow() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -432,18 +402,8 @@ void tst_integration::imitatePass_insertMoveAndShow() {
 
 void tst_integration::imitatePass_insertCopyAndShow() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -467,18 +427,8 @@ void tst_integration::imitatePass_insertCopyAndShow() {
 
 void tst_integration::imitatePass_insertAndRemove() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -495,18 +445,8 @@ void tst_integration::imitatePass_insertAndRemove() {
 
 void tst_integration::imitatePass_nestedDirectoryInsertAndShow() {
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   QVERIFY(QDir(storeDir.path()).mkpath("level1/level2/level3"));
 
@@ -540,18 +480,8 @@ void tst_integration::imitatePass_editExistingEntry() {
   QtPassSettings::setUseGit(false); // Ensure git is off for this test
 
   QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
-
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
-
   ImitatePass pass;
-  setupPass(pass);
+  initImitateStore(storeDir, pass);
 
   // Insert initial entry
   const QString entryName = QStringLiteral("editme");
@@ -593,18 +523,12 @@ void tst_integration::imitatePass_gitInitAndCommit() {
 
   RestoreUseGit restoreUseGit;
 
-  QTemporaryDir storeDir;
-  QVERIFY(storeDir.isValid());
-
-  QtPassSettings::setPassStore(storeDir.path());
   QtPassSettings::setGitExecutable(gitExe);
   QtPassSettings::setUseGit(true);
 
-  {
-    QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
-    QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-    gpgId.write((m_keyFingerprint + "\n").toUtf8());
-  }
+  QTemporaryDir storeDir;
+  ImitatePass pass;
+  initImitateStore(storeDir, pass);
 
   QProcess gitInit;
   gitInit.setWorkingDirectory(storeDir.path());
@@ -636,9 +560,6 @@ void tst_integration::imitatePass_gitInitAndCommit() {
            qPrintable(QString("git config commit.gpgsign failed: %1")
                           .arg(QString::fromUtf8(
                               gitConfigSign.readAllStandardError()))));
-
-  ImitatePass pass;
-  setupPass(pass);
 
   const QString entryName = QStringLiteral("gitentry");
   const QString entryContent = QStringLiteral("secret\nurl: example.com\n");
@@ -977,14 +898,12 @@ void tst_integration::imitatePass_multilineContent() {
   QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted");
 
   const QString decrypted = showSpy[0][0].toString();
-  QVERIFY2(decrypted.startsWith("secret"),
-           "decrypted should start with password");
-  QVERIFY2(decrypted.contains("note: line 1"),
-           "decrypted should contain first note");
-  QVERIFY2(decrypted.contains("note: line 2"),
-           "decrypted should contain second note");
-  QVERIFY2(decrypted.contains("note: line 3"),
-           "decrypted should contain third note");
+  QVERIFY2(
+      decrypted == multilinePw,
+      qPrintable(QString("decrypted should match original multiline content, "
+                         "expected:\n%1\ngot:\n%2")
+                     .arg(multilinePw)
+                     .arg(decrypted)));
 }
 
 QTEST_MAIN(tst_integration)

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -154,7 +154,13 @@ class tst_integration : public QObject {
     {
       QFile gpgId(QDir::cleanPath(storeDir.path() + "/.gpg-id"));
       QVERIFY(gpgId.open(QIODevice::WriteOnly | QIODevice::Text));
-      gpgId.write((m_keyFingerprint + "\n").toUtf8());
+      QByteArray payload = (m_keyFingerprint + "\n").toUtf8();
+      qint64 bytesWritten = gpgId.write(payload);
+      QVERIFY2(
+          bytesWritten == payload.size(),
+          qPrintable(QString("failed to write .gpg-id, wrote %1 of %2 bytes")
+                         .arg(bytesWritten)
+                         .arg(payload.size())));
     }
     pass.init();
     pass.updateEnv();

--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -55,8 +55,8 @@ void tst_simpletransaction::transactionStartEndExplicit() {
   st.transactionAdd(Enums::PASS_SHOW);
   st.transactionEnd(Enums::PASS_SHOW);
   Enums::PROCESS result = st.transactionIsOver(Enums::PASS_SHOW);
-  QVERIFY2(result != Enums::INVALID,
-           "transaction should be complete after transactionEnd");
+  QVERIFY2(result == Enums::PASS_SHOW,
+           "transactionIsOver(PASS_SHOW) should return PASS_SHOW after end");
 }
 
 void tst_simpletransaction::transactionQueueOrder() {
@@ -68,6 +68,10 @@ void tst_simpletransaction::transactionQueueOrder() {
   QVERIFY2(
       r1 == Enums::PASS_INSERT,
       "first item should complete immediately when no transaction started");
+  Enums::PROCESS r2 = st.transactionIsOver(Enums::PASS_REMOVE);
+  QVERIFY2(r2 == Enums::PASS_REMOVE, "PASS_REMOVE should complete second");
+  Enums::PROCESS r3 = st.transactionIsOver(Enums::PASS_SHOW);
+  QVERIFY2(r3 == Enums::PASS_SHOW, "PASS_SHOW should complete third");
 }
 
 void tst_simpletransaction::cleanupTestCase() {}

--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -13,6 +13,8 @@ private Q_SLOTS:
   void transactionAdd();
   void transactionIsOver();
   void nestedTransaction();
+  void transactionStartEndExplicit();
+  void transactionQueueOrder();
   void cleanupTestCase();
 };
 
@@ -44,6 +46,28 @@ void tst_simpletransaction::nestedTransaction() {
   QCOMPARE(passShowResult, Enums::PASS_SHOW);
   Enums::PROCESS gitPullResult = st.transactionIsOver(Enums::GIT_PULL);
   QCOMPARE(gitPullResult, Enums::GIT_PULL);
+}
+
+void tst_simpletransaction::transactionStartEndExplicit() {
+  simpleTransaction st;
+  st.transactionStart();
+  st.transactionAdd(Enums::PASS_INSERT);
+  st.transactionAdd(Enums::PASS_SHOW);
+  st.transactionEnd(Enums::PASS_SHOW);
+  Enums::PROCESS result = st.transactionIsOver(Enums::PASS_SHOW);
+  QVERIFY2(result != Enums::INVALID,
+           "transaction should be complete after transactionEnd");
+}
+
+void tst_simpletransaction::transactionQueueOrder() {
+  simpleTransaction st;
+  st.transactionAdd(Enums::PASS_INSERT);
+  st.transactionAdd(Enums::PASS_REMOVE);
+  st.transactionAdd(Enums::PASS_SHOW);
+  Enums::PROCESS r1 = st.transactionIsOver(Enums::PASS_INSERT);
+  QVERIFY2(
+      r1 == Enums::PASS_INSERT,
+      "first item should complete immediately when no transaction started");
 }
 
 void tst_simpletransaction::cleanupTestCase() {}


### PR DESCRIPTION
## Summary

Add 3 new integration tests to `tests/auto/integration/tst_integration.cpp`:

1. **imitatePass_grepCaseInsensitive** - Tests case-insensitive grep search (passes `true` for caseInsensitive parameter)

2. **imitatePass_specialCharactersInPassword** - Tests passwords with special characters like `@`, `!`, `#`, `$`, etc. and verifies URL and user fields are properly handled

3. **imitatePass_emptyPassword** - Tests edge case of empty password (just newline)

## Testing

- Built successfully with `qmake6 && make -j4`
- Integration tests require GPG to run (will be skipped in environments without GPG)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration tests for the GPG-backed password store: case-insensitive search, special-character and empty passwords, UTF-8/unicode, long passwords, multiline entries, and unified temporary-store setup across tests to reduce duplication.
  * Added file-content parsing tests: multi-line password handling, whitespace-first-line behavior, template-field extraction (including empty values), and preservation of remaining content.
  * Added transaction tests validating explicit transaction lifecycle and queue ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->