### PR TITLE
feat: add Share submenu for folders

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1241,10 +1241,8 @@ void MainWindow::showContextMenu(const QPoint &pos) {
       QString exePath = QtPassSettings::isUsePass()
                             ? QtPassSettings::getPassExecutable()
                             : QtPassSettings::getGpgExecutable();
-      bool gpgAvailable =
-          QtPassSettings::isUsePass()
-              ? QFile::exists(exePath) || exePath.startsWith("/mnt")
-              : !QtPassSettings::getGpgExecutable().isEmpty();
+      bool gpgAvailable = !exePath.isEmpty() && (exePath.startsWith("wsl ") ||
+                                                 QFile(exePath).exists());
 
       QAction *reencrypt = shareMenu->addAction(tr("Re-encrypt all passwords"));
       reencrypt->setEnabled(gpgIdExists && gpgAvailable);
@@ -1577,7 +1575,7 @@ void MainWindow::endReencryptPath() { setUiElementsEnabled(true); }
 void MainWindow::exportPublicKey() {
   QString identity = QtPassSettings::getPassSigningKey();
   if (identity.isEmpty()) {
-    identity = "user@qtpass.org";
+    identity = "<your-key-id>";
   }
   identity = identity.toHtmlEscaped();
   QMessageBox::information(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1231,9 +1231,39 @@ void MainWindow::showContextMenu(const QPoint &pos) {
     if (fileOrFolder.isDir()) {
       QString dirPath = QDir::cleanPath(
           Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel));
-      QAction *reencrypt = contextMenu.addAction(tr("Re-encrypt"));
+
+      QMenu *shareMenu = new QMenu(tr("Share"), &contextMenu);
+      contextMenu.addMenu(shareMenu);
+
+      QString gpgIdPath = Pass::getGpgIdPath(dirPath);
+      bool gpgIdExists = !gpgIdPath.isEmpty() && QFile(gpgIdPath).exists();
+
+      QString exePath = QtPassSettings::isUsePass()
+                            ? QtPassSettings::getPassExecutable()
+                            : QtPassSettings::getGpgExecutable();
+      bool gpgAvailable =
+          QtPassSettings::isUsePass()
+              ? QFile::exists(exePath) || exePath.startsWith("/mnt")
+              : !QtPassSettings::getGpgExecutable().isEmpty();
+
+      QAction *reencrypt = shareMenu->addAction(tr("Re-encrypt all passwords"));
+      reencrypt->setEnabled(gpgIdExists && gpgAvailable);
       connect(reencrypt, &QAction::triggered, this,
               [this, dirPath]() { reencryptPath(dirPath); });
+
+      QAction *exportKey = shareMenu->addAction(tr("Export my public key..."));
+      exportKey->setEnabled(gpgAvailable);
+      connect(exportKey, &QAction::triggered, this,
+              &MainWindow::exportPublicKey);
+
+      QAction *addRecipientAction =
+          shareMenu->addAction(tr("Add recipient..."));
+      addRecipientAction->setEnabled(gpgIdExists && gpgAvailable);
+      connect(addRecipientAction, &QAction::triggered, this,
+              [this, dirPath]() { addRecipient(dirPath); });
+
+      QAction *shareHelp = shareMenu->addAction(tr("What is this?"));
+      connect(shareHelp, &QAction::triggered, this, &MainWindow::showShareHelp);
     }
   }
   contextMenu.exec(globalPos);
@@ -1538,6 +1568,69 @@ void MainWindow::startReencryptPath() {
  * @brief MainWindow::endReencryptPath re-enable ui elements
  */
 void MainWindow::endReencryptPath() { setUiElementsEnabled(true); }
+
+/**
+ * @brief MainWindow::exportPublicKey export current user's public key
+ * Shows instructions to export key via command line
+ * TODO: Wire to real gpg export via Executor - see issue #422
+ */
+void MainWindow::exportPublicKey() {
+  QString identity = QtPassSettings::getPassSigningKey();
+  if (identity.isEmpty()) {
+    identity = "user@qtpass.org";
+  }
+  identity = identity.toHtmlEscaped();
+  QMessageBox::information(
+      this, tr("Export Public Key"),
+      tr("<h3>Export Your Public Key</h3>"
+         "<p>To export your public GPG key, run this in terminal:</p>"
+         "<pre>gpg --armor --export --output my_key.asc %1</pre>"
+         "<p>Then send the file to your teammates.</p>"
+         "<p>Your key ID: You can find it in QtPass Settings &gt; GPG "
+         "keys.</p>")
+          .arg(identity));
+}
+
+/**
+ * @brief MainWindow::addRecipient add a new recipient's public key
+ * @param dir Directory path
+ */
+void MainWindow::addRecipient(const QString &dir) {
+  QString gpgIdPath = Pass::getGpgIdPath(dir).toHtmlEscaped();
+  QMessageBox::information(
+      this, tr("Add Recipient"),
+      tr("<h3>Add Recipient</h3>"
+         "<p>To add a teammate's public key:</p>"
+         "<ol>"
+         "<li>Save their public key as a .asc file</li>"
+         "<li>Copy the key text</li>"
+         "<li>Open %1</li>"
+         "<li>Add the new key ID to the file</li>"
+         "<li>Re-encrypt passwords to share with them</li>"
+         "</ol>"
+         "<p>Use the full fingerprint to ensure accuracy.</p>")
+          .arg(gpgIdPath));
+}
+
+/**
+ * @brief MainWindow::showShareHelp show help about GPG sharing
+ */
+void MainWindow::showShareHelp() {
+  QMessageBox::information(
+      this, tr("Sharing Passwords with GPG"),
+      tr("<h3>Sharing Passwords with GPG</h3>"
+         "<p>To share passwords with other users:</p>"
+         "<ol>"
+         "<li><b>Export your public key</b> and send it to teammates</li>"
+         "<li><b>Import teammates' public keys</b> to their own folders</li>"
+         "<li><b>Re-encrypt passwords</b> so all recipients can decrypt "
+         "them</li>"
+         "</ol>"
+         "<p>Only people who have a matching secret key can decrypt the "
+         "passwords.</p>"
+         "<p><b>Tip:</b> Use the same GPG key for all shared folders.</p>"
+         "<p>See the FAQ for more details.</p>"));
+}
 
 void MainWindow::updateGitButtonVisibility() {
   if (!QtPassSettings::isUseGit() ||

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -280,6 +280,10 @@ private:
   void destroyTrayIcon();
   void clearTemplateWidgets();
   void reencryptPath(const QString &dir);
+  void exportPublicKey();
+  void addRecipient(const QString &dir);
+  void showShareHelp();
+
   void addToGridLayout(int position, const QString &field,
                        const QString &value);
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new "Share" submenu within the context menu for folders.

Key changes include:
*   **Share Submenu for Folders:** When right-clicking a folder, a new "Share" submenu is now available.
*   **Re-encrypt Action Relocation:** The existing "Re-encrypt" action has been moved into the "Share" submenu and renamed to "Re-encrypt all passwords".
*   **Export Public Key Option:** A new "Export my public key..." action provides instructions on how to export the user's GPG public key for sharing.
*   **Add Recipient Option:** A new "Add recipient..." action provides guidance on how to add another user's public key to a folder's `.gpg-id` file to enable sharing.
*   **Sharing Help:** A "What is this?" action offers general information and steps on how to share passwords using GPG within QtPass.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Share" submenu to folder context menus with options to export your public key, add recipients, view sharing help, and re-encrypt passwords.
  * Sharing actions now enable/disable based on presence of an encryption identifier in the folder and availability of required tooling.
  * New dialogs provide step-by-step guidance for exporting keys, adding recipients, and general sharing help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->