### PR TITLE
docs: clarify squash merge preference and force push guidance

### DIFF
--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -84,12 +84,36 @@ git push -u origin new-branch-name
 
 ## Merging PRs
 
-```bash
-# Merge via GitHub CLI (if you have admin rights)
-gh pr merge <PR_NUMBER> --admin --merge
+**Preferred: Squash merge for long PR threads**
 
-# Or squash merge
+Squash merging keeps the main branch history clean and avoids cluttering it with numerous intermediate commits from review iterations.
+
+```bash
+# Squash merge via GitHub CLI
+gh pr merge <PR_NUMBER> --squash --auto --delete-branch --subject "fix: description"
+
+# Or with auto-merge (waits for CI)
 gh pr merge <PR_NUMBER> --squash --auto --delete-branch
+```
+
+**Avoid force pushing to shared branches** - Only force push to feature branches when absolutely necessary (e.g., resolving merge conflicts, cleaning up commits). Never force push to main or branches that others may be working from.
+
+**Merge strategies:**
+
+| Strategy | Use Case                                             |
+| -------- | ---------------------------------------------------- |
+| Squash   | Feature PRs with multiple review commits (preferred) |
+| Merge    | PRs where individual commits have meaningful history |
+| Rebase   | Clean, linear history (rarely used here)             |
+
+**When to use merge (not squash):**
+
+- Hotfixes that need individual commits for rollback
+- PRs with distinct, logically separate changes
+
+```bash
+# Regular merge (when needed)
+gh pr merge <PR_NUMBER> --merge --auto --delete-branch
 ```
 
 ## Commenting on Issues/PRs


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `.opencode/skills/qtpass-github/SKILL.md` documentation to provide clearer guidance on merging Pull Requests and using Git.

Key changes include:
- Explicitly stating a preference for squash merging for long PR threads to maintain a clean main branch history.
- Adding a detailed explanation of when to use squash merge versus a regular merge, including specific use cases for each strategy.
- Introducing a table summarizing different merge strategies (Squash, Merge, Rebase) and their recommended use cases.
- Providing updated GitHub CLI commands for both squash and regular merges.
- Adding clear guidance on avoiding force pushes to shared branches, especially `main`.
<!-- kody-pr-summary:end -->