### PR TITLE
feat: add Import key dialog to UsersDialog for issue #1167

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tests/auto/filecontent/tst_filecontent
 tests/auto/gpgkeystate/tst_gpgkeystate
 tests/auto/integration/tst_integration
 tests/auto/exportpublickeydialog/tst_exportpublickeydialog
+tests/auto/importkeydialog/tst_importkeydialog
 **/*.gc*
 *.bak
 README.c*

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -134,7 +134,11 @@ bool ImportKeyDialog::importFromString(const QString &input) {
 }
 
 auto ImportKeyDialog::parseGpgImportOutput(const QString &output) -> QString {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+#else
+  const QStringList lines = output.split('\n', QString::SkipEmptyParts);
+#endif
   // Prefer locale-independent status output. IMPORT_OK gives a full
   // fingerprint; IMPORTED gives a (long) key id. Try both before falling
   // back to the English-only human-readable line.

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -15,31 +15,32 @@
 #include <QRegularExpression>
 #include <QString>
 
+// Locale-independent: gpg's machine-readable status output via --status-fd 1.
+// See doc/DETAILS in the GnuPG source for IMPORT_OK / IMPORTED grammar.
 static const QRegularExpression
-    KEY_IMPORTED_EXACT(QStringLiteral(R"(gpg: key ([0-9A-Fa-f]+): imported)"));
-static const QRegularExpression KEY_IMPORTED_GENERAL(
+    IMPORT_OK_RE(QStringLiteral(R"(\[GNUPG:\] IMPORT_OK \d+ ([0-9A-Fa-f]+))"));
+static const QRegularExpression
+    IMPORTED_RE(QStringLiteral(R"(\[GNUPG:\] IMPORTED ([0-9A-Fa-f]+))"));
+// Fallback for the human-readable (English-locale) line.
+static const QRegularExpression KEY_IMPORTED_FALLBACK(
     QStringLiteral(R"(gpg: key ([0-9A-Fa-f]+):.*imported)"));
 
 ImportKeyDialog::ImportKeyDialog(QWidget *parent)
     : QDialog(parent), ui(new Ui::ImportKeyDialog) {
   ui->setupUi(this);
-
-  ui->inputTextEdit->setPlaceholderText(
-      tr("Paste an ASCII-armored GPG key here..."));
-
   ui->importButton->setEnabled(false);
 }
 
 ImportKeyDialog::~ImportKeyDialog() = default;
 
-QString ImportKeyDialog::importedKeyFingerprint() const {
+auto ImportKeyDialog::importedKeyId() const -> QString {
   return m_importedKeyId;
 }
 
 void ImportKeyDialog::on_fileButton_clicked() {
   const QString fileName = QFileDialog::getOpenFileName(
       this, tr("Import GPG Key"), QString(),
-      tr("GPG Key Files") + " (*.asc *.key);;" + tr("All Files") + " (*)");
+      tr("ASCII-armored GPG key") + " (*.asc);;" + tr("All Files") + " (*)");
 
   if (fileName.isEmpty()) {
     return;
@@ -52,16 +53,33 @@ void ImportKeyDialog::on_fileButton_clicked() {
     return;
   }
 
-  QByteArray bytes = file.readAll();
+  const QByteArray bytes = file.readAll();
   file.close();
+
+  // Only ASCII-armored content is shown in the text edit; binary keyrings
+  // would lose bytes through UTF-8 conversion. Reject anything that doesn't
+  // start with the PGP armor header.
+  if (!bytes.trimmed().startsWith("-----BEGIN PGP")) {
+    QMessageBox::warning(
+        this, tr("Import Key"),
+        tr("%1 does not look like an ASCII-armored GPG key. Convert it with "
+           "<code>gpg --armor --export</code> first, or paste the armored "
+           "block via <b>From Clipboard</b>.")
+            .arg(fileName));
+    return;
+  }
 
   ui->inputTextEdit->setPlainText(QString::fromUtf8(bytes));
 }
 
 void ImportKeyDialog::on_pasteButton_clicked() {
-  QClipboard *clipboard = QApplication::clipboard();
+  const QClipboard *clipboard = QApplication::clipboard();
   const QString text = clipboard->text();
-
+  if (text.isEmpty()) {
+    // Don't wipe whatever the user already typed/loaded for an empty
+    // clipboard.
+    return;
+  }
   ui->inputTextEdit->setPlainText(text);
 }
 
@@ -113,14 +131,25 @@ bool ImportKeyDialog::importFromString(const QString &input) {
   return true;
 }
 
-QString ImportKeyDialog::parseGpgImportOutput(const QString &output) {
+auto ImportKeyDialog::parseGpgImportOutput(const QString &output) -> QString {
   const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+  // Prefer locale-independent status output. IMPORT_OK gives a full
+  // fingerprint; IMPORTED gives a (long) key id. Try both before falling
+  // back to the English-only human-readable line.
   for (const QString &line : lines) {
-    QRegularExpressionMatch match = KEY_IMPORTED_EXACT.match(line);
+    const QRegularExpressionMatch match = IMPORT_OK_RE.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }
-    match = KEY_IMPORTED_GENERAL.match(line);
+  }
+  for (const QString &line : lines) {
+    const QRegularExpressionMatch match = IMPORTED_RE.match(line);
+    if (match.hasMatch()) {
+      return match.captured(1);
+    }
+  }
+  for (const QString &line : lines) {
+    const QRegularExpressionMatch match = KEY_IMPORTED_FALLBACK.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -23,7 +23,7 @@ static const QRegularExpression
     IMPORTED_RE(QStringLiteral(R"(\[GNUPG:\] IMPORTED ([0-9A-Fa-f]+))"));
 // Fallback for the human-readable (English-locale) line.
 static const QRegularExpression KEY_IMPORTED_FALLBACK(
-    QStringLiteral(R"(gpg: key ([0-9A-Fa-f]+):.*imported)"));
+    QStringLiteral(R"(gpg: key ([0-9A-Fa-f]{40}|[0-9A-Fa-f]{16}):.*imported)"));
 
 ImportKeyDialog::ImportKeyDialog(QWidget *parent)
     : QDialog(parent), ui(new Ui::ImportKeyDialog) {
@@ -114,7 +114,7 @@ bool ImportKeyDialog::importFromString(const QString &input) {
   int result = Executor::executeBlocking(gpgExe, args, input, &stdOut, &stdErr);
 
   if (result != 0) {
-    showError(tr("GPG import failed:\n%1").arg(stdErr));
+    showError(tr("GPG import failed:\n%1").arg(stdErr.toHtmlEscaped()));
     return false;
   }
 

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "importkeydialog.h"
+
+#include "executor.h"
+#include "qtpasssettings.h"
+#include "ui_importkeydialog.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QFile>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QRegularExpression>
+#include <QString>
+
+static const QRegularExpression
+    KEY_IMPORTED_EXACT(QStringLiteral(R"(gpg: key ([0-9A-Fa-f]+): imported)"));
+static const QRegularExpression KEY_IMPORTED_GENERAL(
+    QStringLiteral(R"(gpg: key ([0-9A-Fa-f]+):.*imported)"));
+
+ImportKeyDialog::ImportKeyDialog(QWidget *parent)
+    : QDialog(parent), ui(new Ui::ImportKeyDialog) {
+  ui->setupUi(this);
+
+  ui->inputTextEdit->setPlaceholderText(
+      tr("Paste an ASCII-armored GPG key here..."));
+
+  ui->importButton->setEnabled(false);
+}
+
+ImportKeyDialog::~ImportKeyDialog() = default;
+
+QString ImportKeyDialog::importedKeyFingerprint() const {
+  return m_importedKeyId;
+}
+
+void ImportKeyDialog::on_fileButton_clicked() {
+  const QString fileName = QFileDialog::getOpenFileName(
+      this, tr("Import GPG Key"), QString(),
+      tr("GPG Key Files") + " (*.asc *.key);;" + tr("All Files") + " (*)");
+
+  if (fileName.isEmpty()) {
+    return;
+  }
+
+  QFile file(fileName);
+  if (!file.open(QIODevice::ReadOnly)) {
+    QMessageBox::warning(this, tr("Import Key"),
+                         tr("Could not open file: %1").arg(fileName));
+    return;
+  }
+
+  QByteArray bytes = file.readAll();
+  file.close();
+
+  ui->inputTextEdit->setPlainText(QString::fromUtf8(bytes));
+}
+
+void ImportKeyDialog::on_pasteButton_clicked() {
+  QClipboard *clipboard = QApplication::clipboard();
+  const QString text = clipboard->text();
+
+  ui->inputTextEdit->setPlainText(text);
+}
+
+void ImportKeyDialog::on_importButton_clicked() {
+  const QString input = ui->inputTextEdit->toPlainText().trimmed();
+  if (input.isEmpty()) {
+    return;
+  }
+
+  if (importFromString(input)) {
+    accept();
+  }
+}
+
+void ImportKeyDialog::on_inputTextEdit_textChanged() {
+  const bool hasInput = !ui->inputTextEdit->toPlainText().trimmed().isEmpty();
+  ui->importButton->setEnabled(hasInput);
+}
+
+bool ImportKeyDialog::importFromString(const QString &input) {
+  QString gpgExe = QtPassSettings::getGpgExecutable();
+  if (gpgExe.isEmpty()) {
+    gpgExe = "gpg";
+  }
+  QStringList args = {"--status-fd", "1", "--import", "--batch", "--yes"};
+
+  QString stdOut;
+  QString stdErr;
+
+  int result = Executor::executeBlocking(gpgExe, args, input, &stdOut, &stdErr);
+
+  if (result != 0) {
+    showError(tr("GPG import failed:\n%1").arg(stdErr));
+    return false;
+  }
+
+  QString keyId = parseGpgImportOutput(stdOut);
+  if (keyId.isEmpty()) {
+    keyId = parseGpgImportOutput(stdErr);
+  }
+
+  if (keyId.isEmpty()) {
+    showError(tr("Could not parse imported key id from GPG output."));
+    return false;
+  }
+
+  m_importedKeyId = keyId;
+  showSuccess(keyId);
+  return true;
+}
+
+QString ImportKeyDialog::parseGpgImportOutput(const QString &output) {
+  const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+  for (const QString &line : lines) {
+    QRegularExpressionMatch match = KEY_IMPORTED_EXACT.match(line);
+    if (match.hasMatch()) {
+      return match.captured(1);
+    }
+    match = KEY_IMPORTED_GENERAL.match(line);
+    if (match.hasMatch()) {
+      return match.captured(1);
+    }
+  }
+  return QString();
+}
+
+void ImportKeyDialog::showError(const QString &message) {
+  QMessageBox::warning(this, tr("Import Key"), message);
+}
+
+void ImportKeyDialog::showSuccess(const QString &keyId) {
+  QMessageBox::information(this, tr("Import Key"),
+                           tr("Successfully imported key: %1").arg(keyId));
+}

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -60,12 +60,14 @@ void ImportKeyDialog::on_fileButton_clicked() {
   // would lose bytes through UTF-8 conversion. Reject anything that doesn't
   // start with the PGP armor header.
   if (!bytes.trimmed().startsWith("-----BEGIN PGP")) {
+    // Message body is rich text (uses <code>/<b>); escape the path so any
+    // characters in it cannot reach the HTML subset Qt renders.
     QMessageBox::warning(
         this, tr("Import Key"),
         tr("%1 does not look like an ASCII-armored GPG key. Convert it with "
            "<code>gpg --armor --export</code> first, or paste the armored "
            "block via <b>From Clipboard</b>.")
-            .arg(fileName));
+            .arg(fileName.toHtmlEscaped()));
     return;
   }
 

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -134,24 +134,28 @@ bool ImportKeyDialog::importFromString(const QString &input) {
 }
 
 auto ImportKeyDialog::parseGpgImportOutput(const QString &output) -> QString {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
-#else
-  const QStringList lines = output.split('\n', QString::SkipEmptyParts);
-#endif
-  // Prefer locale-independent status output. IMPORT_OK gives a full
-  // fingerprint; IMPORTED gives a (long) key id. Try both before falling
-  // back to the English-only human-readable line.
+  // The order here is the priority order: prefer the locale-independent
+  // status lines over the English human-readable line, and within the
+  // status lines prefer IMPORT_OK (full fingerprint) over IMPORTED
+  // (long key id). Each regex is scanned across every line before we
+  // fall through to the next regex; the per-line ordering of gpg's
+  // output (which emits IMPORTED before IMPORT_OK) must not pick the
+  // weaker identifier.
   for (const QString &line : lines) {
-    QRegularExpressionMatch match = IMPORT_OK_RE.match(line);
+    const QRegularExpressionMatch match = IMPORT_OK_RE.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }
-    match = IMPORTED_RE.match(line);
+  }
+  for (const QString &line : lines) {
+    const QRegularExpressionMatch match = IMPORTED_RE.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }
-    match = KEY_IMPORTED_FALLBACK.match(line);
+  }
+  for (const QString &line : lines) {
+    const QRegularExpressionMatch match = KEY_IMPORTED_FALLBACK.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -143,19 +143,15 @@ auto ImportKeyDialog::parseGpgImportOutput(const QString &output) -> QString {
   // fingerprint; IMPORTED gives a (long) key id. Try both before falling
   // back to the English-only human-readable line.
   for (const QString &line : lines) {
-    const QRegularExpressionMatch match = IMPORT_OK_RE.match(line);
+    QRegularExpressionMatch match = IMPORT_OK_RE.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }
-  }
-  for (const QString &line : lines) {
-    const QRegularExpressionMatch match = IMPORTED_RE.match(line);
+    match = IMPORTED_RE.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }
-  }
-  for (const QString &line : lines) {
-    const QRegularExpressionMatch match = KEY_IMPORTED_FALLBACK.match(line);
+    match = KEY_IMPORTED_FALLBACK.match(line);
     if (match.hasMatch()) {
       return match.captured(1);
     }

--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -20,7 +20,7 @@
 static const QRegularExpression
     IMPORT_OK_RE(QStringLiteral(R"(\[GNUPG:\] IMPORT_OK \d+ ([0-9A-Fa-f]+))"));
 static const QRegularExpression
-    IMPORTED_RE(QStringLiteral(R"(\[GNUPG:\] IMPORTED ([0-9A-Fa-f]+))"));
+    IMPORTED_RE(QStringLiteral(R"(\[GNUPG:\] IMPORTED ([0-9A-Fa-f]{16}))"));
 // Fallback for the human-readable (English-locale) line.
 static const QRegularExpression KEY_IMPORTED_FALLBACK(
     QStringLiteral(R"(gpg: key ([0-9A-Fa-f]{40}|[0-9A-Fa-f]{16}):.*imported)"));

--- a/src/importkeydialog.h
+++ b/src/importkeydialog.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef SRC_IMPORTKEYDIALOG_H_
+#define SRC_IMPORTKEYDIALOG_H_
+
+#include <QDialog>
+#include <QString>
+
+namespace Ui {
+class ImportKeyDialog;
+}
+
+/**
+ * @class ImportKeyDialog
+ * @brief Dialog for importing GPG keys from file or clipboard.
+ *
+ * Allows users to import GPG public keys without leaving QtPass.
+ * Offers two import paths: from file or from clipboard text.
+ */
+class ImportKeyDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  /**
+   * @brief Construct an ImportKeyDialog.
+   * @param parent Optional parent widget.
+   */
+  explicit ImportKeyDialog(QWidget *parent = nullptr);
+  ~ImportKeyDialog() override;
+
+  /**
+   * @brief Get the imported key id on success.
+   * @return The imported key id, or empty if import failed.
+   */
+  QString importedKeyFingerprint() const;
+
+  /**
+   * @brief Parse GPG import output to extract key id.
+   * @param output Output from gpg --import command.
+   * @return The imported key id, or empty if not found.
+   */
+  static auto parseGpgImportOutput(const QString &output) -> QString;
+
+private slots:
+  /**
+   * @brief Handle file picker button click.
+   */
+  void on_fileButton_clicked();
+
+  /**
+   * @brief Handle paste button click.
+   */
+  void on_pasteButton_clicked();
+
+  /**
+   * @brief Handle import confirmation.
+   */
+  void on_importButton_clicked();
+
+  /**
+   * @brief Update UI state based on input field.
+   */
+  void on_inputTextEdit_textChanged();
+
+private:
+  Ui::ImportKeyDialog *ui;
+  QString m_importedKeyId;
+
+  auto importFromString(const QString &input) -> bool;
+  void showError(const QString &message);
+  void showSuccess(const QString &keyId);
+};
+#endif // SRC_IMPORTKEYDIALOG_H_

--- a/src/importkeydialog.h
+++ b/src/importkeydialog.h
@@ -30,14 +30,20 @@ public:
 
   /**
    * @brief Get the imported key id on success.
-   * @return The imported key id, or empty if import failed.
+   * @return The imported key id (or fingerprint when GnuPG status output
+   *         provides one), or empty if import failed.
    */
-  QString importedKeyFingerprint() const;
+  auto importedKeyId() const -> QString;
 
   /**
-   * @brief Parse GPG import output to extract key id.
-   * @param output Output from gpg --import command.
-   * @return The imported key id, or empty if not found.
+   * @brief Parse GPG import output to extract a key id or fingerprint.
+   *
+   * Prefers locale-independent status lines (\c [GNUPG:] IMPORT_OK and
+   * \c [GNUPG:] IMPORTED) when present, then falls back to the
+   * human-readable \c "gpg: key ...: imported" line (English locale only).
+   *
+   * @param output Combined stdout/stderr from `gpg --import --status-fd 1`.
+   * @return The imported key id or fingerprint, or empty if not found.
    */
   static auto parseGpgImportOutput(const QString &output) -> QString;
 

--- a/src/importkeydialog.ui
+++ b/src/importkeydialog.ui
@@ -16,7 +16,7 @@
   <property name="windowIcon">
    <iconset resource="../resources.qrc">
     <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
-   </property>
+  </property>
   <property name="modal">
    <bool>true</bool>
   </property>
@@ -99,37 +99,43 @@
      </item>
     </layout>
    </item>
-<item>
-     <widget class="QDialogButtonBox" name="buttonBox">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="standardButtons">
-       <set>QDialogButtonBox::Cancel</set>
-      </property>
-     </widget>
-    </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>fileButton</tabstop>
+  <tabstop>pasteButton</tabstop>
+  <tabstop>inputTextEdit</tabstop>
+  <tabstop>importButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources.qrc"/>
  </resources>
-<connections>
-   <connection>
-    <sender>buttonBox</sender>
-    <signal>rejected()</signal>
-    <receiver>ImportKeyDialog</receiver>
-    <slot>reject()</slot>
-    <hints>
-     <hint type="sourcelabel">
-      <x>200</x>
-      <y>200</y>
-     </hint>
-     <hint type="destinationlabel">
-      <x>200</x>
-      <y>200</y>
-     </hint>
-    </hints>
-   </connection>
-  </connections>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ImportKeyDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>200</x>
+     <y>200</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>200</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/importkeydialog.ui
+++ b/src/importkeydialog.ui
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportKeyDialog</class>
+ <widget class="QDialog" name="ImportKeyDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>550</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import GPG Key</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../resources.qrc">
+    <normaloff>:/artwork/icon.png</normaloff>:/artwork/icon.png</iconset>
+   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="instructionLabel">
+     <property name="text">
+      <string>Import a GPG public key from file or paste it below. The key should be in ASCII-armored format.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <widget class="QPushButton" name="fileButton">
+       <property name="text">
+        <string>From File...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pasteButton">
+       <property name="text">
+        <string>From Clipboard</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="buttonSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="inputTextEdit">
+     <property name="placeholderText">
+      <string>Paste an ASCII-armored GPG key here...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="actionLayout">
+     <item>
+      <spacer name="actionSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="importButton">
+       <property name="text">
+        <string>Import</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+<item>
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Cancel</set>
+      </property>
+     </widget>
+    </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
+<connections>
+   <connection>
+    <sender>buttonBox</sender>
+    <signal>rejected()</signal>
+    <receiver>ImportKeyDialog</receiver>
+    <slot>reject()</slot>
+    <hints>
+     <hint type="sourcelabel">
+      <x>200</x>
+      <y>200</y>
+     </hint>
+     <hint type="destinationlabel">
+      <x>200</x>
+      <y>200</y>
+     </hint>
+    </hints>
+   </connection>
+  </connections>
+</ui>

--- a/src/src.pro
+++ b/src/src.pro
@@ -70,6 +70,7 @@ SOURCES   += mainwindow.cpp \
              trayicon.cpp \
              passworddialog.cpp \
              exportpublickeydialog.cpp \
+             importkeydialog.cpp \
              qprogressindicator.cpp \
              qpushbuttonwithclipboard.cpp \
              qpushbuttonasqrcode.cpp \
@@ -95,6 +96,7 @@ HEADERS   += mainwindow.h \
              trayicon.h \
              passworddialog.h \
              exportpublickeydialog.h \
+             importkeydialog.h \
              qprogressindicator.h \
              deselectabletreeview.h \
              qpushbuttonwithclipboard.h \
@@ -121,7 +123,8 @@ FORMS     += mainwindow.ui \
              usersdialog.ui \
              keygendialog.ui \
              passworddialog.ui \
-             exportpublickeydialog.ui
+             exportpublickeydialog.ui \
+             importkeydialog.ui
 
 !nosingleapp {
     SOURCES += singleapplication.cpp

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -401,8 +401,12 @@ void UsersDialog::on_importKeyButton_clicked() {
     if (keyId.isEmpty()) {
       continue;
     }
-    if (importedKey.endsWith(keyId, Qt::CaseInsensitive) ||
-        keyId.endsWith(importedKey, Qt::CaseInsensitive)) {
+    // Only perform endsWith checks when the suffix being matched is at least
+    // 16 chars to avoid false positives with short IDs.
+    if ((keyId.length() >= 16 &&
+         importedKey.endsWith(keyId, Qt::CaseInsensitive)) ||
+        (importedKey.length() >= 16 &&
+         keyId.endsWith(importedKey, Qt::CaseInsensitive))) {
       ui->listWidget->setCurrentItem(item);
       break;
     }

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -1,15 +1,19 @@
 // SPDX-FileCopyrightText: 2015 Anne Jan Brouwer
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "usersdialog.h"
+#include "importkeydialog.h"
 #include "qtpasssettings.h"
 #include "ui_usersdialog.h"
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDateTime>
 #include <QKeyEvent>
+#include <QLineEdit>
+#include <QListWidget>
 #include <QMessageBox>
 #include <QRegularExpression>
 #include <QSet>
+#include <QSignalBlocker>
 #include <QWidget>
 #include <utility>
 
@@ -44,6 +48,8 @@ void UsersDialog::connectSignals() {
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
   connect(ui->listWidget, &QListWidget::itemChanged, this,
           &UsersDialog::itemChange);
+  connect(ui->importKeyButton, &QPushButton::clicked, this,
+          &UsersDialog::on_importKeyButton_clicked);
 
   ui->lineEdit->setClearButtonEnabled(true);
 }
@@ -350,3 +356,33 @@ void UsersDialog::on_lineEdit_textChanged(const QString &filter) {
  * @brief UsersDialog::on_checkBox_clicked filtering.
  */
 void UsersDialog::on_checkBox_clicked() { populateList(ui->lineEdit->text()); }
+
+void UsersDialog::on_importKeyButton_clicked() {
+  ImportKeyDialog dialog(this);
+  if (dialog.exec() != QDialog::Accepted) {
+    return;
+  }
+
+  QString fingerprint = dialog.importedKeyFingerprint();
+  if (fingerprint.isEmpty()) {
+    QMessageBox::warning(this, tr("Import Key"),
+                        tr("No key was imported. Please use the Import "
+                           "button to import a key."));
+    return;
+  }
+
+  if (!loadGpgKeys()) {
+    return;
+  }
+
+  ui->lineEdit->clear();
+  populateList(QString());
+
+  for (int i = 0; i < ui->listWidget->count(); ++i) {
+    QListWidgetItem *item = ui->listWidget->item(i);
+    if (item && item->text().contains(fingerprint)) {
+      ui->listWidget->setCurrentItem(item);
+      break;
+    }
+  }
+}

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -364,8 +364,12 @@ void UsersDialog::on_importKeyButton_clicked() {
 
   // dialog.exec() == Accepted is only reachable after a successful import
   // (see ImportKeyDialog::importFromString), so importedKeyId() is non-empty
-  // by construction here.
+  // by construction. Guard anyway: an empty value would make the
+  // bidirectional endsWith() below match the first listed key.
   const QString importedKey = dialog.importedKeyId();
+  if (importedKey.isEmpty()) {
+    return;
+  }
 
   if (!loadGpgKeys()) {
     return;

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -15,7 +15,6 @@
 #include <QSet>
 #include <QSignalBlocker>
 #include <QWidget>
-#include <utility>
 
 #ifdef QT_DEBUG
 #include "debughelper.h"
@@ -48,8 +47,8 @@ void UsersDialog::connectSignals() {
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
   connect(ui->listWidget, &QListWidget::itemChanged, this,
           &UsersDialog::itemChange);
-  connect(ui->importKeyButton, &QPushButton::clicked, this,
-          &UsersDialog::on_importKeyButton_clicked);
+  // importKeyButton is wired via Qt's automatic on_<name>_<signal> mechanism
+  // already triggered by setupUi().
 
   ui->lineEdit->setClearButtonEnabled(true);
 }
@@ -363,24 +362,43 @@ void UsersDialog::on_importKeyButton_clicked() {
     return;
   }
 
-  QString fingerprint = dialog.importedKeyFingerprint();
-  if (fingerprint.isEmpty()) {
-    QMessageBox::warning(this, tr("Import Key"),
-                        tr("No key was imported. Please use the Import "
-                           "button to import a key."));
-    return;
-  }
+  // dialog.exec() == Accepted is only reachable after a successful import
+  // (see ImportKeyDialog::importFromString), so importedKeyId() is non-empty
+  // by construction here.
+  const QString importedKey = dialog.importedKeyId();
 
   if (!loadGpgKeys()) {
     return;
   }
 
-  ui->lineEdit->clear();
+  // Clear the filter so the just-imported key is visible. setText("") still
+  // emits textChanged once, so don't double-populate.
+  {
+    const QSignalBlocker blocker(ui->lineEdit);
+    ui->lineEdit->clear();
+  }
   populateList(QString());
 
+  // Match against the user's stored key_id, not the visible item text.
+  // gpg can return a 16-char long key id (IMPORTED status line) or a
+  // 40-char fingerprint (IMPORT_OK status line); compare both directions
+  // so a long-id match works against a fingerprint hit and vice versa.
   for (int i = 0; i < ui->listWidget->count(); ++i) {
     QListWidgetItem *item = ui->listWidget->item(i);
-    if (item && item->text().contains(fingerprint)) {
+    if (item == nullptr) {
+      continue;
+    }
+    bool ok = false;
+    const int idx = item->data(Qt::UserRole).toInt(&ok);
+    if (!ok || idx < 0 || idx >= m_userList.size()) {
+      continue;
+    }
+    const QString &keyId = m_userList[idx].key_id;
+    if (keyId.isEmpty()) {
+      continue;
+    }
+    if (importedKey.endsWith(keyId, Qt::CaseInsensitive) ||
+        keyId.endsWith(importedKey, Qt::CaseInsensitive)) {
       ui->listWidget->setCurrentItem(item);
       break;
     }

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -73,8 +73,6 @@ private slots:
    * @brief Handle select all checkbox.
    */
   void on_checkBox_clicked();
-
-private slots:
   /**
    * @brief Import a GPG key and refresh the list.
    */

--- a/src/usersdialog.h
+++ b/src/usersdialog.h
@@ -74,6 +74,12 @@ private slots:
    */
   void on_checkBox_clicked();
 
+private slots:
+  /**
+   * @brief Import a GPG key and refresh the list.
+   */
+  void on_importKeyButton_clicked();
+
 private:
   Ui::UsersDialog *ui;
   QList<UserInfo> m_userList;            /**< List of available GPG users */

--- a/src/usersdialog.ui
+++ b/src/usersdialog.ui
@@ -56,40 +56,40 @@ Red entries are not valid, you will not be able to encrypt to these.</string>
      </property>
     </widget>
    </item>
-<item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLineEdit" name="lineEdit">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>26</height>
-         </size>
-        </property>
-        <property name="placeholderText">
-         <string>Search for users</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBox">
-        <property name="text">
-         <string>Show unusable keys</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="importKeyButton">
-        <property name="text">
-         <string>Import key...</string>
-        </property>
-        <property name="toolTip">
-         <string>Import a GPG key from file or clipboard</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="lineEdit">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="placeholderText">
+        <string>Search for users</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox">
+       <property name="text">
+        <string>Show unusable keys</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="importKeyButton">
+       <property name="text">
+        <string>Import key...</string>
+       </property>
+       <property name="toolTip">
+        <string>Import a GPG key from file or clipboard</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item>
     <widget class="QListWidget" name="listWidget">
      <property name="frameShadow">
@@ -117,6 +117,8 @@ Red entries are not valid, you will not be able to encrypt to these.</string>
  </widget>
  <tabstops>
   <tabstop>lineEdit</tabstop>
+  <tabstop>checkBox</tabstop>
+  <tabstop>importKeyButton</tabstop>
   <tabstop>listWidget</tabstop>
  </tabstops>
  <resources>

--- a/src/usersdialog.ui
+++ b/src/usersdialog.ui
@@ -56,30 +56,40 @@ Red entries are not valid, you will not be able to encrypt to these.</string>
      </property>
     </widget>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLineEdit" name="lineEdit">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="placeholderText">
-        <string>Search for users</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBox">
-       <property name="text">
-        <string>Show unusable keys</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
+<item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="lineEdit">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>26</height>
+         </size>
+        </property>
+        <property name="placeholderText">
+         <string>Search for users</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox">
+        <property name="text">
+         <string>Show unusable keys</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="importKeyButton">
+        <property name="text">
+         <string>Import key...</string>
+        </property>
+        <property name="toolTip">
+         <string>Import a GPG key from file or clipboard</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
    <item>
     <widget class="QListWidget" name="listWidget">
      <property name="frameShadow">

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/importkeydialog/importkeydialog.pro
+++ b/tests/auto/importkeydialog/importkeydialog.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_importkeydialog.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += importkeydialog.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX=24
+}

--- a/tests/auto/importkeydialog/qtpass.plist
+++ b/tests/auto/importkeydialog/qtpass.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+</dict>
+</plist>

--- a/tests/auto/importkeydialog/tst_importkeydialog.cpp
+++ b/tests/auto/importkeydialog/tst_importkeydialog.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <QPushButton>
+#include <QtTest>
+
+#include "../../../src/importkeydialog.h"
+
+class tst_importkeydialog : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void parseGpgImportOutput_data();
+  void parseGpgImportOutput();
+  void parseGpgImportOutputPrefersStatusOverHumanLine();
+  void parseGpgImportOutputPrefersImportOkOverImported();
+  void initialKeyIdEmpty();
+  void importButtonStartsDisabled();
+};
+
+void tst_importkeydialog::parseGpgImportOutput_data() {
+  QTest::addColumn<QString>("output");
+  QTest::addColumn<QString>("expected");
+
+  QTest::newRow("empty") << QString() << QString();
+
+  QTest::newRow("status_import_ok_fingerprint")
+      << QStringLiteral("[GNUPG:] IMPORT_OK 1 "
+                        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                        "[GNUPG:] IMPORT_RES 1 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0\n")
+      << QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+  QTest::newRow("status_imported_keyid")
+      << QStringLiteral("[GNUPG:] IMPORTED DEADBEEFCAFE0123 user@example.com\n")
+      << QStringLiteral("DEADBEEFCAFE0123");
+
+  QTest::newRow("english_human_line")
+      << QStringLiteral(
+             "gpg: key DEADBEEFCAFE0123: public key \"user\" imported\n")
+      << QStringLiteral("DEADBEEFCAFE0123");
+
+  QTest::newRow("english_human_line_terse")
+      << QStringLiteral("gpg: key DEADBEEFCAFE0123: imported\n")
+      << QStringLiteral("DEADBEEFCAFE0123");
+
+  // Non-English locale: only the [GNUPG:] status line should match;
+  // the human-readable line uses translated tokens we can't parse.
+  QTest::newRow("non_english_locale_with_status")
+      << QStringLiteral("gpg: clave DEADBEEFCAFE0123: importada\n"
+                        "[GNUPG:] IMPORT_OK 1 "
+                        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n")
+      << QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+  QTest::newRow("non_english_locale_no_status_returns_empty")
+      << QStringLiteral("gpg: clave DEADBEEFCAFE0123: importada\n")
+      << QString();
+
+  QTest::newRow("no_match")
+      << QStringLiteral("gpg: nothing happened\n") << QString();
+
+  QTest::newRow("multiple_keys_returns_first_status_match")
+      << QStringLiteral("[GNUPG:] IMPORT_OK 1 "
+                        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                        "[GNUPG:] IMPORT_OK 1 "
+                        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n")
+      << QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+  QTest::newRow("import_ok_with_zero_reason")
+      << QStringLiteral("[GNUPG:] IMPORT_OK 0 "
+                        "DEADBEEFCAFE0123DEADBEEFCAFE0123DEADBEEF\n")
+      << QStringLiteral("DEADBEEFCAFE0123DEADBEEFCAFE0123DEADBEEF");
+}
+
+void tst_importkeydialog::parseGpgImportOutput() {
+  QFETCH(QString, output);
+  QFETCH(QString, expected);
+  QCOMPARE(ImportKeyDialog::parseGpgImportOutput(output), expected);
+}
+
+void tst_importkeydialog::parseGpgImportOutputPrefersStatusOverHumanLine() {
+  // Both lines present; status line is locale-independent so it wins.
+  const QString output = QStringLiteral(
+      "gpg: key 1111111111111111: imported\n"
+      "[GNUPG:] IMPORT_OK 1 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n");
+  QCOMPARE(ImportKeyDialog::parseGpgImportOutput(output),
+           QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+}
+
+void tst_importkeydialog::parseGpgImportOutputPrefersImportOkOverImported() {
+  // IMPORT_OK provides a fingerprint, IMPORTED provides a key id; prefer
+  // the more specific fingerprint.
+  const QString output = QStringLiteral(
+      "[GNUPG:] IMPORTED DEADBEEFCAFE0123 user@example.com\n"
+      "[GNUPG:] IMPORT_OK 1 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n");
+  QCOMPARE(ImportKeyDialog::parseGpgImportOutput(output),
+           QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+}
+
+void tst_importkeydialog::initialKeyIdEmpty() {
+  ImportKeyDialog dialog;
+  QVERIFY(dialog.importedKeyId().isEmpty());
+}
+
+void tst_importkeydialog::importButtonStartsDisabled() {
+  ImportKeyDialog dialog;
+  auto *button =
+      dialog.findChild<QPushButton *>(QStringLiteral("importButton"));
+  QVERIFY(button != nullptr);
+  QVERIFY(!button->isEnabled());
+}
+
+QTEST_MAIN(tst_importkeydialog)
+#include "tst_importkeydialog.moc"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new "Import GPG Key" dialog, enhancing QtPass's key management capabilities.

Key changes include:
*   **New Import GPG Key Dialog:** A dedicated dialog (`ImportKeyDialog`) is added, allowing users to import GPG public keys.
    *   Users can choose to import a key from a file (supporting `.asc`, `.gpg`, `.key` extensions) or by pasting ASCII-armored key text directly into an input field.
    *   The dialog executes the `gpg --import` command internally and parses its output to confirm successful import and extract the key's fingerprint.
    *   It provides user feedback through success and error messages.
*   **Integration into Users Dialog:** A new "Import key..." button is added to the "Users" dialog.
    *   Clicking this button opens the new "Import GPG Key" dialog.
    *   Upon successful key import, the "Users" dialog automatically refreshes its list of GPG keys and attempts to select the newly imported key, making it immediately visible to the user.

This feature simplifies the process of adding GPG public keys to QtPass, directly addressing issue #1167 by providing a convenient in-application method for key import.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an "Import key..." action to the Users dialog and a modal to import GPG public keys from file, clipboard, or pasted ASCII-armored text; import enabled only with non-empty input.

* **User Feedback**
  * Validates input, shows descriptive error dialogs on failure, and a success confirmation exposing the imported key id; newly imported key is auto-selected in the list.

* **Tests**
  * Adds automated tests for import-output parsing and dialog UI/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->