### PR TITLE
Add status bar to profile creation (#1034)

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -678,6 +678,7 @@ void ConfigDialog::on_addButton_clicked() {
   ui->profileTable->item(n, 0)->setSelected(true);
 
   validate();
+  updateProfileStatus(n);
 }
 
 /**
@@ -718,6 +719,7 @@ void ConfigDialog::on_deleteButton_clicked() {
   }
 
   validate();
+  updateProfileStatus(-1);
 }
 
 /**
@@ -1115,8 +1117,42 @@ void ConfigDialog::on_checkBoxUseTemplate_clicked() {
       ui->checkBoxUseTemplate->isChecked());
 }
 
+/**
+ * @brief Update status bar with profile preview for given row.
+ * @param row The row index to preview, or -1 to clear.
+ */
+void ConfigDialog::updateProfileStatus(int row) {
+  if (row < 0 || row >= ui->profileTable->rowCount()) {
+    ui->statusLabel->setText(QString());
+    return;
+  }
+
+  QTableWidgetItem *nameItem = ui->profileTable->item(row, 0);
+  QTableWidgetItem *pathItem = ui->profileTable->item(row, 1);
+
+  QString statusMessage;
+  if (nameItem && !nameItem->text().isEmpty() && pathItem &&
+      !pathItem->text().isEmpty()) {
+    QDir dir(QDir::cleanPath(pathItem->text()));
+    if (!dir.exists()) {
+      statusMessage = tr("New profile: %1 at %2")
+                          .arg(nameItem->text())
+                          .arg(QDir::cleanPath(pathItem->text()));
+    } else {
+      statusMessage = tr("Profile: %1 at %2")
+                          .arg(nameItem->text())
+                          .arg(QDir::cleanPath(pathItem->text()));
+    }
+  } else {
+    statusMessage = tr("Fill in all required fields");
+  }
+
+  ui->statusLabel->setText(statusMessage);
+}
+
 void ConfigDialog::onProfileTableItemChanged(QTableWidgetItem *item) {
   validate(item);
+  updateProfileStatus(item ? item->row() : -1);
 }
 
 /**

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -164,6 +164,7 @@ private slots:
   void on_checkBoxUsePwgen_clicked();
   void on_checkBoxUseTemplate_clicked();
   void onProfileTableItemChanged(QTableWidgetItem *item);
+  void updateProfileStatus(int row);
 
 private:
   QScopedPointer<Ui::ConfigDialog> ui;

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -1106,16 +1106,29 @@ e-mail</string>
       </spacer>
      </item>
      <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+<widget class="QDialogButtonBox" name="buttonBox">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="statusLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds a status bar to the profile creation and editing dialog. This status bar provides real-time feedback to the user as they modify profile names and paths. It displays messages indicating whether all required fields are filled, and if the entered path corresponds to a new profile (directory does not exist) or an existing one.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration dialog now shows a status label beneath the action buttons that updates in real time while editing profiles.
  * Status messages indicate missing required fields, and show whether the profile directory exists or will be created, helping validate profile name/path as you add, edit, or remove entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->