### PR TITLE
feat: auto-apply templates when creating new passwords

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -839,6 +839,20 @@ auto MainWindow::firstFile(QModelIndex parentIndex) -> QModelIndex {
 void MainWindow::setPassword(const QString &file, bool isNew) {
   PasswordDialog d(file, isNew, this);
 
+  if (isNew) {
+    QString storePath = QtPassSettings::getPassStore();
+    QString folder =
+        Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel);
+    if (folder.isEmpty()) {
+      folder = storePath;
+    }
+    QHash<QString, QStringList> templates = Util::readTemplates(storePath);
+    if (!templates.isEmpty()) {
+      QString defaultTemplate = Util::getFolderTemplate(folder, storePath);
+      d.setAvailableTemplates(templates, defaultTemplate);
+    }
+  }
+
   if (!d.exec()) {
     ui->treeView->setFocus();
   }

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -80,9 +80,9 @@ public:
   void usePwgen(bool usePwgen);
 
   /**
-   * @brief Set the available templates from .templates file.
+   * @brief Set available templates from file and select default.
    * @param templates Hash of template name to field list.
-   * @param defaultTemplate Name of default template to select.
+   * @param defaultTemplate Name of default template.
    */
   void setAvailableTemplates(const QHash<QString, QStringList> &templates,
                              const QString &defaultTemplate);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a feature to automatically apply password templates when creating new password entries.

Specifically, when a user initiates the creation of a new password:
- The application now identifies the folder where the new password is being created.
- It reads available templates from the `.templates` file within the pass store.
- It then determines if a default template is configured for that specific folder.
- Finally, it passes these available templates and the identified default template to the password creation dialog, allowing for pre-population of fields based on the template.

This change streamlines the process of adding new passwords by leveraging folder-specific templates.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When creating a new password entry, available templates from the password store are automatically preloaded and presented in the creation dialog; a sensible default template for the selected folder is pre-selected to speed entry creation. Editing existing entries retains its previous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->