### PR TITLE
docs: clarify legacy key name in comment

### DIFF
--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -72,7 +72,8 @@ const QString SettingsConstants::lessRandom = "lessRandom";
 const QString SettingsConstants::useSymbols = "useSymbols";
 const QString SettingsConstants::passwordLength = "passwordLength";
 const QString SettingsConstants::passwordCharsSelection =
-    "passwordCharsselection"; // stored key kept lowercase for backward compat
+    "passwordCharsselection"; // actual persisted legacy key (lowercase 's');
+// keep unchanged for backward compatibility with existing user settings.
 const QString SettingsConstants::passwordChars = "passwordChars";
 const QString SettingsConstants::useTrayIcon = "useTrayIcon";
 const QString SettingsConstants::hideOnClose = "hideOnClose";


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the comment for the `passwordCharsSelection` setting constant to clarify that its lowercase 's' is due to it being an actual persisted legacy key. The comment now explicitly states that the key name must remain unchanged to maintain backward compatibility with existing user settings.
<!-- kody-pr-summary:end -->