### PR TITLE
docs: even more words for qt versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To add a new language:
 
 - Add your language code to `src/qtpass.pro` under TRANSLATIONS
 - If you have an existing build, run `make distclean` first (prevents stale generated files like `ui_*.h` from being included)
-- Determine which qmake command your Qt 6 installation provides: run `qmake6 -v` (or `qmake -v` if `qmake6` is unavailable) and confirm it shows Qt version 6.x.x.
+- Determine which qmake command your Qt 6 installation provides: run `qmake6 -v` (or `qmake -v` if `qmake6` is unavailable) and confirm it shows Qt version 6.2 or newer.
 - Run that same command (`qmake6` or `qmake`) to prepare the build files.
 - Run `lupdate src/src.pro` to generate/update the translation `.ts` files
 - Edit the `.ts` file with Qt Linguist: `linguist localization/qtpass_xx_YY.ts`


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the `CONTRIBUTING.md` file to clarify the minimum required Qt 6 version for contributors. The instructions for adding a new language now specify that Qt version 6.2 or newer is required, replacing the previous "6.x.x" general reference.
<!-- kody-pr-summary:end -->