### PR TITLE
fix: SimpleTransaction transactionEnd always queues item (#1130)

### DIFF
--- a/src/simpletransaction.cpp
+++ b/src/simpletransaction.cpp
@@ -47,11 +47,11 @@ void simpleTransaction::transactionEnd(PROCESS pid) {
   dbg() << "END" << transactionDepth;
 #endif
   if (transactionDepth > 0) {
-    transactionDepth--;
-    if (transactionDepth == 0 && lastInTransaction != INVALID) {
+    if (lastInTransaction != INVALID) {
       transactionQueue.emplace(lastInTransaction, pid);
-      lastInTransaction = INVALID;
     }
+    transactionDepth--;
+    lastInTransaction = INVALID;
   }
 }
 

--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -14,6 +14,8 @@ private Q_SLOTS:
   void transactionIsOver();
   void nestedTransaction();
   void transactionStartEndExplicit();
+  void transactionEndWithoutStart();
+  void transactionStartMultipleTimes();
   void transactionQueueOrder();
 };
 
@@ -64,6 +66,33 @@ void tst_simpletransaction::transactionStartEndExplicit() {
   Enums::PROCESS result = st.transactionIsOver(Enums::PASS_SHOW);
   QVERIFY2(result == Enums::PASS_SHOW,
            "transactionIsOver(PASS_SHOW) should return PASS_SHOW after end");
+}
+
+void tst_simpletransaction::transactionEndWithoutStart() {
+  simpleTransaction st;
+  st.transactionAdd(Enums::PASS_INSERT);
+  st.transactionEnd(Enums::PASS_INSERT);
+  Enums::PROCESS result = st.transactionIsOver(Enums::PASS_INSERT);
+  QVERIFY2(result == Enums::PASS_INSERT,
+           "transactionEnd without transactionStart should not break queue "
+           "completion");
+}
+
+void tst_simpletransaction::transactionStartMultipleTimes() {
+  simpleTransaction st;
+  st.transactionAdd(Enums::PASS_INSERT);
+  st.transactionStart();
+  st.transactionStart();
+  st.transactionAdd(Enums::PASS_SHOW);
+  st.transactionEnd(Enums::PASS_SHOW);
+
+  Enums::PROCESS first = st.transactionIsOver(Enums::PASS_INSERT);
+  QVERIFY2(first == Enums::PASS_INSERT,
+           "multiple transactionStart calls should not lose previously queued "
+           "items");
+  Enums::PROCESS second = st.transactionIsOver(Enums::PASS_SHOW);
+  QVERIFY2(second == Enums::PASS_SHOW,
+           "transaction should still complete after repeated transactionStart");
 }
 
 void tst_simpletransaction::transactionQueueOrder() {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactors the `transactionEnd` method in `simpleTransaction` to modify how `lastInTransaction` is handled and when items are enqueued.

Specifically, the changes ensure that:
*   `lastInTransaction` is now consistently reset to `INVALID` whenever `transactionEnd` is called (provided `transactionDepth` is greater than 0), rather than only when the transaction depth reaches zero.
*   An item is enqueued into `transactionQueue` if `lastInTransaction` is valid, removing the previous condition that `transactionDepth` must become zero for the enqueue operation to occur.

This adjustment aims to improve the reliability of transaction finalization, ensuring `lastInTransaction` is cleared and items are enqueued more consistently across nested transaction scopes.
<!-- kody-pr-summary:end -->