### PR TITLE
docs: clarify squash merge options and recommend force-with-lease

### DIFF
--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -53,8 +53,8 @@ git remote add upstream https://github.com/IJHack/QtPass.git
 git fetch upstream
 git pull upstream main --rebase
 
-# Force push if needed
-git push -f
+# Force push if needed (safer)
+git push --force-with-lease origin <branch>
 ```
 
 This prevents "branch is out-of-date with base branch" errors.
@@ -108,7 +108,7 @@ gh pr merge <PR_NUMBER> --squash --auto --delete-branch
 
 **Avoid force pushing to shared branches**
 
-Only force push to feature branches when absolutely necessary (e.g., resolving merge conflicts, cleaning up commits). If you must force push, use `--force-with-lease` instead of `--force`:
+Only force push to feature branches when absolutely necessary (e.g., resolving merge conflicts, cleaning up commits). Prefer `--force-with-lease` over `-f` because it fails if someone else pushed to the branch, preventing accidental overwrites of others' work. Never use `-f` or `--force` on main or shared branches:
 
 ```bash
 # Safe force push (recommended)
@@ -308,8 +308,8 @@ git rebase upstream/main
 git add <resolved-files>
 git rebase --continue
 
-# Force push (since we rewrote history)
-git push -f
+# Force push (since we rewrote history; safer)
+git push --force-with-lease origin <branch>
 ```
 
 ## Fork Workflow
@@ -338,7 +338,7 @@ Note: When working with forks, use `myfork` for pushing and `upstream` for synci
 ```bash
 git checkout <branch-name>
 git pull upstream main --rebase
-git push -f
+git push --force-with-lease origin <branch-name>
 ```
 
 ### Merge Failed
@@ -474,5 +474,5 @@ act push -W .github/workflows/linter.yml -j build
 git fetch upstream
 git checkout <branch>
 git pull upstream main --rebase
-git push -f
+git push --force-with-lease origin <branch>
 ```

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -54,7 +54,7 @@ git fetch upstream
 git pull upstream main --rebase
 
 # Force push if needed (safer)
-git push --force-with-lease origin <branch>
+git push --force-with-lease <push-remote> <branch>
 ```
 
 This prevents "branch is out-of-date with base branch" errors.
@@ -112,7 +112,7 @@ Only force push to feature branches when absolutely necessary (e.g., resolving m
 
 ```bash
 # Safe force push (recommended)
-git push --force-with-lease origin <branch>
+git push --force-with-lease <push-remote> <branch>
 
 # Never use on main or shared branches
 git push --force origin main  # AVOID THIS
@@ -309,7 +309,7 @@ git add <resolved-files>
 git rebase --continue
 
 # Force push (since we rewrote history; safer)
-git push --force-with-lease origin <branch>
+git push --force-with-lease <push-remote> <branch>
 ```
 
 ## Fork Workflow
@@ -338,7 +338,7 @@ Note: When working with forks, use `myfork` for pushing and `upstream` for synci
 ```bash
 git checkout <branch-name>
 git pull upstream main --rebase
-git push --force-with-lease origin <branch-name>
+git push --force-with-lease <push-remote> <branch-name>
 ```
 
 ### Merge Failed
@@ -474,5 +474,5 @@ act push -W .github/workflows/linter.yml -j build
 git fetch upstream
 git checkout <branch>
 git pull upstream main --rebase
-git push --force-with-lease origin <branch>
+git push --force-with-lease <push-remote> <branch>
 ```

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -88,15 +88,37 @@ git push -u origin new-branch-name
 
 Squash merging keeps the main branch history clean and avoids cluttering it with numerous intermediate commits from review iterations.
 
-```bash
-# Squash merge via GitHub CLI
-gh pr merge <PR_NUMBER> --squash --auto --delete-branch --subject "fix: description"
+### Squash merge now via GitHub CLI
 
-# Or with auto-merge (waits for CI)
+When all CI checks pass and you want to merge immediately:
+
+```bash
+# Squash merge immediately (all checks passed)
+gh pr merge <PR_NUMBER> --squash --delete-branch --subject "fix: description"
+```
+
+### Schedule squash merge (waits for CI)
+
+When you want to wait for CI to pass before merging:
+
+```bash
+# Squash merge that waits for CI checks to pass
 gh pr merge <PR_NUMBER> --squash --auto --delete-branch
 ```
 
-**Avoid force pushing to shared branches** - Only force push to feature branches when absolutely necessary (e.g., resolving merge conflicts, cleaning up commits). Never force push to main or branches that others may be working from.
+**Avoid force pushing to shared branches**
+
+Only force push to feature branches when absolutely necessary (e.g., resolving merge conflicts, cleaning up commits). If you must force push, use `--force-with-lease` instead of `--force`:
+
+```bash
+# Safe force push (recommended)
+git push --force-with-lease origin <branch>
+
+# Never use on main or shared branches
+git push --force origin main  # AVOID THIS
+```
+
+Never force push to main or branches that others may be working from.
 
 **Merge strategies:**
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
The pull request updates the documentation for GitHub CLI usage and Git best practices.

Specifically, it:
*   Clarifies the GitHub CLI squash merge options, distinguishing between merging immediately and scheduling a merge that waits for CI checks to pass.
*   Recommends using `git push --force-with-lease` for safer force pushes on feature branches when necessary, providing a code example.
*   Explicitly warns against using `git push --force` on `main` or other shared branches.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Git workflow guidance to recommend safer force-push practices and updated examples
  * Strengthened branch-protection guidance with explicit recommended vs. forbidden push examples
  * Clarified squash-merge instructions by splitting GitHub CLI flows into immediate and scheduled merge paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->