### PR TITLE
feat: add process output area to mainwindow (#252)

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -77,6 +77,8 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
   ui->plainTextEditTemplate->setPlainText(QtPassSettings::getPassTemplate());
   ui->checkBoxTemplateAllFields->setChecked(
       QtPassSettings::isTemplateAllFields());
+  ui->checkBoxShowProcessOutput->setChecked(
+      QtPassSettings::isShowProcessOutput());
   ui->checkBoxAutoPull->setChecked(QtPassSettings::isAutoPull());
   ui->checkBoxAutoPush->setChecked(QtPassSettings::isAutoPush());
   ui->checkBoxAlwaysOnTop->setChecked(QtPassSettings::isAlwaysOnTop());
@@ -287,6 +289,8 @@ void ConfigDialog::on_accepted() {
   QtPassSettings::setPassTemplate(ui->plainTextEditTemplate->toPlainText());
   QtPassSettings::setTemplateAllFields(
       ui->checkBoxTemplateAllFields->isChecked());
+  QtPassSettings::setShowProcessOutput(
+      ui->checkBoxShowProcessOutput->isChecked());
   QtPassSettings::setAlwaysOnTop(ui->checkBoxAlwaysOnTop->isChecked());
 
   QtPassSettings::setVersion(VERSION);

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -232,22 +232,22 @@
              </property>
             </widget>
            </item>
-<item>
-             <widget class="QCheckBox" name="checkBoxNoLineWrapping">
-              <property name="text">
-               <string>No line wrapping</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="checkBoxShowProcessOutput">
-              <property name="text">
-               <string>Show process output</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_9">
+           <item>
+            <widget class="QCheckBox" name="checkBoxNoLineWrapping">
+             <property name="text">
+              <string>No line wrapping</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="checkBoxShowProcessOutput">
+             <property name="text">
+              <string>Show process output</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_9">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -232,15 +232,22 @@
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QCheckBox" name="checkBoxNoLineWrapping">
-             <property name="text">
-              <string>No line wrapping</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_9">
+<item>
+             <widget class="QCheckBox" name="checkBoxNoLineWrapping">
+              <property name="text">
+               <string>No line wrapping</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxShowProcessOutput">
+              <property name="text">
+               <string>Show process output</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_9">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>

--- a/src/enums.h
+++ b/src/enums.h
@@ -3,6 +3,8 @@
 #ifndef SRC_ENUMS_H_
 #define SRC_ENUMS_H_
 
+#include <QMetaType>
+
 /**
  * @namespace Enums
  * @brief Enumerators for QtPass configuration and runtime operations.
@@ -46,5 +48,7 @@ enum PROCESS {
 };
 
 } // namespace Enums
+
+Q_DECLARE_METATYPE(Enums::PROCESS)
 
 #endif // SRC_ENUMS_H_

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -125,8 +125,17 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   initStatusBar();
 
   connect(QtPassSettings::getPass(), &Pass::finishedAnyWithPid, this,
-          [this](const QString &out, const QString &err, int pid) {
-            if (pid == Enums::PASS_SHOW || pid == Enums::PASS_OTP_GENERATE) {
+          [this](const QString &out, const QString &err, Enums::PROCESS pid) {
+            // Never route potentially-secret output through the panel:
+            // - PASS_SHOW / PASS_OTP_GENERATE go via dedicated signals to
+            //   the main text browser (which clears on a timer).
+            // - PASS_GREP returns lines from password files; #252 must
+            //   not leak those into a long-lived panel.
+            // - PASS_INSERT's stdin is the password; stdout normally
+            //   carries gpg/git progress only, but exclude defensively
+            //   in case a future code path uses --echo or similar.
+            if (pid == Enums::PASS_SHOW || pid == Enums::PASS_OTP_GENERATE ||
+                pid == Enums::PASS_GREP || pid == Enums::PASS_INSERT) {
               return;
             }
             if (!out.isEmpty()) {
@@ -1725,8 +1734,7 @@ void MainWindow::critical(const QString &title, const QString &msg) {
   QMessageBox::critical(this, title, msg);
 }
 
-void MainWindow::appendProcessOutput(const QString &output, bool isError,
-                                     int pid) {
+void MainWindow::appendProcessOutput(const QString &output, bool isError) {
   if (!QtPassSettings::isShowProcessOutput()) {
     return;
   }
@@ -1764,43 +1772,54 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError,
   }
 }
 
-void MainWindow::onProcessOutput(const QString &output, bool isError, int pid) {
-  QString cmdName = getProcessName(pid);
+void MainWindow::onProcessOutput(const QString &output, bool isError,
+                                 Enums::PROCESS pid) {
+  const QString cmdName = getProcessName(pid);
   appendProcessOutput(cmdName.isEmpty() ? output : cmdName + ": " + output,
                       isError);
 }
 
-auto MainWindow::getProcessName(int pid) -> QString {
+auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
+  // Literal command names — intentionally not translated, since they refer
+  // to actual shell commands the user could run to reproduce the action.
   switch (pid) {
   case Enums::GIT_INIT:
-    return "git init";
+    return QStringLiteral("git init"); // no-tr
   case Enums::GIT_ADD:
-    return "git add";
+    return QStringLiteral("git add"); // no-tr
   case Enums::GIT_COMMIT:
-    return "git commit";
+    return QStringLiteral("git commit"); // no-tr
   case Enums::GIT_RM:
-    return "git rm";
+    return QStringLiteral("git rm"); // no-tr
   case Enums::GIT_PULL:
-    return "git pull";
+    return QStringLiteral("git pull"); // no-tr
   case Enums::GIT_PUSH:
-    return "git push";
+    return QStringLiteral("git push"); // no-tr
+  case Enums::GIT_MOVE:
+    return QStringLiteral("git mv"); // no-tr
+  case Enums::GIT_COPY:
+    return QStringLiteral("git cp"); // no-tr
   case Enums::PASS_INSERT:
-    return "pass insert";
+    return QStringLiteral("pass insert"); // no-tr
   case Enums::PASS_REMOVE:
-    return "pass rm";
+    return QStringLiteral("pass rm"); // no-tr
   case Enums::PASS_INIT:
-    return "pass init";
+    return QStringLiteral("pass init"); // no-tr
   case Enums::PASS_MOVE:
-    return "pass mv";
+    return QStringLiteral("pass mv"); // no-tr
   case Enums::PASS_COPY:
-    return "pass cp";
+    return QStringLiteral("pass cp"); // no-tr
   case Enums::PASS_GREP:
-    return "pass grep";
+    return QStringLiteral("pass grep"); // no-tr
   case Enums::GPG_GENKEYS:
-    return "gpg --gen-key";
-  default:
-    return QString();
+    return QStringLiteral("gpg --gen-key"); // no-tr
+  case Enums::PASS_SHOW:
+  case Enums::PASS_OTP_GENERATE:
+  case Enums::PROCESS_COUNT:
+  case Enums::INVALID:
+    break;
   }
+  return QString();
 }
 
 void MainWindow::updateProcessOutputVisibility() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -228,7 +228,6 @@ void MainWindow::initStatusBar() {
   logoApp->setPixmap(logo);
   statusBar()->addPermanentWidget(logoApp);
 
-  ui->processOutputWidget->setParent(statusBar());
   statusBar()->addPermanentWidget(ui->processOutputWidget);
 
   updateProcessOutputVisibility();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1807,7 +1807,13 @@ auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
   case Enums::GIT_MOVE:
     return QStringLiteral("git mv"); // no-tr
   case Enums::GIT_COPY:
-    return QStringLiteral("git cp"); // no-tr
+    // The underlying invocation is `git cp` (a git-extras subcommand) but
+    // most users don't have git-extras installed, so showing that as the
+    // label would be unactionable. Use `git add` instead — it's the
+    // closest reproducible step a stock-git user would take to stage the
+    // copied file; the subsequent commit shows separately under
+    // GIT_COMMIT.
+    return QStringLiteral("git add"); // no-tr
   case Enums::PASS_INSERT:
     return QStringLiteral("pass insert"); // no-tr
   case Enums::PASS_REMOVE:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -134,8 +134,7 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
             // - PASS_INSERT's stdin is the password; stdout normally
             //   carries gpg/git progress only, but exclude defensively
             //   in case a future code path uses --echo or similar.
-            if (pid == Enums::PASS_SHOW || pid == Enums::PASS_OTP_GENERATE ||
-                pid == Enums::PASS_GREP || pid == Enums::PASS_INSERT) {
+            if (isSensitiveProcess(pid)) {
               return;
             }
             if (!out.isEmpty()) {
@@ -147,7 +146,10 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
           });
 
   connect(ui->processOutputEdit->verticalScrollBar(),
-          &QScrollBar::sliderPressed, this, [this]() { m_autoScroll = false; });
+          &QScrollBar::sliderPressed, this, [this]() {
+            auto *sb = ui->processOutputEdit->verticalScrollBar();
+            m_autoScroll = sb->value() >= sb->maximum();
+          });
   connect(ui->processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
           this, [this]() {
             auto *sb = ui->processOutputEdit->verticalScrollBar();
@@ -1733,6 +1735,17 @@ void MainWindow::critical(const QString &title, const QString &msg) {
   QMessageBox::critical(this, title, msg);
 }
 
+/**
+ * @brief Appends processed command output to the output panel.
+ *
+ * Appends text to the process output text edit, with per-line numbering,
+ * optional command prefix, and color coding for errors vs. success.
+ * Handles auto-scrolling and line limits.
+ *
+ * @param output The raw output text from the command.
+ * @param isError true if this is error output (stderr).
+ * @param linePrefix Optional command name to prefix each line with.
+ */
 void MainWindow::appendProcessOutput(const QString &output, bool isError,
                                      const QString &linePrefix) {
   if (!QtPassSettings::isShowProcessOutput()) {
@@ -1777,14 +1790,32 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError,
   }
 }
 
+/**
+ * @brief Handles process output from the Pass executor.
+ *
+ * Called when any non-sensitive process completes. Filters out password-
+ * related commands (pass show, insert, etc.) and delegates to
+ * appendProcessOutput.
+ *
+ * @param output The stdout/stderr text from the process.
+ * @param isError true if this is error output (stderr).
+ * @param pid The process ID identifying which command ran.
+ */
 void MainWindow::onProcessOutput(const QString &output, bool isError,
                                  Enums::PROCESS pid) {
   appendProcessOutput(output, isError, getProcessName(pid));
 }
 
+/**
+ * @brief Maps a process ID to its human-readable command name.
+ *
+ * Returns static strings for git/pass commands that appear in output.
+ * Password-related commands return empty (they are filtered).
+ *
+ * @param pid The process ID to look up.
+ * @return QString with command name, or empty if filtered.
+ */
 auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
-  // Literal command names — intentionally not translated, since they refer
-  // to actual shell commands the user could run to reproduce the action.
   switch (pid) {
   case Enums::GIT_INIT:
     return QStringLiteral("git init"); // no-tr
@@ -1798,17 +1829,7 @@ auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
     return QStringLiteral("git pull"); // no-tr
   case Enums::GIT_PUSH:
     return QStringLiteral("git push"); // no-tr
-  case Enums::GIT_MOVE:
-    return QStringLiteral("git mv"); // no-tr
-  case Enums::GIT_COPY:
-    // The underlying invocation is `git cp` (a git-extras subcommand) but
-    // most users don't have git-extras installed, so showing that as the
-    // label would be unactionable. Use `git add` instead — it's the
-    // closest reproducible step a stock-git user would take to stage the
-    // copied file; the subsequent commit shows separately under
-    // GIT_COMMIT.
-    return QStringLiteral("git add"); // no-tr
-  case Enums::PASS_INSERT: // Unreachable: filtered by finishedAnyWithPid (lines 137-140)
+  case Enums::PASS_INSERT:
     return QStringLiteral("pass insert"); // no-tr
   case Enums::PASS_REMOVE:
     return QStringLiteral("pass rm"); // no-tr
@@ -1831,10 +1852,57 @@ auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
   return QString();
 }
 
+/**
+ * @brief Checks if a process ID represents a sensitive operation whose
+ * output should not be shown in the process output panel.
+ *
+ * Password-related commands (pass show, OTP generate, grep, insert)
+ * display their output in other UI areas, so we skip them here.
+ *
+ * @param pid The process ID to check.
+ * @return true if the process is sensitive and should be filtered.
+ */
+auto MainWindow::isSensitiveProcess(Enums::PROCESS pid) -> bool {
+  switch (pid) {
+  case Enums::PASS_SHOW:
+  case Enums::PASS_OTP_GENERATE:
+  case Enums::PASS_GREP:
+  case Enums::PASS_INSERT:
+    return true;
+  case Enums::GIT_INIT:
+  case Enums::GIT_ADD:
+  case Enums::GIT_COMMIT:
+  case Enums::GIT_RM:
+  case Enums::GIT_PULL:
+  case Enums::GIT_PUSH:
+  case Enums::PASS_REMOVE:
+  case Enums::PASS_INIT:
+  case Enums::PASS_MOVE:
+  case Enums::PASS_COPY:
+  case Enums::GPG_GENKEYS:
+  case Enums::PROCESS_COUNT:
+  case Enums::INVALID:
+    break;
+  }
+  return false;
+}
+
+/**
+ * @brief Updates the visibility of the process output panel.
+ *
+ * Shows or hides the process output widget based on the user's
+ * showProcessOutput setting.
+ */
 void MainWindow::updateProcessOutputVisibility() {
   ui->processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
 }
 
+/**
+ * @brief Limits the output panel to max lines, trimming old excess.
+ *
+ * Removes the oldest lines when the document exceeds MaxOutputLines (1000).
+ * Called after each append to prevent unbounded growth.
+ */
 void MainWindow::limitOutputLines() {
   QTextDocument *doc = ui->processOutputEdit->document();
   int excess = doc->blockCount() - MaxOutputLines;
@@ -1848,6 +1916,12 @@ void MainWindow::limitOutputLines() {
   cursor.removeSelectedText();
 }
 
+/**
+ * @brief Clears the process output panel.
+ *
+ * Clears all output, resets the line counter, re-enables auto-scroll,
+ * and moves the cursor to the end for subsequent appends.
+ */
 void MainWindow::on_clearOutputButton_clicked() {
   ui->processOutputEdit->clear();
   m_outputCounter = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -469,7 +469,6 @@ void MainWindow::executeWrapperStarted() {
   ui->textBrowser->clear();
   setUiElementsEnabled(false);
   clearPanelTimer.stop();
-  m_processOutputShownForCurrentCommand = false;
   if (QtPassSettings::isShowProcessOutput()) {
     ui->processOutputWidget->setVisible(true);
   }
@@ -1776,11 +1775,6 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError,
   if (m_autoScroll) {
     ui->processOutputEdit->moveCursor(QTextCursor::End);
   }
-
-  if (!m_processOutputShownForCurrentCommand) {
-    ui->processOutputWidget->setVisible(true);
-    m_processOutputShownForCurrentCommand = true;
-  }
 }
 
 void MainWindow::onProcessOutput(const QString &output, bool isError,
@@ -1814,7 +1808,7 @@ auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
     // copied file; the subsequent commit shows separately under
     // GIT_COMMIT.
     return QStringLiteral("git add"); // no-tr
-  case Enums::PASS_INSERT:
+  case Enums::PASS_INSERT: // Unreachable: filtered by finishedAnyWithPid (lines 137-140)
     return QStringLiteral("pass insert"); // no-tr
   case Enums::PASS_REMOVE:
     return QStringLiteral("pass rm"); // no-tr

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -125,13 +125,12 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 
   connect(QtPassSettings::getPass(), &Pass::finishedAny, this,
           [this](const QString &out, const QString &err) {
-            QString output = out;
-            if (!err.isEmpty()) {
-              if (!output.isEmpty())
-                output += "\n";
-              output += err;
+            if (!out.isEmpty()) {
+              onProcessOutput(out, false);
             }
-            onProcessOutput(output, !err.isEmpty());
+            if (!err.isEmpty()) {
+              onProcessOutput(err, true);
+            }
           });
 
   connect(ui->processOutputEdit->verticalScrollBar(),
@@ -351,6 +350,7 @@ void MainWindow::config() {
       updateGitButtonVisibility();
       updateOtpButtonVisibility();
       updateGrepButtonVisibility();
+      updateProcessOutputVisibility();
       if (QtPassSettings::isUseTrayIcon() && tray == nullptr) {
         initTrayIcon();
       } else if (!QtPassSettings::isUseTrayIcon() && tray != nullptr) {
@@ -1723,13 +1723,27 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError) {
     return;
   }
 
-  m_outputCounter++;
-  QString lineNumber = QString::number(m_outputCounter);
-  QString coloredOutput = isError ? QString("<span style=\"color: red;\">")
-                                  : QString("<span style=\"color: black;\">");
-  coloredOutput += lineNumber + ": " + output.toHtmlEscaped() + "</span><br>";
+  QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+  for (QString &line : lines) {
+    line = line.trimmed();
+    if (line.isEmpty()) {
+      continue;
+    }
 
-  ui->processOutputEdit->append(coloredOutput);
+    m_outputCounter++;
+    QString lineNumber = QString::number(m_outputCounter);
+
+    QColor textColor =
+        isError ? QColor(Qt::red)
+                : ui->processOutputEdit->palette().color(QPalette::Text);
+    QString colorHex = textColor.name();
+    QString coloredOutput =
+        QString("<span style=\"color: %1;\">%2: %3</span>")
+            .arg(colorHex, lineNumber, line.toHtmlEscaped());
+
+    ui->processOutputEdit->append(coloredOutput);
+  }
+
   limitOutputLines();
 
   if (m_autoScroll) {
@@ -1765,4 +1779,6 @@ void MainWindow::limitOutputLines() {
 void MainWindow::on_clearOutputButton_clicked() {
   ui->processOutputEdit->clear();
   m_outputCounter = 0;
+  m_autoScroll = true;
+  ui->processOutputEdit->moveCursor(QTextCursor::End);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -456,6 +456,10 @@ void MainWindow::executeWrapperStarted() {
   ui->textBrowser->clear();
   setUiElementsEnabled(false);
   clearPanelTimer.stop();
+  m_processOutputShownForCurrentCommand = false;
+  if (QtPassSettings::isShowProcessOutput()) {
+    ui->processOutputWidget->setVisible(true);
+  }
 }
 
 /**
@@ -1749,8 +1753,9 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError) {
     ui->processOutputEdit->moveCursor(QTextCursor::End);
   }
 
-  if (!ui->processOutputWidget->isVisible()) {
+  if (!m_processOutputShownForCurrentCommand) {
     ui->processOutputWidget->setVisible(true);
+    m_processOutputShownForCurrentCommand = true;
   }
 }
 
@@ -1764,15 +1769,15 @@ void MainWindow::updateProcessOutputVisibility() {
 
 void MainWindow::limitOutputLines() {
   QTextDocument *doc = ui->processOutputEdit->document();
-  while (doc->blockCount() > MaxOutputLines) {
-    QTextCursor cursor(doc);
-    cursor.movePosition(QTextCursor::Start);
-    cursor.select(QTextCursor::BlockUnderCursor);
-    cursor.removeSelectedText();
-    if (!cursor.atEnd()) {
-      cursor.deleteChar();
-    }
+  int excess = doc->blockCount() - MaxOutputLines;
+  if (excess <= 0) {
+    return;
   }
+
+  QTextCursor cursor(doc);
+  cursor.movePosition(QTextCursor::Start);
+  cursor.movePosition(QTextCursor::NextBlock, QTextCursor::KeepAnchor, excess);
+  cursor.removeSelectedText();
 }
 
 void MainWindow::on_clearOutputButton_clicked() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1741,7 +1741,12 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError) {
 
   QStringList lines = output.split('\n', Qt::SkipEmptyParts);
   for (QString &line : lines) {
-    line = line.trimmed();
+    // Right-trim only: remove trailing CR and whitespace, preserve leading
+    // indentation
+    line.remove('\r');
+    while (!line.isEmpty() && line.back().isSpace()) {
+      line.chop(1);
+    }
     if (line.isEmpty()) {
       continue;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include "configdialog.h"
+#include "enums.h"
 #include "executor.h"
 #include "exportpublickeydialog.h"
 #include "filecontent.h"
@@ -123,8 +124,11 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   initToolBarButtons();
   initStatusBar();
 
-  connect(QtPassSettings::getPass(), &Pass::finishedAny, this,
-          [this](const QString &out, const QString &err) {
+  connect(QtPassSettings::getPass(), &Pass::finishedAnyWithPid, this,
+          [this](const QString &out, const QString &err, int pid) {
+            if (pid == Enums::PASS_SHOW || pid == Enums::PASS_OTP_GENERATE) {
+              return;
+            }
             if (!out.isEmpty()) {
               onProcessOutput(out, false);
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -130,10 +130,10 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
               return;
             }
             if (!out.isEmpty()) {
-              onProcessOutput(out, false);
+              onProcessOutput(out, false, pid);
             }
             if (!err.isEmpty()) {
-              onProcessOutput(err, true);
+              onProcessOutput(err, true, pid);
             }
           });
 
@@ -1725,7 +1725,8 @@ void MainWindow::critical(const QString &title, const QString &msg) {
   QMessageBox::critical(this, title, msg);
 }
 
-void MainWindow::appendProcessOutput(const QString &output, bool isError) {
+void MainWindow::appendProcessOutput(const QString &output, bool isError,
+                                     int pid) {
   if (!QtPassSettings::isShowProcessOutput()) {
     return;
   }
@@ -1763,8 +1764,43 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError) {
   }
 }
 
-void MainWindow::onProcessOutput(const QString &output, bool isError) {
-  appendProcessOutput(output, isError);
+void MainWindow::onProcessOutput(const QString &output, bool isError, int pid) {
+  QString cmdName = getProcessName(pid);
+  appendProcessOutput(cmdName.isEmpty() ? output : cmdName + ": " + output,
+                      isError);
+}
+
+auto MainWindow::getProcessName(int pid) -> QString {
+  switch (pid) {
+  case Enums::GIT_INIT:
+    return "git init";
+  case Enums::GIT_ADD:
+    return "git add";
+  case Enums::GIT_COMMIT:
+    return "git commit";
+  case Enums::GIT_RM:
+    return "git rm";
+  case Enums::GIT_PULL:
+    return "git pull";
+  case Enums::GIT_PUSH:
+    return "git push";
+  case Enums::PASS_INSERT:
+    return "pass insert";
+  case Enums::PASS_REMOVE:
+    return "pass rm";
+  case Enums::PASS_INIT:
+    return "pass init";
+  case Enums::PASS_MOVE:
+    return "pass mv";
+  case Enums::PASS_COPY:
+    return "pass cp";
+  case Enums::PASS_GREP:
+    return "pass grep";
+  case Enums::GPG_GENKEYS:
+    return "gpg --gen-key";
+  default:
+    return QString();
+  }
 }
 
 void MainWindow::updateProcessOutputVisibility() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1734,7 +1734,8 @@ void MainWindow::critical(const QString &title, const QString &msg) {
   QMessageBox::critical(this, title, msg);
 }
 
-void MainWindow::appendProcessOutput(const QString &output, bool isError) {
+void MainWindow::appendProcessOutput(const QString &output, bool isError,
+                                     const QString &linePrefix) {
   if (!QtPassSettings::isShowProcessOutput()) {
     return;
   }
@@ -1758,9 +1759,14 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError) {
         isError ? QColor(Qt::red)
                 : ui->processOutputEdit->palette().color(QPalette::Text);
     QString colorHex = textColor.name();
+    // Apply the optional prefix per line so multi-line output stays
+    // attributed to its command (e.g. all 3 lines of a `git push` show
+    // "git push: ..." rather than only the first).
+    QString prefixed =
+        linePrefix.isEmpty() ? line : linePrefix + QStringLiteral(": ") + line;
     QString coloredOutput =
         QString("<span style=\"color: %1;\">%2: %3</span>")
-            .arg(colorHex, lineNumber, line.toHtmlEscaped());
+            .arg(colorHex, lineNumber, prefixed.toHtmlEscaped());
 
     ui->processOutputEdit->append(coloredOutput);
   }
@@ -1779,9 +1785,7 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError) {
 
 void MainWindow::onProcessOutput(const QString &output, bool isError,
                                  Enums::PROCESS pid) {
-  const QString cmdName = getProcessName(pid);
-  appendProcessOutput(cmdName.isEmpty() ? output : cmdName + ": " + output,
-                      isError);
+  appendProcessOutput(output, isError, getProcessName(pid));
 }
 
 auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -30,7 +30,9 @@
 #include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
+#include <QScrollBar>
 #include <QShortcut>
+#include <QTextCursor>
 #include <QTimer>
 #include <QTreeWidget>
 #include <utility>
@@ -121,6 +123,25 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   initToolBarButtons();
   initStatusBar();
 
+  connect(QtPassSettings::getPass(), &Pass::finishedAny, this,
+          [this](const QString &out, const QString &err) {
+            QString output = out;
+            if (!err.isEmpty()) {
+              if (!output.isEmpty())
+                output += "\n";
+              output += err;
+            }
+            onProcessOutput(output, !err.isEmpty());
+          });
+
+  connect(ui->processOutputEdit->verticalScrollBar(),
+          &QScrollBar::sliderPressed, this, [this]() { m_autoScroll = false; });
+  connect(ui->processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
+          this, [this]() {
+            auto *sb = ui->processOutputEdit->verticalScrollBar();
+            m_autoScroll = sb->value() >= sb->maximum();
+          });
+
   ui->lineEdit->setClearButtonEnabled(true);
   updateGrepButtonVisibility();
 
@@ -207,6 +228,11 @@ void MainWindow::initStatusBar() {
   auto *logoApp = new QLabel(statusBar());
   logoApp->setPixmap(logo);
   statusBar()->addPermanentWidget(logoApp);
+
+  ui->processOutputWidget->setParent(statusBar());
+  statusBar()->addPermanentWidget(ui->processOutputWidget);
+
+  updateProcessOutputVisibility();
 }
 
 auto MainWindow::getCurrentTreeViewIndex() -> QModelIndex {
@@ -1690,4 +1716,53 @@ void MainWindow::enableGitButtons(const bool &state) {
  */
 void MainWindow::critical(const QString &title, const QString &msg) {
   QMessageBox::critical(this, title, msg);
+}
+
+void MainWindow::appendProcessOutput(const QString &output, bool isError) {
+  if (!QtPassSettings::isShowProcessOutput()) {
+    return;
+  }
+
+  m_outputCounter++;
+  QString lineNumber = QString::number(m_outputCounter);
+  QString coloredOutput = isError ? QString("<span style=\"color: red;\">")
+                                  : QString("<span style=\"color: black;\">");
+  coloredOutput += lineNumber + ": " + output.toHtmlEscaped() + "</span><br>";
+
+  ui->processOutputEdit->append(coloredOutput);
+  limitOutputLines();
+
+  if (m_autoScroll) {
+    ui->processOutputEdit->moveCursor(QTextCursor::End);
+  }
+
+  if (!ui->processOutputWidget->isVisible()) {
+    ui->processOutputWidget->setVisible(true);
+  }
+}
+
+void MainWindow::onProcessOutput(const QString &output, bool isError) {
+  appendProcessOutput(output, isError);
+}
+
+void MainWindow::updateProcessOutputVisibility() {
+  ui->processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
+}
+
+void MainWindow::limitOutputLines() {
+  QTextDocument *doc = ui->processOutputEdit->document();
+  while (doc->blockCount() > MaxOutputLines) {
+    QTextCursor cursor(doc);
+    cursor.movePosition(QTextCursor::Start);
+    cursor.select(QTextCursor::BlockUnderCursor);
+    cursor.removeSelectedText();
+    if (!cursor.atEnd()) {
+      cursor.deleteChar();
+    }
+  }
+}
+
+void MainWindow::on_clearOutputButton_clicked() {
+  ui->processOutputEdit->clear();
+  m_outputCounter = 0;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1786,7 +1786,8 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError,
   limitOutputLines();
 
   if (m_autoScroll) {
-    ui->processOutputEdit->moveCursor(QTextCursor::End);
+    ui->processOutputEdit->verticalScrollBar()->setValue(
+        ui->processOutputEdit->verticalScrollBar()->maximum());
   }
 }
 
@@ -1925,12 +1926,10 @@ void MainWindow::limitOutputLines() {
 /**
  * @brief Clears the process output panel.
  *
- * Clears all output, resets the line counter, re-enables auto-scroll,
- * and moves the cursor to the end for subsequent appends.
+ * Clears all output, resets the line counter, and re-enables auto-scroll.
  */
 void MainWindow::on_clearOutputButton_clicked() {
   ui->processOutputEdit->clear();
   m_outputCounter = 0;
   m_autoScroll = true;
-  ui->processOutputEdit->moveCursor(QTextCursor::End);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1829,6 +1829,10 @@ auto MainWindow::getProcessName(Enums::PROCESS pid) -> QString {
     return QStringLiteral("git pull"); // no-tr
   case Enums::GIT_PUSH:
     return QStringLiteral("git push"); // no-tr
+  case Enums::GIT_MOVE:
+    return QStringLiteral("git mv"); // no-tr
+  case Enums::GIT_COPY:
+    return QStringLiteral("git cp"); // no-tr
   case Enums::PASS_INSERT:
     return QStringLiteral("pass insert"); // no-tr
   case Enums::PASS_REMOVE:
@@ -1875,6 +1879,8 @@ auto MainWindow::isSensitiveProcess(Enums::PROCESS pid) -> bool {
   case Enums::GIT_RM:
   case Enums::GIT_PULL:
   case Enums::GIT_PUSH:
+  case Enums::GIT_MOVE:
+  case Enums::GIT_COPY:
   case Enums::PASS_REMOVE:
   case Enums::PASS_INIT:
   case Enums::PASS_MOVE:

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -311,7 +311,8 @@ private:
   void updateGrepButtonVisibility();
   void enableGitButtons(const bool &);
 
-  void appendProcessOutput(const QString &output, bool isError);
+  void appendProcessOutput(const QString &output, bool isError,
+                           const QString &linePrefix = QString());
   void updateProcessOutputVisibility();
   void limitOutputLines();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -164,6 +164,13 @@ public slots:
   void messageAvailable(const QString &message);
 
   /**
+   * @brief Handle generic process output for display in output panel.
+   * @param output Process output text.
+   * @param isError true if output should be styled as error (red).
+   */
+  void onProcessOutput(const QString &output, bool isError);
+
+  /**
    * @brief Display a critical error dialog.
    * @param title Dialog title.
    * @param msg Error message body.
@@ -224,6 +231,7 @@ public slots:
 private slots:
   void on_grepButton_toggled(bool checked);
   void on_grepResultsList_itemClicked(QTreeWidgetItem *item, int column);
+  void on_clearOutputButton_clicked();
   void addPassword();
   void addFolder();
   void onEdit();
@@ -258,6 +266,9 @@ private:
   bool m_grepMode = false;
   bool m_grepBusy = false;
   bool m_grepCancelled = false;
+  bool m_autoScroll = true;
+  int m_outputCounter = 0;
+  static constexpr int MaxOutputLines = 1000;
   QFileSystemModel model;
   StoreModel proxyModel;
   QScopedPointer<QItemSelectionModel> selectionModel;
@@ -294,6 +305,10 @@ private:
   void updateOtpButtonVisibility();
   void updateGrepButtonVisibility();
   void enableGitButtons(const bool &);
+
+  void appendProcessOutput(const QString &output, bool isError);
+  void updateProcessOutputVisibility();
+  void limitOutputLines();
 };
 
 #endif // SRC_MAINWINDOW_H_

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -267,6 +267,7 @@ private:
   bool m_grepBusy = false;
   bool m_grepCancelled = false;
   bool m_autoScroll = true;
+  bool m_processOutputShownForCurrentCommand = false;
   int m_outputCounter = 0;
   static constexpr int MaxOutputLines = 1000;
   QFileSystemModel model;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 #ifndef SRC_MAINWINDOW_H_
 #define SRC_MAINWINDOW_H_
 
+#include "enums.h"
 #include "storemodel.h"
 
 #include <QFileSystemModel>
@@ -167,8 +168,11 @@ public slots:
    * @brief Handle generic process output for display in output panel.
    * @param output Process output text.
    * @param isError true if output should be styled as error (red).
+   * @param pid Identifier of the originating subprocess (for the label
+   *            prefix); defaults to Enums::INVALID for unlabelled output.
    */
-  void onProcessOutput(const QString &output, bool isError, int pid = -1);
+  void onProcessOutput(const QString &output, bool isError,
+                       Enums::PROCESS pid = Enums::INVALID);
 
   /**
    * @brief Display a critical error dialog.
@@ -307,11 +311,11 @@ private:
   void updateGrepButtonVisibility();
   void enableGitButtons(const bool &);
 
-  void appendProcessOutput(const QString &output, bool isError, int pid = -1);
+  void appendProcessOutput(const QString &output, bool isError);
   void updateProcessOutputVisibility();
   void limitOutputLines();
 
-  auto getProcessName(int pid) -> QString;
+  static auto getProcessName(Enums::PROCESS pid) -> QString;
 };
 
 #endif // SRC_MAINWINDOW_H_

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -271,7 +271,6 @@ private:
   bool m_grepBusy = false;
   bool m_grepCancelled = false;
   bool m_autoScroll = true;
-  bool m_processOutputShownForCurrentCommand = false;
   int m_outputCounter = 0;
   static constexpr int MaxOutputLines = 1000;
   QFileSystemModel model;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -316,6 +316,7 @@ private:
   void limitOutputLines();
 
   static auto getProcessName(Enums::PROCESS pid) -> QString;
+  static auto isSensitiveProcess(Enums::PROCESS pid) -> bool;
 };
 
 #endif // SRC_MAINWINDOW_H_

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -168,7 +168,7 @@ public slots:
    * @param output Process output text.
    * @param isError true if output should be styled as error (red).
    */
-  void onProcessOutput(const QString &output, bool isError);
+  void onProcessOutput(const QString &output, bool isError, int pid = -1);
 
   /**
    * @brief Display a critical error dialog.
@@ -307,9 +307,11 @@ private:
   void updateGrepButtonVisibility();
   void enableGitButtons(const bool &);
 
-  void appendProcessOutput(const QString &output, bool isError);
+  void appendProcessOutput(const QString &output, bool isError, int pid = -1);
   void updateProcessOutputVisibility();
   void limitOutputLines();
+
+  auto getProcessName(int pid) -> QString;
 };
 
 #endif // SRC_MAINWINDOW_H_

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -338,42 +338,42 @@
     </item>
    </layout>
   </widget>
-<widget class="QWidget" name="processOutputWidget">
-    <layout class="QHBoxLayout" name="processOutputLayout">
-      <item>
-       <widget class="QToolButton" name="clearOutputButton">
-        <property name="toolTip">
-         <string>Clear output</string>
-        </property>
-        <property name="text">
-         <string>Clear</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QTextEdit" name="processOutputEdit">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>80</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>150</height>
-         </size>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-        <property name="acceptRichText">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-   </widget>
+  <widget class="QWidget" name="processOutputWidget">
+   <layout class="QHBoxLayout" name="processOutputLayout">
+    <item>
+     <widget class="QToolButton" name="clearOutputButton">
+      <property name="toolTip">
+       <string>Clear output</string>
+      </property>
+      <property name="text">
+       <string>Clear</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QTextEdit" name="processOutputEdit">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>80</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>150</height>
+       </size>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+      <property name="acceptRichText">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="contextMenuPolicy">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -338,6 +338,42 @@
     </item>
    </layout>
   </widget>
+<widget class="QWidget" name="processOutputWidget">
+    <layout class="QHBoxLayout" name="processOutputLayout">
+      <item>
+       <widget class="QToolButton" name="clearOutputButton">
+        <property name="toolTip">
+         <string>Clear output</string>
+        </property>
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTextEdit" name="processOutputEdit">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>80</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>150</height>
+         </size>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+        <property name="acceptRichText">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="contextMenuPolicy">

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -712,6 +712,17 @@ auto Pass::formatInsertError(const QString &friendly, const QString &err)
  */
 void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
                                      const QString &err) {
+  /**
+   * @brief Filter sensitive commands to prevent password leakage.
+   *
+   * Sensitive commands (PASS_SHOW, etc.) output plaintext passwords or
+   * searchable content that should not be exposed to any UI listener.
+   *
+   * Using a default branch: if new PASS_* values are added, they
+   * default to NOT leaking (safe by default). Making this
+   * exhaustive would require updating here for every new
+   * command and risk silent password leakage if forgotten.
+   */
   switch (pid) {
   case PASS_SHOW:
   case PASS_OTP_GENERATE:

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -713,7 +713,7 @@ auto Pass::formatInsertError(const QString &friendly, const QString &err)
 void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
                                      const QString &err) {
   emit finishedAny(out, err);
-  emit finishedAnyWithPid(out, err, static_cast<int>(pid));
+  emit finishedAnyWithPid(out, err, pid);
 
   switch (pid) {
   case GIT_INIT:

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -712,8 +712,17 @@ auto Pass::formatInsertError(const QString &friendly, const QString &err)
  */
 void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
                                      const QString &err) {
-  emit finishedAny(out, err);
-  emit finishedAnyWithPid(out, err, pid);
+  switch (pid) {
+  case PASS_SHOW:
+  case PASS_OTP_GENERATE:
+  case PASS_GREP:
+  case PASS_INSERT:
+    break;
+  default:
+    emit finishedAny(out, err);
+    emit finishedAnyWithPid(out, err, pid);
+    break;
+  }
 
   switch (pid) {
   case GIT_INIT:

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -712,6 +712,9 @@ auto Pass::formatInsertError(const QString &friendly, const QString &err)
  */
 void Pass::emitProcessFinishedSignal(PROCESS pid, const QString &out,
                                      const QString &err) {
+  emit finishedAny(out, err);
+  emit finishedAnyWithPid(out, err, static_cast<int>(pid));
+
   switch (pid) {
   case GIT_INIT:
     emit finishedGitInit(out, err);

--- a/src/pass.h
+++ b/src/pass.h
@@ -329,7 +329,8 @@ signals:
    * @param err Standard error from the process.
    * @param pid Process identifier for filtering/display.
    */
-  void finishedAnyWithPid(const QString &out, const QString &err, int pid);
+  void finishedAnyWithPid(const QString &out, const QString &err,
+                          Enums::PROCESS pid);
   /**
    * @brief Emitted when Git init finishes.
    * @param out Standard output.

--- a/src/pass.h
+++ b/src/pass.h
@@ -324,6 +324,13 @@ signals:
    */
   void finishedAny(const QString &out, const QString &err);
   /**
+   * @brief Emitted when any operation finishes with process ID for filtering.
+   * @param out Standard output from the process.
+   * @param err Standard error from the process.
+   * @param pid Process identifier for filtering/display.
+   */
+  void finishedAnyWithPid(const QString &out, const QString &err, int pid);
+  /**
    * @brief Emitted when Git init finishes.
    * @param out Standard output.
    * @param err Standard error.

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -885,6 +885,16 @@ void QtPassSettings::setTemplateAllFields(const bool &templateAllFields) {
                           templateAllFields);
 }
 
+auto QtPassSettings::isShowProcessOutput(const bool &defaultValue) -> bool {
+  return getInstance()
+      ->value(SettingsConstants::showProcessOutput, defaultValue)
+      .toBool();
+}
+void QtPassSettings::setShowProcessOutput(const bool &showProcessOutput) {
+  getInstance()->setValue(SettingsConstants::showProcessOutput,
+                          showProcessOutput);
+}
+
 auto QtPassSettings::getRealPass() -> RealPass * {
   if (realPass.isNull()) {
     realPass.reset(new RealPass());

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -871,6 +871,18 @@ public:
   static void setTemplateAllFields(const bool &templateAllFields);
 
   /**
+   * @brief Get showProcessOutput setting.
+   * @param defaultValue Default value if not set.
+   * @return Whether process output should be displayed.
+   */
+  static auto isShowProcessOutput(const bool &defaultValue = false) -> bool;
+  /**
+   * @brief Save showProcessOutput setting.
+   * @param showProcessOutput Whether to show process output.
+   */
+  static void setShowProcessOutput(const bool &showProcessOutput);
+
+  /**
    * @brief Get all configured profiles.
    * @return Profile map keyed by profile name.
    */

--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -83,4 +83,5 @@ const QString SettingsConstants::autoPush = "autoPush";
 const QString SettingsConstants::passTemplate = "passTemplate";
 const QString SettingsConstants::useTemplate = "useTemplate";
 const QString SettingsConstants::templateAllFields = "templateAllFields";
+const QString SettingsConstants::showProcessOutput = "showProcessOutput";
 const QString SettingsConstants::clipBoardType = "clipBoardType";

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -75,6 +75,7 @@ public:
   static const QString passTemplate;
   static const QString useTemplate;
   static const QString templateAllFields;
+  static const QString showProcessOutput;
   static const QString clipBoardType;
 
 private:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new "Process Output" area to the main window, providing users with real-time feedback on commands executed by QtPass.

Key changes include:
-   **Process Output Display:** A new collapsible widget is added to the main window to display the standard output and error messages from `pass` commands. Error messages are highlighted in red.
-   **Configurable Visibility:** A new "Show process output" option is added to the configuration dialog, allowing users to enable or disable the visibility of this output area.
-   **Dynamic Visibility:** The output area automatically becomes visible when new output is generated, if the setting is enabled.
-   **Auto-scrolling:** The output area automatically scrolls to the latest output, but pauses auto-scrolling if the user manually scrolls up.
-   **Output Limiting:** The output area retains a maximum of 1000 lines to prevent excessive memory usage.
-   **Clear Functionality:** A "Clear" button is included to easily clear the displayed output.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New process output panel showing stdout/stderr (stderr highlighted); per-line numbering and optional command-name prefixes.
  * Auto-scroll that pauses while the user scrolls and resumes at the bottom; panel auto-opens when a command runs.
  * Clear button to reset output and counters.
  * Persistent "Show process output" setting with a Settings checkbox.
  * Session output capped and filtered to exclude sensitive commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->