### PR TITLE
fix: correct QProgressIndicator license and copyright

### DIFF
--- a/.opencode/settings.local.json
+++ b/.opencode/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(npx prettier *)",
+      "Bash(gh pr *)",
+      "Bash(gh issue *)"
+    ]
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ QtPass uses [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/) for tr
 
 To add a new language:
 
-- Add your language code to `src/qtpass.pro` under TRANSLATIONS
+- Add your language code to `src/src.pro` under TRANSLATIONS
 - If you have an existing build, run `make distclean` first (prevents stale generated files like `ui_*.h` from being included)
 - Determine which qmake command your Qt 6 installation provides: run `qmake6 -v` (or `qmake -v` if `qmake6` is unavailable) and confirm it shows Qt version 6.2 or newer.
 - Run that same command (`qmake6` or `qmake`) to prepare the build files.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -31,13 +31,7 @@ SPDX-FileCopyrightText = "IJHack"
 SPDX-License-Identifier = "GFDL-1.3-or-later"
 
 [[annotations]]
-path = "src/qprogressindicator.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015 Anne Jan Brouwer", "2011 Morgan Leborgne"]
-SPDX-License-Identifier = "MIT"
-
-[[annotations]]
-path = "src/qprogressindicator.h"
+path = "src/qprogressindicator.*"
 precedence = "aggregate"
 SPDX-FileCopyrightText = ["2015 Anne Jan Brouwer", "2011 Morgan Leborgne"]
 SPDX-License-Identifier = "MIT"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -33,12 +33,12 @@ SPDX-License-Identifier = "GFDL-1.3-or-later"
 [[annotations]]
 path = "src/qprogressindicator.cpp"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2011 Morgan Leborgne and Anne Jan Brouwer"
+SPDX-FileCopyrightText = ["2015 Anne Jan Brouwer", "2011 Morgan Leborgne"]
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = "src/qprogressindicator.h"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2011 Morgan Leborgne and Anne Jan Brouwer"
+SPDX-FileCopyrightText = ["2015 Anne Jan Brouwer", "2011 Morgan Leborgne"]
 SPDX-License-Identifier = "MIT"
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -30,3 +30,15 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "IJHack"
 SPDX-License-Identifier = "GFDL-1.3-or-later"
 
+[[annotations]]
+path = "src/qprogressindicator.cpp"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2011 Morgan Leborgne and Anne Jan Brouwer"
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = "src/qprogressindicator.h"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2011 Morgan Leborgne and Anne Jan Brouwer"
+SPDX-License-Identifier = "MIT"
+

--- a/localization/localization_nl_BE.ts
+++ b/localization/localization_nl_BE.ts
@@ -423,7 +423,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="817"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;gpg&lt;/strong&gt; using your favorite package manager&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-<translation>Installeer GnuPG op uw systeem.&lt;br&gt;Installeer &lt;strong&gt;gpg&lt;/strong&gt; via uw favoriete package manager&lt;br&gt;of &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; op GnuPG.org</translation>
+        <translation>Installeer GnuPG op uw systeem.&lt;br&gt;Installeer &lt;strong&gt;gpg&lt;/strong&gt; via uw favoriete package manager&lt;br&gt;of &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; op GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="871"/>
@@ -433,7 +433,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="872"/>
         <source>Would you like to create a password-store at %1?</source>
-<translation>Wilt u een password-store maken op %1?</translation>
+        <translation>Wilt u een password-store maken op %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="877"/>
@@ -1176,7 +1176,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="914"/>
         <source>Are you sure you want to delete %1%2?</source>
-<translation>Weet u zeker dat u %1%2 wilt verwijderen?</translation>
+        <translation>Weet u zeker dat u %1%2 wilt verwijderen?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="913"/>
@@ -1430,7 +1430,7 @@ Doorgaan?</translation>
         <location filename="../src/pass.cpp" line="527"/>
         <location filename="../src/pass.cpp" line="547"/>
         <source>Encryption failed. Check that your GPG key is valid.</source>
-<translation>Encryptie faalde. Controleer dat uw GPG sleutel geldig is.</translation>
+        <translation>Encryptie faalde. Controleer dat uw GPG sleutel geldig is.</translation>
     </message>
 </context>
 <context>

--- a/src/qprogressindicator.cpp
+++ b/src/qprogressindicator.cpp
@@ -1,31 +1,6 @@
+// SPDX-FileCopyrightText: 2011 Morgan Leborgne
 // SPDX-FileCopyrightText: 2015 Anne Jan Brouwer
-// SPDX-License-Identifier: GPL-3.0-or-later
-/*
- * This code is based on https://github.com/mojocorp/QProgressIndicator
- * and published under
- *
- * The MIT License (MIT)
- *
- * Copyright (c) 2011 Morgan Leborgne
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+// SPDX-License-Identifier: MIT
 #include "qprogressindicator.h"
 #include <QPainter>
 

--- a/src/qprogressindicator.h
+++ b/src/qprogressindicator.h
@@ -1,31 +1,6 @@
+// SPDX-FileCopyrightText: 2011 Morgan Leborgne
 // SPDX-FileCopyrightText: 2015 Anne Jan Brouwer
-// SPDX-License-Identifier: GPL-3.0-or-later
-/*
- * This code is based on https://github.com/mojocorp/QProgressIndicator
- * and published under
- *
- * The MIT License (MIT)
- *
- * Copyright (c) 2011 Morgan Leborgne
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+// SPDX-License-Identifier: MIT
 
 #ifndef SRC_QPROGRESSINDICATOR_H_
 #define SRC_QPROGRESSINDICATOR_H_


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request primarily addresses the licensing and copyright information for the `QProgressIndicator` component.

Key changes include:

*   **Corrected `QProgressIndicator` License**: The license identifier for `src/qprogressindicator.cpp` and `src/qprogressindicator.h` has been updated from `GPL-3.0-or-later` to `MIT`. The detailed MIT license text, which was previously embedded as a comment block, has been removed, and `SPDX-FileCopyrightText` entries for Morgan Leborgne (2011) and Anne Jan Brouwer (2015) have been added to accurately reflect the component's origin and license.
*   **Updated Contributing Guidelines**: The `CONTRIBUTING.md` file has been updated to correctly reference `src/src.pro` instead of `src/qtpass.pro` when instructing contributors on where to add new language codes.
*   **Localization File Formatting**: Minor formatting adjustments (indentation) were made to several translation entries in `localization/localization_nl_BE.ts` without altering the translated text itself.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated translation contribution guide to reference the corrected project file path for adding languages

* **Chores**
  * Replaced license on a progress indicator component and added updated attribution under MIT
  * Added MIT license text and updated project license metadata/annotations
  * Normalized translation file formatting/indentation
  * Added a local tooling permissions configuration file
<!-- end of auto-generated comment: release notes by coderabbit.ai -->