### PR TITLE
feat: multi-template support via .templates files

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -250,6 +250,7 @@ void PasswordDialog::setAvailableTemplates(
   if (templateNames.isEmpty()) {
     return;
   }
+  std::sort(templateNames.begin(), templateNames.end());
   QString selected = defaultTemplate;
   if (!templateNames.contains(selected)) {
     selected = templateNames.first();

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -7,7 +7,9 @@
 #include "passwordconfiguration.h"
 #include "qtpasssettings.h"
 #include "ui_passworddialog.h"
+#include "util.h"
 
+#include <QHash>
 #include <QLabel>
 #include <QLineEdit>
 #include <utility>
@@ -234,6 +236,29 @@ void PasswordDialog::setPasswordCharTemplate(int templateIndex) {
 void PasswordDialog::usePwgen(bool usePwgen) {
   ui->passwordTemplateSwitch->setDisabled(usePwgen);
   ui->label_characterset->setDisabled(usePwgen);
+}
+
+/**
+ * @brief Set available templates from .templates file and apply default.
+ * @param templates Hash of template name to field list.
+ * @param defaultTemplate Name of default template to select.
+ */
+void PasswordDialog::setAvailableTemplates(
+    const QHash<QString, QStringList> &templates,
+    const QString &defaultTemplate) {
+  QStringList templateNames = templates.keys();
+  if (templateNames.isEmpty()) {
+    return;
+  }
+  QString selected = defaultTemplate;
+  if (!templateNames.contains(selected)) {
+    selected = templateNames.first();
+  }
+  auto it = templates.constFind(selected);
+  if (it != templates.constEnd()) {
+    QString fields = it.value().join("\n");
+    setTemplate(fields, true);
+  }
 }
 
 /**

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -8,6 +8,7 @@
 #include "qtpasssettings.h"
 #include "ui_passworddialog.h"
 #include "util.h"
+#include <algorithm>
 
 #include <QHash>
 #include <QLabel>

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -79,6 +79,14 @@ public:
    */
   void usePwgen(bool usePwgen);
 
+  /**
+   * @brief Set the available templates from .templates file.
+   * @param templates Hash of template name to field list.
+   * @param defaultTemplate Name of default template to select.
+   */
+  void setAvailableTemplates(const QHash<QString, QStringList> &templates,
+                             const QString &defaultTemplate);
+
 public slots:
   /**
    * @brief Populate the dialog's password field from pass show output.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -12,9 +12,11 @@
  */
 
 #include "util.h"
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QSaveFile>
 #include <QTextStream>
 #include <algorithm>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -333,7 +335,7 @@ auto Util::readTemplates(const QString &storePath)
       if (!currentSection.isEmpty() && !skipInvalidSection) {
         result.insert(currentSection, currentFields);
       }
-      currentSection = line.mid(1, line.length() - 2);
+      currentSection = line.mid(1, line.length() - 2).trimmed();
       if (currentSection.isEmpty()) {
         qWarning()
             << "Empty template section in .templates file, ignoring fields";
@@ -363,11 +365,11 @@ auto Util::readTemplates(const QString &storePath)
 auto Util::writeTemplates(const QString &storePath,
                           const QHash<QString, QStringList> &templates)
     -> bool {
-  QFile file(QDir(storePath).filePath(".templates"));
-  if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+  QSaveFile saveFile(QDir(storePath).filePath(".templates"));
+  if (!saveFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
     return false;
   }
-  QTextStream out(&file);
+  QTextStream out(&saveFile);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   out.setEncoding(QStringConverter::Utf8);
 #else
@@ -386,8 +388,11 @@ auto Util::writeTemplates(const QString &storePath,
     }
     out << "\n";
   }
-  file.close();
-  return true;
+  out.flush();
+  if (out.status() != QTextStream::Ok) {
+    return false;
+  }
+  return saveFile.commit();
 }
 
 /**
@@ -399,8 +404,10 @@ auto Util::writeTemplates(const QString &storePath,
  */
 auto Util::getFolderTemplate(const QString &folderPath,
                              const QString &storePath) -> QString {
+  QDir storeDir(storePath);
+  QString cleanStoreAbs = QDir::cleanPath(storeDir.absolutePath());
+  QString sep = QDir::separator();
   QDir dir(folderPath);
-  QString cleanStore = QDir::cleanPath(storePath);
   while (true) {
     if (dir.exists(".default_template")) {
       QFile file(dir.filePath(".default_template"));
@@ -419,7 +426,10 @@ auto Util::getFolderTemplate(const QString &folderPath,
       }
     }
     QString currentPath = QDir::cleanPath(dir.absolutePath());
-    if (currentPath == cleanStore) {
+    if (currentPath == cleanStoreAbs) {
+      break;
+    }
+    if (!currentPath.startsWith(cleanStoreAbs + sep)) {
       break;
     }
     if (!dir.cdUp()) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -13,7 +13,9 @@
 
 #include "util.h"
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
+#include <QTextStream>
 #ifdef Q_OS_WIN
 #include <windows.h>
 #else
@@ -298,4 +300,97 @@ auto Util::isValidKeyId(const QString &keyId) -> bool {
   }
 
   return hexKeyIdRegex.match(normalized).hasMatch();
+}
+
+/**
+ * @brief Read templates from .templates file in password store.
+ * @param storePath Path to password store root.
+ * @return Hash of template name to field list.
+ */
+auto Util::readTemplates(const QString &storePath)
+    -> QHash<QString, QStringList> {
+  QHash<QString, QStringList> result;
+  QFile file(QDir(storePath).filePath(".templates"));
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return result;
+  }
+  QTextStream in(&file);
+  QString currentSection;
+  QStringList currentFields;
+  while (!in.atEnd()) {
+    QString line = in.readLine().trimmed();
+    if (line.startsWith('[') && line.endsWith(']')) {
+      if (!currentSection.isEmpty()) {
+        result.insert(currentSection, currentFields);
+      }
+      currentSection = line.mid(1, line.length() - 2);
+      currentFields.clear();
+    } else if (!line.isEmpty() && !line.startsWith('#')) {
+      currentFields.append(line);
+    }
+  }
+  if (!currentSection.isEmpty()) {
+    result.insert(currentSection, currentFields);
+  }
+  file.close();
+  return result;
+}
+
+/**
+ * @brief Write templates to .templates file in password store.
+ * @param storePath Path to password store root.
+ * @param templates Hash of template name to field list.
+ * @return true if write succeeded.
+ */
+auto Util::writeTemplates(const QString &storePath,
+                          const QHash<QString, QStringList> &templates)
+    -> bool {
+  QFile file(QDir(storePath).filePath(".templates"));
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    return false;
+  }
+  QTextStream out(&file);
+  out << "# QtPass templates configuration\n";
+  out << "# Format: INI-style with [template_name] sections,\n";
+  out << "# followed by field names (one per line)\n\n";
+  for (auto it = templates.constKeyValueBegin();
+       it != templates.constKeyValueEnd(); ++it) {
+    out << "[" << it->first << "]\n";
+    for (const QString &field : it->second) {
+      out << field << "\n";
+    }
+    out << "\n";
+  }
+  file.close();
+  return true;
+}
+
+/**
+ * @brief Get default template for a folder.
+ * Looks in folder, then parent folders up to root.
+ * @param folderPath Path to folder.
+ * @param storePath Path to password store root.
+ * @return Template name or empty if none found.
+ */
+auto Util::getFolderTemplate(const QString &folderPath,
+                             const QString &storePath) -> QString {
+  QDir dir(folderPath);
+  while (dir.exists(".default_template")) {
+    QFile file(dir.filePath(".default_template"));
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      QTextStream in(&file);
+      QString templateName = in.readLine().trimmed();
+      file.close();
+      if (!templateName.isEmpty() && !templateName.startsWith('#')) {
+        return templateName;
+      }
+    }
+    if (dir.absolutePath() == storePath) {
+      break;
+    }
+    if (!dir.cdUp()) {
+      break;
+    }
+  }
+  return QString();
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -15,7 +15,9 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QStringConverter>
 #include <QTextStream>
+#include <algorithm>
 #ifdef Q_OS_WIN
 #include <windows.h>
 #else

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -15,9 +15,11 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QStringConverter>
 #include <QTextStream>
 #include <algorithm>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QStringConverter>
+#endif
 #ifdef Q_OS_WIN
 #include <windows.h>
 #else
@@ -317,34 +319,38 @@ auto Util::readTemplates(const QString &storePath)
     return result;
   }
   QTextStream in(&file);
-#ifdef QT_VERSION_LT_6_0
-  in.setCodec("UTF-8");
-#else
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   in.setEncoding(QStringConverter::Utf8);
+#else
+  in.setCodec("UTF-8");
 #endif
   QString currentSection;
   QStringList currentFields;
+  bool skipInvalidSection = false;
   while (!in.atEnd()) {
     QString line = in.readLine().trimmed();
     if (line.startsWith('[') && line.endsWith(']')) {
-      if (!currentSection.isEmpty()) {
+      if (!currentSection.isEmpty() && !skipInvalidSection) {
         result.insert(currentSection, currentFields);
       }
       currentSection = line.mid(1, line.length() - 2);
       if (currentSection.isEmpty()) {
-        qWarning() << "Empty template section in .templates file";
-        currentSection.clear();
+        qWarning()
+            << "Empty template section in .templates file, ignoring fields";
+        skipInvalidSection = true;
+        currentFields.clear();
+      } else {
+        skipInvalidSection = false;
         currentFields.clear();
       }
-      currentFields.clear();
-    } else if (!line.isEmpty() && !line.startsWith('#')) {
+    } else if (!line.isEmpty() && !line.startsWith('#') &&
+               !skipInvalidSection) {
       currentFields.append(line);
     }
   }
-  if (!currentSection.isEmpty()) {
+  if (!currentSection.isEmpty() && !skipInvalidSection) {
     result.insert(currentSection, currentFields);
   }
-  file.close();
   return result;
 }
 
@@ -362,10 +368,10 @@ auto Util::writeTemplates(const QString &storePath,
     return false;
   }
   QTextStream out(&file);
-#ifdef QT_VERSION_LT_6_0
-  out.setCodec("UTF-8");
-#else
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   out.setEncoding(QStringConverter::Utf8);
+#else
+  out.setCodec("UTF-8");
 #endif
   out << "# QtPass templates configuration\n";
   out << "# Format: INI-style with [template_name] sections,\n";
@@ -400,10 +406,10 @@ auto Util::getFolderTemplate(const QString &folderPath,
       QFile file(dir.filePath(".default_template"));
       if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QTextStream in(&file);
-#ifdef QT_VERSION_LT_6_0
-        in.setCodec("UTF-8");
-#else
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         in.setEncoding(QStringConverter::Utf8);
+#else
+        in.setCodec("UTF-8");
 #endif
         QString templateName = in.readLine().trimmed();
         file.close();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -315,6 +315,11 @@ auto Util::readTemplates(const QString &storePath)
     return result;
   }
   QTextStream in(&file);
+#ifdef QT_VERSION_LT_6_0
+  in.setCodec("UTF-8");
+#else
+  in.setEncoding(QStringConverter::Utf8);
+#endif
   QString currentSection;
   QStringList currentFields;
   while (!in.atEnd()) {
@@ -324,6 +329,11 @@ auto Util::readTemplates(const QString &storePath)
         result.insert(currentSection, currentFields);
       }
       currentSection = line.mid(1, line.length() - 2);
+      if (currentSection.isEmpty()) {
+        qWarning() << "Empty template section in .templates file";
+        currentSection.clear();
+        currentFields.clear();
+      }
       currentFields.clear();
     } else if (!line.isEmpty() && !line.startsWith('#')) {
       currentFields.append(line);
@@ -350,13 +360,20 @@ auto Util::writeTemplates(const QString &storePath,
     return false;
   }
   QTextStream out(&file);
+#ifdef QT_VERSION_LT_6_0
+  out.setCodec("UTF-8");
+#else
+  out.setEncoding(QStringConverter::Utf8);
+#endif
   out << "# QtPass templates configuration\n";
   out << "# Format: INI-style with [template_name] sections,\n";
   out << "# followed by field names (one per line)\n\n";
-  for (auto it = templates.constKeyValueBegin();
-       it != templates.constKeyValueEnd(); ++it) {
-    out << "[" << it->first << "]\n";
-    for (const QString &field : it->second) {
+
+  QStringList sortedKeys = templates.keys();
+  std::sort(sortedKeys.begin(), sortedKeys.end());
+  for (const QString &key : sortedKeys) {
+    out << "[" << key << "]\n";
+    for (const QString &field : templates.value(key)) {
       out << field << "\n";
     }
     out << "\n";
@@ -375,17 +392,26 @@ auto Util::writeTemplates(const QString &storePath,
 auto Util::getFolderTemplate(const QString &folderPath,
                              const QString &storePath) -> QString {
   QDir dir(folderPath);
-  while (dir.exists(".default_template")) {
-    QFile file(dir.filePath(".default_template"));
-    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-      QTextStream in(&file);
-      QString templateName = in.readLine().trimmed();
-      file.close();
-      if (!templateName.isEmpty() && !templateName.startsWith('#')) {
-        return templateName;
+  QString cleanStore = QDir::cleanPath(storePath);
+  while (true) {
+    if (dir.exists(".default_template")) {
+      QFile file(dir.filePath(".default_template"));
+      if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&file);
+#ifdef QT_VERSION_LT_6_0
+        in.setCodec("UTF-8");
+#else
+        in.setEncoding(QStringConverter::Utf8);
+#endif
+        QString templateName = in.readLine().trimmed();
+        file.close();
+        if (!templateName.isEmpty() && !templateName.startsWith('#')) {
+          return templateName;
+        }
       }
     }
-    if (dir.absolutePath() == storePath) {
+    QString currentPath = QDir::cleanPath(dir.absolutePath());
+    if (currentPath == cleanStore) {
       break;
     }
     if (!dir.cdUp()) {

--- a/src/util.h
+++ b/src/util.h
@@ -90,6 +90,31 @@ public:
    * @return true if the key ID format is valid, false otherwise.
    */
   static auto isValidKeyId(const QString &keyId) -> bool;
+  /**
+   * @brief Read templates from .templates file in password store.
+   * @param storePath Path to password store root.
+   * @return Hash of template name to field list.
+   */
+  static auto readTemplates(const QString &storePath)
+      -> QHash<QString, QStringList>;
+  /**
+   * @brief Write templates to .templates file in password store.
+   * @param storePath Path to password store root.
+   * @param templates Hash of template name to field list.
+   * @return true if write succeeded.
+   */
+  static auto writeTemplates(const QString &storePath,
+                             const QHash<QString, QStringList> &templates)
+      -> bool;
+  /**
+   * @brief Get default template for a folder.
+   * Looks in folder, then parent folders up to root.
+   * @param folderPath Path to folder.
+   * @param storePath Path to password store root.
+   * @return Template name or empty if none found.
+   */
+  static auto getFolderTemplate(const QString &folderPath,
+                                const QString &storePath) -> QString;
 
 private:
   static void initialiseEnvironment();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces multi-template support for password entries, allowing users to define and apply different password field structures.

Key changes include:
*   **Template Definition:** A new `.templates` file can be placed in the password store root. This file uses an INI-style format to define multiple templates, each with a name and a list of fields.
*   **Hierarchical Default Template Selection:** A `.default_template` file can be placed in any folder within the password store. This file specifies the name of a default template to be used for that folder and its subfolders. The system will search parent directories up to the store root to find a default template.
*   **Password Dialog Integration:** The `PasswordDialog` now supports setting available templates and applying a specified default template, which populates the dialog's fields accordingly.
*   **Utility Functions:** New utility functions (`readTemplates`, `writeTemplates`, `getFolderTemplate`) have been added to handle reading, writing, and resolving templates and default template names from the file system.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password templates with customizable field lists can be defined and managed.
  * Templates are persisted in the store and can be read back or updated.
  * The UI now exposes available templates and will auto-select a suitable default based on folder context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->