### PR TITLE
tests: use modern QSignalSpy syntax in UI tests

### DIFF
--- a/tests/auto/ui/tst_ui.cpp
+++ b/tests/auto/ui/tst_ui.cpp
@@ -325,14 +325,14 @@ void tst_ui::qrCodeButtonSetAndGetRoundtrip() {
 
 void tst_ui::qrCodeButtonClickEmitsSignal() {
   QPushButtonAsQRCode btn("somedata");
-  QSignalSpy spy(&btn, SIGNAL(clicked(QString)));
+  QSignalSpy spy(&btn, &QPushButtonAsQRCode::clicked);
   btn.click();
   QCOMPARE(spy.count(), 1);
 }
 
 void tst_ui::qrCodeButtonClickSignalCarriesText() {
   QPushButtonAsQRCode btn("payload");
-  QSignalSpy spy(&btn, SIGNAL(clicked(QString)));
+  QSignalSpy spy(&btn, &QPushButtonAsQRCode::clicked);
   btn.click();
   QCOMPARE(spy.count(), 1);
   QList<QVariant> args = spy.takeFirst();
@@ -342,7 +342,7 @@ void tst_ui::qrCodeButtonClickSignalCarriesText() {
 void tst_ui::qrCodeButtonClickAfterSetTextCarriesNewText() {
   QPushButtonAsQRCode btn("old");
   btn.setTextToCopy("new");
-  QSignalSpy spy(&btn, SIGNAL(clicked(QString)));
+  QSignalSpy spy(&btn, &QPushButtonAsQRCode::clicked);
   btn.click();
   QCOMPARE(spy.count(), 1);
   QList<QVariant> args = spy.takeFirst();

--- a/tests/auto/ui/tst_ui.cpp
+++ b/tests/auto/ui/tst_ui.cpp
@@ -268,14 +268,14 @@ void tst_ui::clipboardButtonSetAndGetRoundtrip() {
 
 void tst_ui::clipboardButtonClickEmitsSignal() {
   QPushButtonWithClipboard btn("test");
-  QSignalSpy spy(&btn, SIGNAL(clicked(QString)));
+  QSignalSpy spy(&btn, &QPushButtonWithClipboard::clicked);
   btn.click();
   QCOMPARE(spy.count(), 1);
 }
 
 void tst_ui::clipboardButtonClickSignalCarriesText() {
   QPushButtonWithClipboard btn("mytext");
-  QSignalSpy spy(&btn, SIGNAL(clicked(QString)));
+  QSignalSpy spy(&btn, &QPushButtonWithClipboard::clicked);
   btn.click();
   QCOMPARE(spy.count(), 1);
   QList<QVariant> args = spy.takeFirst();
@@ -285,7 +285,7 @@ void tst_ui::clipboardButtonClickSignalCarriesText() {
 void tst_ui::clipboardButtonClickAfterSetTextCarriesNewText() {
   QPushButtonWithClipboard btn("original");
   btn.setTextToCopy("changed");
-  QSignalSpy spy(&btn, SIGNAL(clicked(QString)));
+  QSignalSpy spy(&btn, &QPushButtonWithClipboard::clicked);
   btn.click();
   QCOMPARE(spy.count(), 1);
   QList<QVariant> args = spy.takeFirst();


### PR DESCRIPTION
_This PR applies 2/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings). 3 suggestions were skipped to avoid creating conflicts._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for clipboard and QR-code button interactions to use modern signal observation patterns. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->