### PR TITLE
fix: mark unused 'out' parameter in handleProcessError

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -620,6 +620,8 @@ void Pass::finished(int id, int exitCode, const QString &out,
 
 void Pass::handleProcessError(PROCESS pid, int exitCode, const QString &out,
                               const QString &err) {
+  Q_UNUSED(out);
+
   if (pid == PASS_GREP) {
     handleGrepError(exitCode, err);
     return;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Marks the `out` parameter in the `handleProcessError` function as unused using `Q_UNUSED`. This change addresses potential compiler warnings about unused variables without altering the function's behavior or logic.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code quality improvements to suppress compiler warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->