### PR TITLE
feat: Store git options per profile (#112)

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -619,6 +619,14 @@ void ConfigDialog::loadGitSettingsForProfile(
  * @return
  */
 auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
+  // Get currently selected profile name
+  QList<QTableWidgetItem *> selected = ui->profileTable->selectedItems();
+  QString selectedProfile;
+  if (!selected.isEmpty()) {
+    selectedProfile =
+        ui->profileTable->item(selected.first()->row(), 0)->text();
+  }
+
   QHash<QString, QHash<QString, QString>> profiles;
   // Check?
   for (int i = 0; i < ui->profileTable->rowCount(); ++i) {
@@ -634,12 +642,16 @@ auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
       if (nullptr != signingKeyItem) {
         profile["signingKey"] = signingKeyItem->text();
       }
-      // Save git settings from current UI state
-      profile["useGit"] = ui->checkBoxUseGit->isChecked() ? "true" : "false";
-      profile["autoPush"] =
-          ui->checkBoxAutoPush->isChecked() ? "true" : "false";
-      profile["autoPull"] =
-          ui->checkBoxAutoPull->isChecked() ? "true" : "false";
+
+      // Only update git settings for the currently selected profile
+      // Preserve existing git settings for other profiles
+      if (item->text() == selectedProfile) {
+        profile["useGit"] = ui->checkBoxUseGit->isChecked() ? "true" : "false";
+        profile["autoPush"] =
+            ui->checkBoxAutoPush->isChecked() ? "true" : "false";
+        profile["autoPull"] =
+            ui->checkBoxAutoPull->isChecked() ? "true" : "false";
+      }
       profiles.insert(item->text(), profile);
     }
   }

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -568,6 +568,9 @@ void ConfigDialog::setProfiles(QHash<QString, QHash<QString, QString>> profiles,
     // remove weird "" key value pairs
   }
 
+  // Cache profiles for use in onProfileTableSelectionChanged
+  m_profiles = profiles;
+
   ui->profileTable->setRowCount(profiles.count());
   QHashIterator<QString, QHash<QString, QString>> i(profiles);
   int n = 0;
@@ -582,7 +585,7 @@ void ConfigDialog::setProfiles(QHash<QString, QHash<QString, QString>> profiles,
       if (i.key() == currentProfile) {
         ui->profileTable->selectRow(n);
         // Load git settings for current profile
-        loadGitSettingsForProfile(currentProfile, profiles);
+        loadGitSettingsForProfile(currentProfile, m_profiles);
       }
     }
     ++n;
@@ -632,9 +635,8 @@ auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
         ui->profileTable->item(selected.first()->row(), 0)->text();
   }
 
-  // Fetch existing profiles to preserve git settings for non-selected profiles
-  QHash<QString, QHash<QString, QString>> existingProfiles =
-      QtPassSettings::getProfiles();
+  // Use cached m_profiles to preserve git settings for non-selected profiles
+  QHash<QString, QHash<QString, QString>> existingProfiles = m_profiles;
 
   QHash<QString, QHash<QString, QString>> profiles;
   // Check?
@@ -677,6 +679,8 @@ auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
       profiles.insert(item->text(), profile);
     }
   }
+  // Update cache with current in-dialog state
+  m_profiles = profiles;
   return profiles;
 }
 
@@ -1231,9 +1235,7 @@ void ConfigDialog::onProfileTableSelectionChanged() {
     return;
   }
   QString profileName = nameItem->text();
-  QHash<QString, QHash<QString, QString>> profiles =
-      QtPassSettings::getProfiles();
-  loadGitSettingsForProfile(profileName, profiles);
+  loadGitSettingsForProfile(profileName, m_profiles);
 }
 
 /**

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -98,14 +98,13 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
     ui->checkBoxUseQrencode->setToolTip(tr("qrencode needs to be installed"));
   }
 
-  setProfiles(QtPassSettings::getProfiles(), QtPassSettings::getProfile());
-  setPwgenPath(QtPassSettings::getPwgenExecutable());
-  setPasswordConfiguration(QtPassSettings::getPasswordConfiguration());
-
   usePass(QtPassSettings::isUsePass());
   useAutoclear(QtPassSettings::isUseAutoclear());
   useAutoclearPanel(QtPassSettings::isUseAutoclearPanel());
   useTrayIcon(QtPassSettings::isUseTrayIcon());
+
+  setProfiles(QtPassSettings::getProfiles(), QtPassSettings::getProfile());
+
   useGit(QtPassSettings::isUseGit());
 
   useOtp(QtPassSettings::isUseOtp());
@@ -145,6 +144,8 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
 
   connect(ui->profileTable, &QTableWidget::itemChanged, this,
           &ConfigDialog::onProfileTableItemChanged);
+  connect(ui->profileTable, &QTableWidget::itemSelectionChanged, this,
+          &ConfigDialog::onProfileTableSelectionChanged);
   connect(this, &ConfigDialog::accepted, this, &ConfigDialog::on_accepted);
 }
 
@@ -286,8 +287,6 @@ void ConfigDialog::on_accepted() {
   QtPassSettings::setPassTemplate(ui->plainTextEditTemplate->toPlainText());
   QtPassSettings::setTemplateAllFields(
       ui->checkBoxTemplateAllFields->isChecked());
-  QtPassSettings::setAutoPush(ui->checkBoxAutoPush->isChecked());
-  QtPassSettings::setAutoPull(ui->checkBoxAutoPull->isChecked());
   QtPassSettings::setAlwaysOnTop(ui->checkBoxAlwaysOnTop->isChecked());
 
   QtPassSettings::setVersion(VERSION);
@@ -606,9 +605,15 @@ void ConfigDialog::loadGitSettingsForProfile(
 
     // Load profile-specific git settings if set, otherwise use global settings
     if (!useGitStr.isEmpty()) {
-      ui->checkBoxUseGit->setChecked(useGitStr == "true");
-      ui->checkBoxAutoPush->setChecked(autoPushStr == "true");
-      ui->checkBoxAutoPull->setChecked(autoPullStr == "true");
+      useGit(useGitStr == "true");
+      ui->checkBoxAutoPush->setEnabled(ui->checkBoxUseGit->isChecked());
+      ui->checkBoxAutoPull->setEnabled(ui->checkBoxUseGit->isChecked());
+      if (autoPushStr == "true" || autoPushStr == "false") {
+        ui->checkBoxAutoPush->setChecked(autoPushStr == "true");
+      }
+      if (autoPullStr == "true" || autoPullStr == "false") {
+        ui->checkBoxAutoPull->setChecked(autoPullStr == "true");
+      }
     }
     // If not set (empty), leave global settings as-is for migration
   }
@@ -626,6 +631,10 @@ auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
     selectedProfile =
         ui->profileTable->item(selected.first()->row(), 0)->text();
   }
+
+  // Fetch existing profiles to preserve git settings for non-selected profiles
+  QHash<QString, QHash<QString, QString>> existingProfiles =
+      QtPassSettings::getProfiles();
 
   QHash<QString, QHash<QString, QString>> profiles;
   // Check?
@@ -651,6 +660,19 @@ auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
             ui->checkBoxAutoPush->isChecked() ? "true" : "false";
         profile["autoPull"] =
             ui->checkBoxAutoPull->isChecked() ? "true" : "false";
+      } else if (existingProfiles.contains(item->text())) {
+        // Preserve existing git settings for non-selected profiles
+        const QHash<QString, QString> &existing =
+            existingProfiles.value(item->text());
+        if (existing.contains("useGit")) {
+          profile["useGit"] = existing.value("useGit");
+        }
+        if (existing.contains("autoPush")) {
+          profile["autoPush"] = existing.value("autoPush");
+        }
+        if (existing.contains("autoPull")) {
+          profile["autoPull"] = existing.value("autoPull");
+        }
       }
       profiles.insert(item->text(), profile);
     }
@@ -717,7 +739,12 @@ void ConfigDialog::initializeNewProfiles(
     usersDialog.setWindowTitle(tr("Select recipients for %1").arg(name));
     const int result = usersDialog.exec();
 
-    if (result == QDialog::Accepted && ui->checkBoxUseGit->isChecked()) {
+    // Use per-profile useGit setting, falling back to global if not set
+    QString useGitStr = newProfiles.value(name).value("useGit");
+    bool useGit =
+        useGitStr.isEmpty() ? QtPassSettings::isUseGit() : useGitStr == "true";
+
+    if (result == QDialog::Accepted && useGit) {
       QtPassSettings::getPass()->GitInit();
     }
 
@@ -1191,6 +1218,22 @@ void ConfigDialog::on_checkBoxUseTemplate_clicked() {
 void ConfigDialog::onProfileTableItemChanged(QTableWidgetItem *item) {
   validate(item);
   updateProfileStatus(item ? item->row() : -1);
+}
+
+void ConfigDialog::onProfileTableSelectionChanged() {
+  QList<QTableWidgetItem *> selected = ui->profileTable->selectedItems();
+  if (selected.isEmpty()) {
+    return;
+  }
+  QTableWidgetItem *nameItem =
+      ui->profileTable->item(selected.first()->row(), 0);
+  if (nameItem == nullptr) {
+    return;
+  }
+  QString profileName = nameItem->text();
+  QHash<QString, QHash<QString, QString>> profiles =
+      QtPassSettings::getProfiles();
+  loadGitSettingsForProfile(profileName, profiles);
 }
 
 /**

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -582,9 +582,35 @@ void ConfigDialog::setProfiles(QHash<QString, QHash<QString, QString>> profiles,
           n, 2, new QTableWidgetItem(i.value().value("signingKey")));
       if (i.key() == currentProfile) {
         ui->profileTable->selectRow(n);
+        // Load git settings for current profile
+        loadGitSettingsForProfile(currentProfile, profiles);
       }
     }
     ++n;
+  }
+}
+
+/**
+ * @brief Load git settings for a specific profile.
+ * @param profileName The profile name.
+ * @param profiles The profiles hash containing git settings.
+ */
+void ConfigDialog::loadGitSettingsForProfile(
+    const QString &profileName,
+    const QHash<QString, QHash<QString, QString>> &profiles) {
+  if (profiles.contains(profileName)) {
+    const QHash<QString, QString> &profile = profiles.value(profileName);
+    QString useGitStr = profile.value("useGit");
+    QString autoPushStr = profile.value("autoPush");
+    QString autoPullStr = profile.value("autoPull");
+
+    // Load profile-specific git settings if set, otherwise use global settings
+    if (!useGitStr.isEmpty()) {
+      ui->checkBoxUseGit->setChecked(useGitStr == "true");
+      ui->checkBoxAutoPush->setChecked(autoPushStr == "true");
+      ui->checkBoxAutoPull->setChecked(autoPullStr == "true");
+    }
+    // If not set (empty), leave global settings as-is for migration
   }
 }
 
@@ -608,6 +634,12 @@ auto ConfigDialog::getProfiles() -> QHash<QString, QHash<QString, QString>> {
       if (nullptr != signingKeyItem) {
         profile["signingKey"] = signingKeyItem->text();
       }
+      // Save git settings from current UI state
+      profile["useGit"] = ui->checkBoxUseGit->isChecked() ? "true" : "false";
+      profile["autoPush"] =
+          ui->checkBoxAutoPush->isChecked() ? "true" : "false";
+      profile["autoPull"] =
+          ui->checkBoxAutoPull->isChecked() ? "true" : "false";
       profiles.insert(item->text(), profile);
     }
   }

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -198,6 +198,7 @@ private:
       const QHash<QString, QHash<QString, QString>> &existingProfiles);
 
   MainWindow *mainWindow;
+  QHash<QString, QHash<QString, QString>> m_profiles;
 };
 
 #endif // SRC_CONFIGDIALOG_H_

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -167,6 +167,9 @@ private slots:
 
 private:
   void updateProfileStatus(int row);
+  void loadGitSettingsForProfile(
+      const QString &profileName,
+      const QHash<QString, QHash<QString, QString>> &profiles);
   QScopedPointer<Ui::ConfigDialog> ui;
 
   auto getSecretKeys() -> QStringList;

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -164,6 +164,7 @@ private slots:
   void on_checkBoxUsePwgen_clicked();
   void on_checkBoxUseTemplate_clicked();
   void onProfileTableItemChanged(QTableWidgetItem *item);
+  void onProfileTableSelectionChanged();
 
 private:
   void updateProfileStatus(int row);

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -599,10 +599,13 @@ void QtPassSettings::setProfile(const QString &profile) {
 auto QtPassSettings::getProfileUseGit(const QString &profileName,
                                       const bool &defaultValue) -> bool {
   getInstance()->beginGroup(SettingsConstants::profile);
-  bool value =
-      getInstance()->value(profileName + "/useGit", defaultValue).toBool();
+  QString stored = getInstance()->value(profileName + "/useGit").toString();
   getInstance()->endGroup();
-  return value;
+  // If empty or not set, return default (migration-friendly fallback)
+  if (stored.isEmpty()) {
+    return defaultValue;
+  }
+  return stored == "true";
 }
 
 /**
@@ -613,7 +616,7 @@ auto QtPassSettings::getProfileUseGit(const QString &profileName,
 void QtPassSettings::setProfileUseGit(const QString &profileName,
                                       const bool &useGit) {
   getInstance()->beginGroup(SettingsConstants::profile);
-  getInstance()->setValue(profileName + "/useGit", useGit);
+  getInstance()->setValue(profileName + "/useGit", useGit ? "true" : "false");
   getInstance()->endGroup();
 }
 
@@ -626,10 +629,12 @@ void QtPassSettings::setProfileUseGit(const QString &profileName,
 auto QtPassSettings::getProfileAutoPush(const QString &profileName,
                                         const bool &defaultValue) -> bool {
   getInstance()->beginGroup(SettingsConstants::profile);
-  bool value =
-      getInstance()->value(profileName + "/autoPush", defaultValue).toBool();
+  QString stored = getInstance()->value(profileName + "/autoPush").toString();
   getInstance()->endGroup();
-  return value;
+  if (stored.isEmpty()) {
+    return defaultValue;
+  }
+  return stored == "true";
 }
 
 /**
@@ -640,7 +645,8 @@ auto QtPassSettings::getProfileAutoPush(const QString &profileName,
 void QtPassSettings::setProfileAutoPush(const QString &profileName,
                                         const bool &autoPush) {
   getInstance()->beginGroup(SettingsConstants::profile);
-  getInstance()->setValue(profileName + "/autoPush", autoPush);
+  getInstance()->setValue(profileName + "/autoPush",
+                          autoPush ? "true" : "false");
   getInstance()->endGroup();
 }
 
@@ -653,10 +659,12 @@ void QtPassSettings::setProfileAutoPush(const QString &profileName,
 auto QtPassSettings::getProfileAutoPull(const QString &profileName,
                                         const bool &defaultValue) -> bool {
   getInstance()->beginGroup(SettingsConstants::profile);
-  bool value =
-      getInstance()->value(profileName + "/autoPull", defaultValue).toBool();
+  QString stored = getInstance()->value(profileName + "/autoPull").toString();
   getInstance()->endGroup();
-  return value;
+  if (stored.isEmpty()) {
+    return defaultValue;
+  }
+  return stored == "true";
 }
 
 /**
@@ -667,7 +675,8 @@ auto QtPassSettings::getProfileAutoPull(const QString &profileName,
 void QtPassSettings::setProfileAutoPull(const QString &profileName,
                                         const bool &autoPull) {
   getInstance()->beginGroup(SettingsConstants::profile);
-  getInstance()->setValue(profileName + "/autoPull", autoPull);
+  getInstance()->setValue(profileName + "/autoPull",
+                          autoPull ? "true" : "false");
   getInstance()->endGroup();
 }
 

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -598,9 +598,10 @@ void QtPassSettings::setProfile(const QString &profile) {
  */
 auto QtPassSettings::getProfileUseGit(const QString &profileName,
                                       const bool &defaultValue) -> bool {
-  getInstance()->beginGroup(SettingsConstants::profile);
-  QString stored = getInstance()->value(profileName + "/useGit").toString();
-  getInstance()->endGroup();
+  QString stored = getInstance()
+                       ->value(SettingsConstants::profile + "/" + profileName +
+                               "/useGit")
+                       .toString();
   // If empty or not set, return default (migration-friendly fallback)
   if (stored.isEmpty()) {
     return defaultValue;
@@ -615,9 +616,9 @@ auto QtPassSettings::getProfileUseGit(const QString &profileName,
  */
 void QtPassSettings::setProfileUseGit(const QString &profileName,
                                       const bool &useGit) {
-  getInstance()->beginGroup(SettingsConstants::profile);
-  getInstance()->setValue(profileName + "/useGit", useGit ? "true" : "false");
-  getInstance()->endGroup();
+  getInstance()->setValue(SettingsConstants::profile + "/" + profileName +
+                              "/useGit",
+                          useGit ? "true" : "false");
 }
 
 /**
@@ -628,9 +629,10 @@ void QtPassSettings::setProfileUseGit(const QString &profileName,
  */
 auto QtPassSettings::getProfileAutoPush(const QString &profileName,
                                         const bool &defaultValue) -> bool {
-  getInstance()->beginGroup(SettingsConstants::profile);
-  QString stored = getInstance()->value(profileName + "/autoPush").toString();
-  getInstance()->endGroup();
+  QString stored = getInstance()
+                       ->value(SettingsConstants::profile + "/" + profileName +
+                               "/autoPush")
+                       .toString();
   if (stored.isEmpty()) {
     return defaultValue;
   }
@@ -644,10 +646,9 @@ auto QtPassSettings::getProfileAutoPush(const QString &profileName,
  */
 void QtPassSettings::setProfileAutoPush(const QString &profileName,
                                         const bool &autoPush) {
-  getInstance()->beginGroup(SettingsConstants::profile);
-  getInstance()->setValue(profileName + "/autoPush",
+  getInstance()->setValue(SettingsConstants::profile + "/" + profileName +
+                              "/autoPush",
                           autoPush ? "true" : "false");
-  getInstance()->endGroup();
 }
 
 /**
@@ -658,9 +659,10 @@ void QtPassSettings::setProfileAutoPush(const QString &profileName,
  */
 auto QtPassSettings::getProfileAutoPull(const QString &profileName,
                                         const bool &defaultValue) -> bool {
-  getInstance()->beginGroup(SettingsConstants::profile);
-  QString stored = getInstance()->value(profileName + "/autoPull").toString();
-  getInstance()->endGroup();
+  QString stored = getInstance()
+                       ->value(SettingsConstants::profile + "/" + profileName +
+                               "/autoPull")
+                       .toString();
   if (stored.isEmpty()) {
     return defaultValue;
   }
@@ -674,10 +676,9 @@ auto QtPassSettings::getProfileAutoPull(const QString &profileName,
  */
 void QtPassSettings::setProfileAutoPull(const QString &profileName,
                                         const bool &autoPull) {
-  getInstance()->beginGroup(SettingsConstants::profile);
-  getInstance()->setValue(profileName + "/autoPull",
+  getInstance()->setValue(SettingsConstants::profile + "/" + profileName +
+                              "/autoPull",
                           autoPull ? "true" : "false");
-  getInstance()->endGroup();
 }
 
 /**

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -124,6 +124,9 @@ auto QtPassSettings::getProfiles() -> QHash<QString, QHash<QString, QString>> {
       QHash<QString, QString> profile;
       profile.insert("path", getInstance()->value(key).toString());
       profile.insert("signingKey", "");
+      profile.insert("useGit", "");
+      profile.insert("autoPush", "");
+      profile.insert("autoPull", "");
       profiles.insert(key, profile);
     }
   }
@@ -135,7 +138,12 @@ auto QtPassSettings::getProfiles() -> QHash<QString, QHash<QString, QString>> {
     profile.insert("path", getInstance()->value(group + "/path").toString());
     profile.insert("signingKey",
                    getInstance()->value(group + "/signingKey").toString());
-    // profiles.insert(group, getInstance()->value(group).toString());
+    profile.insert("useGit",
+                   getInstance()->value(group + "/useGit").toString());
+    profile.insert("autoPush",
+                   getInstance()->value(group + "/autoPush").toString());
+    profile.insert("autoPull",
+                   getInstance()->value(group + "/autoPull").toString());
     profiles.insert(group, profile);
   }
 
@@ -163,6 +171,9 @@ void QtPassSettings::setProfiles(
     getInstance()->setValue(i.key() + "/path", i.value().value("path"));
     getInstance()->setValue(i.key() + "/signingKey",
                             i.value().value("signingKey"));
+    getInstance()->setValue(i.key() + "/useGit", i.value().value("useGit"));
+    getInstance()->setValue(i.key() + "/autoPush", i.value().value("autoPush"));
+    getInstance()->setValue(i.key() + "/autoPull", i.value().value("autoPull"));
   }
 
   getInstance()->endGroup();
@@ -577,6 +588,87 @@ auto QtPassSettings::getProfile(const QString &defaultValue) -> QString {
 }
 void QtPassSettings::setProfile(const QString &profile) {
   getInstance()->setValue(SettingsConstants::profile, profile);
+}
+
+/**
+ * @brief Gets the useGit setting for a specific profile.
+ * @param profileName The profile name.
+ * @param defaultValue The default value if not set.
+ * @return The useGit setting for the profile.
+ */
+auto QtPassSettings::getProfileUseGit(const QString &profileName,
+                                      const bool &defaultValue) -> bool {
+  getInstance()->beginGroup(SettingsConstants::profile);
+  bool value =
+      getInstance()->value(profileName + "/useGit", defaultValue).toBool();
+  getInstance()->endGroup();
+  return value;
+}
+
+/**
+ * @brief Sets the useGit setting for a specific profile.
+ * @param profileName The profile name.
+ * @param useGit The useGit value to set.
+ */
+void QtPassSettings::setProfileUseGit(const QString &profileName,
+                                      const bool &useGit) {
+  getInstance()->beginGroup(SettingsConstants::profile);
+  getInstance()->setValue(profileName + "/useGit", useGit);
+  getInstance()->endGroup();
+}
+
+/**
+ * @brief Gets the autoPush setting for a specific profile.
+ * @param profileName The profile name.
+ * @param defaultValue The default value if not set.
+ * @return The autoPush setting for the profile.
+ */
+auto QtPassSettings::getProfileAutoPush(const QString &profileName,
+                                        const bool &defaultValue) -> bool {
+  getInstance()->beginGroup(SettingsConstants::profile);
+  bool value =
+      getInstance()->value(profileName + "/autoPush", defaultValue).toBool();
+  getInstance()->endGroup();
+  return value;
+}
+
+/**
+ * @brief Sets the autoPush setting for a specific profile.
+ * @param profileName The profile name.
+ * @param autoPush The autoPush value to set.
+ */
+void QtPassSettings::setProfileAutoPush(const QString &profileName,
+                                        const bool &autoPush) {
+  getInstance()->beginGroup(SettingsConstants::profile);
+  getInstance()->setValue(profileName + "/autoPush", autoPush);
+  getInstance()->endGroup();
+}
+
+/**
+ * @brief Gets the autoPull setting for a specific profile.
+ * @param profileName The profile name.
+ * @param defaultValue The default value if not set.
+ * @return The autoPull setting for the profile.
+ */
+auto QtPassSettings::getProfileAutoPull(const QString &profileName,
+                                        const bool &defaultValue) -> bool {
+  getInstance()->beginGroup(SettingsConstants::profile);
+  bool value =
+      getInstance()->value(profileName + "/autoPull", defaultValue).toBool();
+  getInstance()->endGroup();
+  return value;
+}
+
+/**
+ * @brief Sets the autoPull setting for a specific profile.
+ * @param profileName The profile name.
+ * @param autoPull The autoPull value to set.
+ */
+void QtPassSettings::setProfileAutoPull(const QString &profileName,
+                                        const bool &autoPull) {
+  getInstance()->beginGroup(SettingsConstants::profile);
+  getInstance()->setValue(profileName + "/autoPull", autoPull);
+  getInstance()->endGroup();
 }
 
 /**

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -598,10 +598,10 @@ void QtPassSettings::setProfile(const QString &profile) {
  */
 auto QtPassSettings::getProfileUseGit(const QString &profileName,
                                       const bool &defaultValue) -> bool {
-  QString stored = getInstance()
-                       ->value(SettingsConstants::profile + "/" + profileName +
-                               "/useGit")
-                       .toString();
+  QString stored =
+      getInstance()
+          ->value(SettingsConstants::profile + "/" + profileName + "/useGit")
+          .toString();
   // If empty or not set, return default (migration-friendly fallback)
   if (stored.isEmpty()) {
     return defaultValue;
@@ -629,10 +629,10 @@ void QtPassSettings::setProfileUseGit(const QString &profileName,
  */
 auto QtPassSettings::getProfileAutoPush(const QString &profileName,
                                         const bool &defaultValue) -> bool {
-  QString stored = getInstance()
-                       ->value(SettingsConstants::profile + "/" + profileName +
-                               "/autoPush")
-                       .toString();
+  QString stored =
+      getInstance()
+          ->value(SettingsConstants::profile + "/" + profileName + "/autoPush")
+          .toString();
   if (stored.isEmpty()) {
     return defaultValue;
   }
@@ -659,10 +659,10 @@ void QtPassSettings::setProfileAutoPush(const QString &profileName,
  */
 auto QtPassSettings::getProfileAutoPull(const QString &profileName,
                                         const bool &defaultValue) -> bool {
-  QString stored = getInstance()
-                       ->value(SettingsConstants::profile + "/" + profileName +
-                               "/autoPull")
-                       .toString();
+  QString stored =
+      getInstance()
+          ->value(SettingsConstants::profile + "/" + profileName + "/autoPull")
+          .toString();
   if (stored.isEmpty()) {
     return defaultValue;
   }

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -549,6 +549,56 @@ public:
   static void setProfile(const QString &profile);
 
   /**
+   * @brief Get Git setting for a specific profile.
+   * @param profileName Name of the profile.
+   * @param defaultValue Value if not set.
+   * @return Git setting for profile.
+   */
+  static auto getProfileUseGit(const QString &profileName,
+                               const bool &defaultValue = QVariant().toBool())
+      -> bool;
+  /**
+   * @brief Set Git setting for a specific profile.
+   * @param profileName Name of the profile.
+   * @param useGit Git setting value.
+   */
+  static void setProfileUseGit(const QString &profileName, const bool &useGit);
+
+  /**
+   * @brief Get autoPush setting for a specific profile.
+   * @param profileName Name of the profile.
+   * @param defaultValue Value if not set.
+   * @return autoPush setting for profile.
+   */
+  static auto getProfileAutoPush(const QString &profileName,
+                                 const bool &defaultValue = QVariant().toBool())
+      -> bool;
+  /**
+   * @brief Set autoPush setting for a specific profile.
+   * @param profileName Name of the profile.
+   * @param autoPush autoPush setting value.
+   */
+  static void setProfileAutoPush(const QString &profileName,
+                                 const bool &autoPush);
+
+  /**
+   * @brief Get autoPull setting for a specific profile.
+   * @param profileName Name of the profile.
+   * @param defaultValue Value if not set.
+   * @return autoPull setting for profile.
+   */
+  static auto getProfileAutoPull(const QString &profileName,
+                                 const bool &defaultValue = QVariant().toBool())
+      -> bool;
+  /**
+   * @brief Set autoPull setting for a specific profile.
+   * @param profileName Name of the profile.
+   * @param autoPull autoPull setting value.
+   */
+  static void setProfileAutoPull(const QString &profileName,
+                                 const bool &autoPull);
+
+  /**
    * @brief Check whether Git integration is enabled.
    * @param defaultValue Value returned if not saved.
    * @return True if Git integration is enabled.

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -75,6 +75,12 @@ void tst_settings::initTestCase() {
 }
 
 void tst_settings::cleanupTestCase() {
+  // Clean up test profiles that may have been created during tests
+  // This ensures cleanup happens even if individual tests abort on QVERIFY
+  QtPassSettings::getInstance()->beginGroup("profile");
+  QtPassSettings::getInstance()->remove("test-git-profile");
+  QtPassSettings::getInstance()->endGroup();
+
   // Restore original settings after all tests
   // This ensures make check doesn't change user's live config
   if (m_isPortableMode && !m_settingsBackupPath.isEmpty()) {
@@ -526,10 +532,7 @@ void tst_settings::profileGitOptions() {
   QVERIFY(!QtPassSettings::getProfileAutoPush(profileName, true));
   QVERIFY(!QtPassSettings::getProfileAutoPull(profileName, true));
 
-  // Clean up test profile from settings
-  QtPassSettings::getInstance()->beginGroup("profile");
-  QtPassSettings::getInstance()->remove(profileName);
-  QtPassSettings::getInstance()->endGroup();
+  // Cleanup moved to cleanupTestCase() to ensure it runs even on test failure
 }
 
 void tst_settings::setAndGetProfileDefault() {

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -44,6 +44,7 @@ private Q_SLOTS:
   void setAndGetPasswordCharsSelection();
   void setAndGetPasswordChars();
   void setAndGetMultipleProfiles();
+  void profileGitOptions();
   void setAndGetProfileDefault();
 
 private:
@@ -492,6 +493,44 @@ void tst_settings::setAndGetMultipleProfiles() {
   QVERIFY(readProfiles.contains("profile2"));
   QVERIFY(readProfiles["profile1"].contains("path"));
   QVERIFY(readProfiles["profile2"].contains("path"));
+  // Verify new git options are in profile (issue #112)
+  QVERIFY(readProfiles["profile1"].contains("useGit"));
+  QVERIFY(readProfiles["profile1"].contains("autoPush"));
+  QVERIFY(readProfiles["profile1"].contains("autoPull"));
+}
+
+void tst_settings::profileGitOptions() {
+  const QString profileName = "test-git-profile";
+
+  // Initially should return defaults
+  QVERIFY(!QtPassSettings::getProfileAutoPush(profileName, false));
+  QVERIFY(!QtPassSettings::getProfileAutoPull(profileName, false));
+  QVERIFY(!QtPassSettings::getProfileUseGit(profileName, false));
+
+  // Set values
+  QtPassSettings::setProfileUseGit(profileName, true);
+  QtPassSettings::setProfileAutoPush(profileName, true);
+  QtPassSettings::setProfileAutoPull(profileName, true);
+
+  // Verify values persisted
+  QVERIFY(QtPassSettings::getProfileUseGit(profileName, false));
+  QVERIFY(QtPassSettings::getProfileAutoPush(profileName, false));
+  QVERIFY(QtPassSettings::getProfileAutoPull(profileName, false));
+
+  // Reset to false
+  QtPassSettings::setProfileUseGit(profileName, false);
+  QtPassSettings::setProfileAutoPush(profileName, false);
+  QtPassSettings::setProfileAutoPull(profileName, false);
+
+  QVERIFY(!QtPassSettings::getProfileUseGit(profileName, true));
+  QVERIFY(!QtPassSettings::getProfileAutoPush(profileName, true));
+  QVERIFY(!QtPassSettings::getProfileAutoPull(profileName, true));
+
+  // Clean up test profile from QSettings
+  QSettings qtSettings;
+  qtSettings.beginGroup("profile");
+  qtSettings.remove(profileName);
+  qtSettings.endGroup();
 }
 
 void tst_settings::setAndGetProfileDefault() {

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -526,11 +526,10 @@ void tst_settings::profileGitOptions() {
   QVERIFY(!QtPassSettings::getProfileAutoPush(profileName, true));
   QVERIFY(!QtPassSettings::getProfileAutoPull(profileName, true));
 
-  // Clean up test profile from QSettings
-  QSettings qtSettings;
-  qtSettings.beginGroup("profile");
-  qtSettings.remove(profileName);
-  qtSettings.endGroup();
+  // Clean up test profile from settings
+  QtPassSettings::getInstance()->beginGroup("profile");
+  QtPassSettings::getInstance()->remove(profileName);
+  QtPassSettings::getInstance()->endGroup();
 }
 
 void tst_settings::setAndGetProfileDefault() {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces the ability to configure Git integration settings on a per-profile basis.

Key changes include:
- **Per-Profile Git Settings:** Git usage (`useGit`), automatic push (`autoPush`), and automatic pull (`autoPull`) options are now stored and retrieved individually for each password store profile.
- **Configuration Dialog Updates:** The configuration dialog has been modified to load and display the Git settings specific to the currently selected profile. When a profile's settings are saved, the current state of the Git options from the UI is stored with that profile.
- **Settings Management:** New methods have been added to `QtPassSettings` to facilitate getting and setting these profile-specific Git options.
- **Backward Compatibility:** Existing profiles that do not have explicit Git settings will continue to use the global Git settings until they are individually configured.
- **Localization Updates:** Localization files have been updated to reflect changes in line numbers within the `configdialog.cpp` file.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile Git options (Enable Git, Auto-push, Auto-pull) are shown, persisted per profile, and update immediately when selecting a profile.

* **Bug Fixes**
  * Profile switching/add/rename/delete preserve each profile’s Git option state; dialog acceptance no longer overwrites global Git settings and profile initialization respects per-profile Git choice.

* **Tests**
  * Added tests for per-profile Git persistence, defaults/fallbacks, and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->