### PR TITLE
fix: add PASS_INSERT to queue before transaction sequence

### DIFF
--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -53,10 +53,14 @@ void tst_simpletransaction::nestedTransaction() {
 
 void tst_simpletransaction::transactionStartEndExplicit() {
   simpleTransaction st;
-  st.transactionStart();
   st.transactionAdd(Enums::PASS_INSERT);
+  st.transactionStart();
   st.transactionAdd(Enums::PASS_SHOW);
   st.transactionEnd(Enums::PASS_SHOW);
+  Enums::PROCESS passInsertResult = st.transactionIsOver(Enums::PASS_INSERT);
+  QVERIFY2(
+      passInsertResult == Enums::PASS_INSERT,
+      "PASS_INSERT should still be in queue after transactionEnd(PASS_SHOW)");
   Enums::PROCESS result = st.transactionIsOver(Enums::PASS_SHOW);
   QVERIFY2(result == Enums::PASS_SHOW,
            "transactionIsOver(PASS_SHOW) should return PASS_SHOW after end");


### PR DESCRIPTION
## Summary

- Add PASS_INSERT to transactionQueue before starting a transaction with transactionStart/End
- This ensures PASS_INSERT remains in queue after transactionEnd(PASS_SHOW)
- Verifies transactionEnd only affects the specified transaction, not queue entries

Found by GitHub AI-powered bug detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated transaction handling tests to verify proper queue state management when multiple transactions are active. Enhanced validation ensures transactions remain in the queue as expected during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->