### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -72,7 +72,7 @@ const QString SettingsConstants::lessRandom = "lessRandom";
 const QString SettingsConstants::useSymbols = "useSymbols";
 const QString SettingsConstants::passwordLength = "passwordLength";
 const QString SettingsConstants::passwordCharsSelection =
-    "passwordCharsselection"; // stored key kept lowercase for backward compat
+    "passwordCharsselection"; // NOTE: actual persisted legacy key (lowercase 's' in "selection"); keep unchanged for backward compatibility with existing user settings.
 const QString SettingsConstants::passwordChars = "passwordChars";
 const QString SettingsConstants::useTrayIcon = "useTrayIcon";
 const QString SettingsConstants::hideOnClose = "hideOnClose";


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the comment for the `passwordCharsSelection` constant in `SettingsConstants` to clarify that its lowercase 's' in "selection" is the actual persisted legacy key and must remain unchanged for backward compatibility with existing user settings. This change improves code documentation without altering functionality.
<!-- kody-pr-summary:end -->