### PR TITLE
fix: translation spelling corrections

### DIFF
--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -389,7 +389,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="371"/>
         <source>Alphabetical</source>
-        <translation>Alphabetic</translation>
+        <translation>Alphabétique</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="376"/>

--- a/localization/localization_lb_LU.ts
+++ b/localization/localization_lb_LU.ts
@@ -132,7 +132,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
         <source>Exclude capital letters</source>
-        <translation>Kapitalbréiwer	Ausgeschloss</translation>
+        <translation>Kapitalbréiwer Ausgeschloss</translation>
     </message>
     <message>
         <source>Include special symbols </source>

--- a/localization/localization_nl_BE.ts
+++ b/localization/localization_nl_BE.ts
@@ -32,7 +32,7 @@
         <location filename="../src/configdialog.ui" line="115"/>
         <location filename="../src/configdialog.ui" line="198"/>
         <source>Seconds</source>
-        <translation>Secondes</translation>
+        <translation>Seconden</translation>
     </message>
     <message>
         <source>Password Behaviour:</source>
@@ -106,7 +106,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="371"/>
         <source>Alphabetical</source>
-        <translation>Alphabetisch</translation>
+        <translation>Alfabetisch</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="376"/>
@@ -1464,7 +1464,7 @@ Doorgaan?</translation>
     <message>
         <location filename="../src/passworddialog.ui" line="119"/>
         <source>Alphabetical</source>
-        <translation>Alphabetisch</translation>
+        <translation>Alfabetisch</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="124"/>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrected several spelling and formatting errors in the following localization files:

*   **French (`localization_fr_FR.ts`)**: Corrected "Alphabetic" to "Alphabétique".
*   **Luxembourgish (`localization_lb_LU.ts`)**: Removed an extraneous tab character from the translation for "Exclude capital letters".
*   **Dutch (Belgium) (`localization_nl_BE.ts`)**:
    *   Corrected "Secondes" to "Seconden" for "Seconds".
    *   Corrected "Alphabetisch" to "Alfabetisch" for "Alphabetical".
<!-- kody-pr-summary:end -->