### PR TITLE
Fix: QProgressIndicator memory leak and dark mode support

### DIFF
--- a/src/keygendialog.cpp
+++ b/src/keygendialog.cpp
@@ -19,7 +19,7 @@
  * @param parent
  */
 KeygenDialog::KeygenDialog(ConfigDialog *parent)
-    : QDialog(parent), ui(new Ui::KeygenDialog) {
+    : QDialog(parent), ui(new Ui::KeygenDialog), m_progressIndicator(nullptr) {
   ui->setupUi(this);
   dialog = parent;
 
@@ -187,9 +187,14 @@ void KeygenDialog::done(int r) {
     ui->checkBox->setEnabled(false);
     ui->plainTextEdit->setEnabled(false);
 
-    auto *pi = new QProgressIndicator();
-    pi->startAnimation();
-    pi->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    if (!m_progressIndicator) {
+      m_progressIndicator = std::make_unique<QProgressIndicator>();
+      m_progressIndicator->setParent(this);
+      m_progressIndicator->startAnimation();
+      m_progressIndicator->setSizePolicy(QSizePolicy::Expanding,
+                                         QSizePolicy::Expanding);
+      this->layout()->addWidget(m_progressIndicator.get());
+    }
 
     ui->frame->hide();
     ui->label->setText(
@@ -198,8 +203,6 @@ void KeygenDialog::done(int r) {
            "perform some other action (type on the keyboard, move the mouse, "
            "utilize the disks) during the prime generation; this gives the "
            "random number generator a better chance to gain enough entropy."));
-
-    this->layout()->addWidget(pi);
 
     this->show();
     dialog->genKey(ui->plainTextEdit->toPlainText(), this);

--- a/src/keygendialog.h
+++ b/src/keygendialog.h
@@ -4,6 +4,9 @@
 #define SRC_KEYGENDIALOG_H_
 
 #include <QDialog>
+#include <memory>
+
+#include "qprogressindicator.h"
 
 namespace Ui {
 class KeygenDialog;
@@ -47,6 +50,7 @@ private:
   void done(int r) override;
   void no_protection(bool enable);
   ConfigDialog *dialog;
+  std::unique_ptr<QProgressIndicator> m_progressIndicator;
 };
 
 #endif // SRC_KEYGENDIALOG_H_

--- a/src/qprogressindicator.cpp
+++ b/src/qprogressindicator.cpp
@@ -108,7 +108,7 @@ void QProgressIndicator::paintEvent(QPaintEvent * /*event*/) {
 
   for (int i = 0; i < 12; ++i) {
     QColor color = m_color;
-    color.setAlphaF(int(1.0f - (i / 12.0f)));
+    color.setAlphaF(1.0f - (i / 12.0f));
     p.setPen(Qt::NoPen);
     p.setBrush(color);
     p.save();

--- a/src/qprogressindicator.cpp
+++ b/src/qprogressindicator.cpp
@@ -10,7 +10,7 @@
  */
 QProgressIndicator::QProgressIndicator(QWidget *parent)
     : QWidget(parent), m_angle(0), m_timerId(-1), m_delay(40),
-      m_displayedWhenStopped(false), m_color(Qt::black) {
+      m_displayedWhenStopped(false), m_color() {
   setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   setFocusPolicy(Qt::NoFocus);
 }
@@ -107,7 +107,7 @@ void QProgressIndicator::paintEvent(QPaintEvent * /*event*/) {
   int capsuleRadius = capsuleWidth / 2;
 
   for (int i = 0; i < 12; ++i) {
-    QColor color = m_color;
+    QColor color = m_color.isValid() ? m_color : palette().windowText().color();
     color.setAlphaF(1.0f - (i / 12.0f));
     p.setPen(Qt::NoPen);
     p.setBrush(color);

--- a/src/qprogressindicator.h
+++ b/src/qprogressindicator.h
@@ -141,9 +141,11 @@ public slots:
    */
   void setDisplayedWhenStopped(bool state);
 
-  /*! Sets the color of the components to the given color.
-      \sa color
-   */
+  /*! Sets the color of the component to the given color.
+         \param color The new color to use. Pass an invalid QColor to reset to
+     the palette fallback color.
+         \sa color
+      */
   void setColor(const QColor &color);
 
 protected:

--- a/tests/auto/ui/tst_ui.cpp
+++ b/tests/auto/ui/tst_ui.cpp
@@ -399,7 +399,7 @@ void tst_ui::progressIndicatorDefaultNotDisplayedWhenStopped() {
 
 void tst_ui::progressIndicatorDefaultColor() {
   QProgressIndicator indicator;
-  QCOMPARE(indicator.color(), QColor(Qt::black));
+  QVERIFY(!indicator.color().isValid());
 }
 
 void tst_ui::progressIndicatorStartAnimation() {
@@ -450,6 +450,8 @@ void tst_ui::progressIndicatorSetColor() {
   QColor red(Qt::red);
   indicator.setColor(red);
   QCOMPARE(indicator.color(), red);
+  indicator.setColor(QColor());
+  QVERIFY(!indicator.color().isValid());
 }
 
 void tst_ui::progressIndicatorSizeHint() {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrects the alpha calculation for the `QProgressIndicator` segments. An unnecessary `int` cast was truncating the floating-point alpha value, which likely resulted in an abrupt or incorrect visual fading effect. Removing the `int` cast ensures that the alpha value is applied as a floating-point number, providing a smoother and more accurate visual fade for the indicator.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Progress indicator now correctly adapts to the application's active color palette instead of defaulting to black when custom colors are not explicitly configured, ensuring improved visual consistency across different themes.

* **Other Changes**
  * Enhanced progress indicator implementation for better resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->