### PR TITLE
feat: add Ctrl+T to cycle between templates

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -850,6 +850,8 @@ void MainWindow::setPassword(const QString &file, bool isNew) {
     if (!templates.isEmpty()) {
       QString defaultTemplate = Util::getFolderTemplate(folder, storePath);
       d.setAvailableTemplates(templates, defaultTemplate);
+      new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_T), &d,
+                    [&d]() { d.cycleTemplate(); });
     }
   }
 

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -200,6 +200,13 @@ void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
   }
   templateLines.clear();
 
+  // Defensively remove all rows tracked in otherLines to prevent accumulation
+  // when cycling templates or applying new templates after setPassword
+  for (QLineEdit *line : std::as_const(otherLines)) {
+    ui->formLayout->removeRow(line);
+  }
+  otherLines.clear();
+
   if (m_templating) {
     QWidget *previous = ui->checkBoxShow;
     for (const QString &field : std::as_const(m_fields)) {

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -13,6 +13,7 @@
 #include <QHash>
 #include <QLabel>
 #include <QLineEdit>
+#include <QShortcut>
 #include <utility>
 
 #ifdef QT_DEBUG
@@ -193,6 +194,11 @@ auto PasswordDialog::getPassword() -> QString {
 void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
   m_fields = rawFields.split('\n');
   m_templating = useTemplate;
+
+  for (QLineEdit *line : std::as_const(templateLines)) {
+    ui->formLayout->removeWidget(line);
+    line->deleteLater();
+  }
   templateLines.clear();
 
   if (m_templating) {
@@ -202,8 +208,9 @@ void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
         continue;
       }
       auto *line = new QLineEdit();
+      auto *label = new QLabel(field);
       line->setObjectName(field);
-      ui->formLayout->addRow(new QLabel(field), line);
+      ui->formLayout->addRow(label, line);
       setTabOrder(previous, line);
       templateLines.append(line);
       previous = line;
@@ -247,6 +254,7 @@ void PasswordDialog::usePwgen(bool usePwgen) {
 void PasswordDialog::setAvailableTemplates(
     const QHash<QString, QStringList> &templates,
     const QString &defaultTemplate) {
+  m_availableTemplates = templates;
   QStringList templateNames = templates.keys();
   if (templateNames.isEmpty()) {
     return;
@@ -256,11 +264,38 @@ void PasswordDialog::setAvailableTemplates(
   if (!templateNames.contains(selected)) {
     selected = templateNames.first();
   }
-  auto it = templates.constFind(selected);
-  if (it != templates.constEnd()) {
+  applyTemplate(selected);
+}
+
+/**
+ * @brief Apply a template by name.
+ * @param templateName Name of template to apply.
+ */
+void PasswordDialog::applyTemplate(const QString &templateName) {
+  m_currentTemplateName = templateName;
+  auto it = m_availableTemplates.constFind(templateName);
+  if (it != m_availableTemplates.constEnd()) {
     QString fields = it.value().join("\n");
     setTemplate(fields, true);
   }
+}
+
+/**
+ * @brief Cycle to next template (Ctrl+T).
+ */
+void PasswordDialog::cycleTemplate() {
+  if (m_availableTemplates.isEmpty()) {
+    return;
+  }
+  QStringList names = m_availableTemplates.keys();
+  std::sort(names.begin(), names.end());
+
+  int currentIdx = names.indexOf(m_currentTemplateName);
+  if (currentIdx < 0) {
+    currentIdx = 0;
+  }
+  int nextIdx = (currentIdx + 1) % names.size();
+  applyTemplate(names.at(nextIdx));
 }
 
 /**

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -196,8 +196,7 @@ void PasswordDialog::setTemplate(const QString &rawFields, bool useTemplate) {
   m_templating = useTemplate;
 
   for (QLineEdit *line : std::as_const(templateLines)) {
-    ui->formLayout->removeWidget(line);
-    line->deleteLater();
+    ui->formLayout->removeRow(line);
   }
   templateLines.clear();
 

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -297,10 +297,12 @@ void PasswordDialog::cycleTemplate() {
   std::sort(names.begin(), names.end());
 
   int currentIdx = names.indexOf(m_currentTemplateName);
+  int nextIdx;
   if (currentIdx < 0) {
-    currentIdx = 0;
+    nextIdx = 0;
+  } else {
+    nextIdx = (currentIdx + 1) % names.size();
   }
-  int nextIdx = (currentIdx + 1) % names.size();
   applyTemplate(names.at(nextIdx));
 }
 

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -272,9 +272,9 @@ void PasswordDialog::setAvailableTemplates(
  * @param templateName Name of template to apply.
  */
 void PasswordDialog::applyTemplate(const QString &templateName) {
-  m_currentTemplateName = templateName;
   auto it = m_availableTemplates.constFind(templateName);
   if (it != m_availableTemplates.constEnd()) {
+    m_currentTemplateName = templateName;
     QString fields = it.value().join("\n");
     setTemplate(fields, true);
   }

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -89,6 +89,11 @@ public:
 
 public slots:
   /**
+   * @brief Cycle to next template (Ctrl+T).
+   */
+  void cycleTemplate();
+
+  /**
    * @brief Populate the dialog's password field from pass show output.
    * @param output Output from the pass show command.
    */
@@ -109,6 +114,10 @@ private:
   bool m_isNew;
   QList<QLineEdit *> templateLines;
   QList<QLineEdit *> otherLines;
+  QHash<QString, QStringList> m_availableTemplates;
+  QString m_currentTemplateName;
+
+  void applyTemplate(const QString &templateName);
 };
 
 #endif // SRC_PASSWORDDIALOG_H_


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new keyboard shortcut, `Ctrl+T`, to enhance the user experience when managing password templates.

Key changes include:
*   **New Keyboard Shortcut:** Users can now press `Ctrl+T` within the password creation/editing dialog to cycle through the available password templates.
*   **Template Cycling Functionality:** When `Ctrl+T` is activated, the dialog will apply the next template from the list of available templates, which are sorted alphabetically.
*   **Internal Template Management:** The `PasswordDialog` now internally stores the list of available templates and includes new methods to apply a template by name and to manage the cycling logic.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press Ctrl+T in the password dialog to cycle through available password templates (enabled when templates exist).

* **Refactor**
  * Template handling in the password dialog reorganized for more predictable behavior: available templates are retained, the current selection is tracked, activation is centralized, and UI rows are cleaned up to avoid duplication and ensure consistent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->