### PR TITLE
docs: Mention to QtLinguist 6 instead of 5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To add a new language:
 - Run `lupdate src/src.pro` to generate/update the translation `.ts` files
 - Edit the `.ts` file with Qt Linguist: `linguist localization/qtpass_xx_YY.ts`
 
-Qt Linguist has helpful [in-context translation options](https://doc.qt.io/qt-5/linguist-translators.html).
+Qt Linguist has helpful [in-context translation options](https://doc.qt.io/qt-6/linguist-translators.html).
 
 ## Windows Developers: Symlink Setup
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates the link to Qt Linguist documentation in `CONTRIBUTING.md` to point to the Qt 6 version instead of Qt 5. This ensures contributors are directed to the most current documentation for in-context translation options.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Qt Linguist documentation reference in contributor guidelines to the current version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->