### PR TITLE
docs: restore QtPass patterns to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ this pattern supports nested folder inheritance.
 Git options (useGit, autoPush, autoPull) are stored per-profile:
 
 ```cpp
-QString useGitStr = QtPassSettings::getProfileUseGit(profileName, false);
+bool useGit = QtPassSettings::getProfileUseGit(profileName, false);
 QtPassSettings::setProfileUseGit(profileName, true);
 QtPassSettings::setProfileAutoPush(profileName, true);
 QtPassSettings::setProfileAutoPull(profileName, false);
@@ -263,12 +263,22 @@ Always match the settings backend used by QtPass in tests.
 ### MainWindow Add Entry Pattern
 
 ```cpp
-void MainWindow::addPasswordEntry() {
-    PasswordDialog passDialog(this);
-    QString templateName = Util::getFolderTemplate(currentDir, storePath);
-    QHash<QString, QStringList> templates = Util::readTemplates(storePath);
-    passDialog.setAvailableTemplates(templates, templateName);
-    passDialog.exec();
+void MainWindow::addPassword() {
+    bool ok;
+    QString dir =
+        Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel);
+    QString file =
+        QInputDialog::getText(this, tr("New file"),
+                              tr("New password file: \n(Will be placed in %1 )")
+                                  .arg(QtPassSettings::getPassStore() +
+                                       Util::getDir(ui->treeView->currentIndex(),
+                                                    true, model, proxyModel)),
+                              QLineEdit::Normal, "", &ok);
+    if (!ok || file.isEmpty()) {
+        return;
+    }
+    file = dir + file;
+    setPassword(file);
 }
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,76 @@ returns `\\`.
 See `Pass::getGpgIdPath` in `src/pass.cpp` for the canonical implementation;
 this pattern supports nested folder inheritance.
 
+### Profile Git Settings
+
+Git options (useGit, autoPush, autoPull) are stored per-profile:
+
+```cpp
+QString useGitStr = QtPassSettings::getProfileUseGit(profileName, false);
+QtPassSettings::setProfileUseGit(profileName, true);
+QtPassSettings::setProfileAutoPush(profileName, true);
+QtPassSettings::setProfileAutoPull(profileName, false);
+```
+
+In ConfigDialog, use `getProfiles()`/`setProfiles()` to preserve non-selected profile settings:
+
+```cpp
+setProfiles(QtPassSettings::getProfiles(), QtPassSettings::getProfile());
+QtPassSettings::setProfiles(getProfiles());
+```
+
+### QSettings Singleton Pattern
+
+QtPass uses `QtPassSettings::getInstance()` instead of raw `QSettings`:
+
+```cpp
+QtPassSettings::getInstance()->setValue("key", value);
+QtPassSettings::getInstance()->beginGroup("profile");
+QtPassSettings::getInstance()->remove(profileName);
+QtPassSettings::getInstance()->endGroup();
+```
+
+Always match the settings backend used by QtPass in tests.
+
+### MainWindow Add Entry Pattern
+
+```cpp
+void MainWindow::addPasswordEntry() {
+    PasswordDialog passDialog(this);
+    QString templateName = Util::getFolderTemplate(currentDir, storePath);
+    QHash<QString, QStringList> templates = Util::readTemplates(storePath);
+    passDialog.setAvailableTemplates(templates, templateName);
+    passDialog.exec();
+}
+```
+
+### ConfigDialog Profile Table Selection
+
+```cpp
+void ConfigDialog::onProfileTableSelectionChanged() {
+    QList<QTableWidgetItem *> selected = ui->profileTable->selectedItems();
+    if (selected.isEmpty()) return;
+    QString profileName = ui->profileTable->item(selected.first()->row(), 0)->text();
+    loadGitSettingsForProfile(profileName, m_profiles);
+}
+```
+
+Cache profiles in `m_profiles` member and update on `getProfiles()`.
+
+### Avoid Setter Side Effects in Loops
+
+```cpp
+// Bad - triggers update logic for each profile
+for (const auto &profile : profiles) {
+    setUseGit(profile.useGit);  // Side effects!
+}
+// Good
+for (const auto &profile : profiles) {
+    ui->checkBoxUseGit->setChecked(profile.useGit);
+}
+useGit(selected.useGit);
+```
+
 ## Handling AI Findings
 
 When CodeRabbit/CodeAnt AI flags issues in PRs:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates `AGENTS.md` by adding several documentation sections detailing common patterns and best practices within the QtPass codebase.

The added sections include:
*   **Profile Git Settings**: Explains how Git-related options (useGit, autoPush, autoPull) are managed and stored per-profile using `QtPassSettings`, and how to handle profile settings in `ConfigDialog`.
*   **QSettings Singleton Pattern**: Documents the use of `QtPassSettings::getInstance()` as the standard way to interact with application settings, advising consistency in tests.
*   **MainWindow Add Entry Pattern**: Provides a code example illustrating the process of adding a new password entry via `MainWindow::addPasswordEntry()`, including template handling.
*   **ConfigDialog Profile Table Selection**: Describes the logic for loading profile-specific Git settings when a profile is selected in the `ConfigDialog`'s profile table.
*   **Avoid Setter Side Effects in Loops**: Offers guidance on preventing unintended side effects by demonstrating how to update UI elements efficiently without triggering update logic for each item in a loop.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded developer documentation on configuration and profile handling to improve reliability of profile-specific settings (including Git-related options), settings persistence across profiles, and dialog-driven password workflows. Added guidance and examples to ensure UI state updates are applied cleanly and avoid unintended side effects, improving consistency and predictability of configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->