### PR TITLE
fix: exclude ui_*.h generated files from Doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1089,7 +1089,8 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/*
+EXCLUDE_PATTERNS       = */tests/* \
+                       */ui_*.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Excludes generated `ui_*.h` files from Doxygen documentation. This prevents auto-generated user interface header files from being processed and included in the project's API documentation.
<!-- kody-pr-summary:end -->