### PR TITLE
docs: align qtpass-fixing SPDX-year guidance with repo practice

### DIFF
--- a/.opencode/skills/qtpass-fixing/SKILL.md
+++ b/.opencode/skills/qtpass-fixing/SKILL.md
@@ -167,16 +167,19 @@ Use "cannot" instead of "can't" for formal consistency:
 // On Windows, we cannot safely backup
 ```
 
-### Copyright Year in Templates
+### Copyright Year in SPDX Headers
 
-Use `YYYY` as placeholder instead of current year:
+Use the actual year the file was created — never a placeholder, never a year range. Repo convention is a single literal year (the existing files are 2014/2015/2016/2018/2020/2026, all real years; PR #1162 review explicitly flagged `YYYY` placeholders).
 
 ```cpp
-// Bad
-// SPDX-FileCopyrightText: 2026 Your Name
-
-// Good
+// Bad — placeholder; reviewers will ask for a real year
 // SPDX-FileCopyrightText: YYYY Your Name
+
+// Bad — year range
+// SPDX-FileCopyrightText: 2014-2026 Your Name
+
+// Good — single real year
+// SPDX-FileCopyrightText: 2026 Your Name
 ```
 
 ### Return After Dialog Rejection

--- a/.opencode/skills/qtpass-fixing/SKILL.md
+++ b/.opencode/skills/qtpass-fixing/SKILL.md
@@ -169,7 +169,7 @@ Use "cannot" instead of "can't" for formal consistency:
 
 ### Copyright Year in SPDX Headers
 
-Use the actual year the file was created — never a placeholder, never a year range. Repo convention is a single literal year (the existing files are 2014/2015/2016/2018/2020/2026, all real years; PR #1162 review explicitly flagged `YYYY` placeholders).
+Use the actual year the file was created — never a placeholder, never a year range. Repository convention is a single literal year (the existing files are 2014/2015/2016/2018/2020/2026, all real years; PR #1162 review explicitly flagged `YYYY` placeholders).
 
 ```cpp
 // Bad — placeholder; reviewers will ask for a real year


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
docs: Update SPDX copyright year guidance in `SKILL.md`

This pull request revises the documentation in `.opencode/skills/qtpass-fixing/SKILL.md` to provide updated guidance on specifying copyright years in SPDX headers.

The previous guidance recommended using `YYYY` as a placeholder. This change updates the documentation to instruct contributors to use the actual year the file was created, explicitly stating that placeholders or year ranges are not permitted. This aligns the documented practice with existing repository conventions and feedback from past code reviews.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SPDX copyright-year convention guidelines to require single literal creation years instead of placeholders or year ranges in copyright text declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->