### PR TITLE
fix: Allow editing all password fields (#132)

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -26,7 +26,6 @@ PasswordDialog::PasswordDialog(PasswordConfiguration passConfig,
     : QDialog(parent), ui(new Ui::PasswordDialog),
       m_passConfig(std::move(passConfig)) {
   m_templating = false;
-  m_allFields = false;
   m_isNew = false;
 
   ui->setupUi(this);
@@ -58,7 +57,6 @@ PasswordDialog::PasswordDialog(QString file, const bool &isNew, QWidget *parent)
   usePwgen(QtPassSettings::isUsePwgen());
   setTemplate(QtPassSettings::getPassTemplate(),
               QtPassSettings::isUseTemplate());
-  templateAll(QtPassSettings::isTemplateAllFields());
 
   setLength(m_passConfig.length);
   setPasswordCharTemplate(m_passConfig.selected);
@@ -208,15 +206,6 @@ void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
       previous = line;
     }
   }
-}
-
-/**
- * @brief PasswordDialog::templateAll basic setter for use in
- * PasswordDialog::setPassword templating all tokenisable lines.
- * @param templateAll
- */
-void PasswordDialog::templateAll(bool templateAll) {
-  m_allFields = templateAll;
 }
 
 /**

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -137,8 +137,10 @@ void PasswordDialog::on_rejected() { setPassword(QString()); }
  * @param password
  */
 void PasswordDialog::setPassword(const QString &password) {
-  FileContent fileContent = FileContent::parse(
-      password, m_templating ? m_fields : QStringList(), m_allFields);
+  // Always parse all fields as editable so users can edit any field in the
+  // password file. This fixes issue #132 where users couldn't edit
+  // fields without toggling the "Show all fields templated" setting.
+  FileContent fileContent = FileContent::parse(password, m_fields, true);
   ui->lineEditPassword->setText(fileContent.getPassword());
 
   QWidget *previous = ui->checkBoxShow;

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -62,12 +62,6 @@ public:
   void setTemplate(const QString &rawFields, bool useTemplate);
 
   /**
-   * @brief Enable or disable applying the template to all applicable fields.
-   * @param templateAll true to apply templating to all fields.
-   */
-  void templateAll(bool templateAll);
-
-  /**
    * @brief Set the desired password length shown in the dialog.
    * @param length Desired password length.
    */
@@ -104,7 +98,6 @@ private:
   QStringList m_fields;
   QString m_file;
   bool m_templating{};
-  bool m_allFields{};
   bool m_isNew;
   QList<QLineEdit *> templateLines;
   QList<QLineEdit *> otherLines;

--- a/tests/auto/ui/tst_ui.cpp
+++ b/tests/auto/ui/tst_ui.cpp
@@ -105,24 +105,6 @@ void tst_ui::contentRemainsSame() {
   d->setTemplate("name", true);
   d->setPass(input);
   QCOMPARE(d->getPassword(), input);
-
-  d.reset(new PasswordDialog(PasswordConfiguration{}, nullptr));
-  d->setTemplate("", false);
-  d->templateAll(true);
-  d->setPass(input);
-  QCOMPARE(d->getPassword(), input);
-
-  d.reset(new PasswordDialog(PasswordConfiguration{}, nullptr));
-  d->setTemplate("", true);
-  d->templateAll(true);
-  d->setPass(input);
-  QCOMPARE(d->getPassword(), input);
-
-  d.reset(new PasswordDialog(PasswordConfiguration{}, nullptr));
-  d->setTemplate("name", true);
-  d->templateAll(true);
-  d->setPass(input);
-  QCOMPARE(d->getPassword(), input);
 }
 
 void tst_ui::initTestCase() {}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Ensures all fields in a password file are always parsed as editable within the password dialog. This change allows users to edit any field without needing to enable the "Show all fields templated" setting, resolving an issue where fields were not editable otherwise.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified password dialog field handling logic. All tokenizable fields are now processed consistently as editable, reducing API complexity by removing an unused configuration method. Test coverage adjusted accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->