### PR TITLE
fix: simpletransaction test improvements (v3)

### DIFF
--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -9,7 +9,7 @@ class tst_simpletransaction : public QObject {
   Q_OBJECT
 
 private Q_SLOTS:
-  void transactionStartEnd();
+  void transactionAddAndComplete();
   void transactionAdd();
   void transactionIsOver();
   void nestedTransaction();
@@ -17,7 +17,7 @@ private Q_SLOTS:
   void transactionQueueOrder();
 };
 
-void tst_simpletransaction::transactionStartEnd() {
+void tst_simpletransaction::transactionAddAndComplete() {
   simpleTransaction st;
   st.transactionAdd(Enums::PASS_SHOW);
   Enums::PROCESS result = st.transactionIsOver(Enums::PASS_SHOW);
@@ -27,8 +27,11 @@ void tst_simpletransaction::transactionStartEnd() {
 void tst_simpletransaction::transactionAdd() {
   simpleTransaction st;
   st.transactionAdd(Enums::PASS_SHOW);
-  Enums::PROCESS result = st.transactionIsOver(Enums::PASS_SHOW);
-  QVERIFY2(result == Enums::PASS_SHOW, "PASS_SHOW should be in transaction");
+  st.transactionAdd(Enums::PASS_REMOVE);
+  Enums::PROCESS first = st.transactionIsOver(Enums::PASS_SHOW);
+  Enums::PROCESS second = st.transactionIsOver(Enums::PASS_REMOVE);
+  QCOMPARE(first, Enums::PASS_SHOW);
+  QCOMPARE(second, Enums::PASS_REMOVE);
 }
 
 void tst_simpletransaction::transactionIsOver() {


### PR DESCRIPTION
## Summary

- Renamed `transactionStartEnd` to `transactionAddAndComplete` to better reflect its behavior
- Changed `transactionAdd` to test multiple adds (tests distinct behavior from single-add tests)
- Use consistent `QCOMPARE` macros across all tests

Found by GitHub AI-powered bug detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored and expanded test cases to strengthen validation coverage and improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->