### PR TITLE
test: add profile defaults and fix qWarning tr() usage

### DIFF
--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -508,11 +508,11 @@ void tst_settings::setAndGetMultipleProfiles() {
   QVERIFY(readProfiles["profile1"].contains("useGit"));
   QVERIFY(readProfiles["profile1"].contains("autoPush"));
   QVERIFY(readProfiles["profile1"].contains("autoPull"));
-  QVERIFY2(!readProfiles["profile1"].value("useGit").toInt(),
+  QVERIFY2(!QtPassSettings::getProfileUseGit("profile1", true),
            "useGit should default to false");
-  QVERIFY2(!readProfiles["profile1"].value("autoPush").toInt(),
+  QVERIFY2(!QtPassSettings::getProfileAutoPush("profile1", true),
            "autoPush should default to false");
-  QVERIFY2(!readProfiles["profile1"].value("autoPull").toInt(),
+  QVERIFY2(!QtPassSettings::getProfileAutoPull("profile1", true),
            "autoPull should default to false");
 }
 

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -508,6 +508,12 @@ void tst_settings::setAndGetMultipleProfiles() {
   QVERIFY(readProfiles["profile1"].contains("useGit"));
   QVERIFY(readProfiles["profile1"].contains("autoPush"));
   QVERIFY(readProfiles["profile1"].contains("autoPull"));
+  QVERIFY2(!readProfiles["profile1"].value("useGit").toInt(),
+           "useGit should default to false");
+  QVERIFY2(!readProfiles["profile1"].value("autoPush").toInt(),
+           "autoPush should default to false");
+  QVERIFY2(!readProfiles["profile1"].value("autoPull").toInt(),
+           "autoPull should default to false");
 }
 
 void tst_settings::profileGitOptions() {

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -71,9 +71,9 @@ void tst_settings::initTestCase() {
     // No qtpass.ini next to the binary, so QSettings writes to per-user storage
     // (e.g. the Windows registry). Automatic backup/restore is only safe in
     // portable mode, so persistent user settings may be modified by this run.
-    qWarning() << tr("Non-portable mode detected: tests may modify persistent "
+    qWarning() << "Non-portable mode detected: tests may modify persistent "
                      "user settings (e.g. Windows registry). For an isolated "
-                     "run, drop a qtpass.ini next to the test binary.");
+                     "run, drop a qtpass.ini next to the test binary.";
   }
 }
 


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted test warning message formatting to use a plain string literal.
  * Extended test coverage for per-profile git-related options (useGit, autoPush, autoPull) to verify newly introduced profiles default these options to false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->