### PR TITLE
Add Checkmarx One GitHub Action workflow

### DIFF
--- a/.github/workflows/checkmarx-one.yml
+++ b/.github/workflows/checkmarx-one.yml
@@ -1,0 +1,55 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# The Checkmarx One GitHub Action enables you to trigger SAST, SCA, and KICS scans directly from the GitHub workflow.
+# It provides a wrapper around the Checkmarx One CLI Tool which creates a zip archive from your source code repository
+# and uploads it to Checkmarx One for scanning. The Github Action provides easy integration with GitHub while enabling
+# scan customization using the full functionality and flexibility of the CLI tool.
+
+# This is a basic workflow to help you get started with Using Checkmarx One Action,
+# documentation can be found here : https://checkmarx.com/resource/documents/en/34965-68702-checkmarx-one-github-actions.html
+
+name: Checkmarx Scan
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # This step checks out a copy of your repository.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # This step creates the Checkmarx One scan
+      - name: Checkmarx One scan
+        uses: checkmarx/ast-github-action@8e887bb93dacc44e0f5b64ee2b06d5815f89d4fc
+        with:
+          base_uri: https://ast.checkmarx.net  # This should be replaced by your base uri for Checkmarx One
+          cx_client_id: ${{ secrets.CX_CLIENT_ID }} # This should be created within your Checkmarx One account : https://checkmarx.com/resource/documents/en/34965-118315-authentication-for-checkmarx-one-cli.html#UUID-a4e31a96-1f36-6293-e95a-97b4b9189060_UUID-4123a2ff-32d0-2287-8dd2-3c36947f675e
+          cx_client_secret: ${{ secrets.CX_CLIENT_SECRET }} # This should be created within your Checkmarx One account : https://checkmarx.com/resource/documents/en/34965-118315-authentication-for-checkmarx-one-cli.html#UUID-a4e31a96-1f36-6293-e95a-97b4b9189060_UUID-4123a2ff-32d0-2287-8dd2-3c36947f675e
+          cx_tenant: ${{ secrets.CX_TENANT }} # This should be replaced by your tenant for Checkmarx One
+          additional_params: --report-format sarif --output-path .
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: cx_result.sarif


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new GitHub Actions workflow named "Checkmarx Scan". This workflow is configured to automatically perform Checkmarx One security scans (SAST, SCA, and KICS) on pull requests that are opened, reopened, or synchronized, specifically when targeting the `main` branch. The scan results will be generated in SARIF format and subsequently uploaded to GitHub's security tab, integrating automated security analysis directly into the development pipeline.
<!-- kody-pr-summary:end -->