### PR TITLE
docs: update github skill for opencode/qtpass

### DIFF
--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -340,7 +340,7 @@ When PR shows "All comments must be resolved" but you've fixed the issues:
 **1. Identify unresolved threads via GraphQL:**
 
 ```bash
-gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: N) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
+gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: <PR_NUMBER>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
 ```
 
 **2. Resolve threads programmatically:**

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -340,7 +340,7 @@ When PR shows "All comments must be resolved" but you've fixed the issues:
 **1. Identify unresolved threads via GraphQL:**
 
 ```bash
-gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: <PR_NUMBER>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
+gh api graphql -f query='{ repository(owner: "<OWNER>", name: "<REPO>") { pullRequest(number: <PR_NUMBER>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
 ```
 
 **2. Resolve threads programmatically:**

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -355,7 +355,7 @@ gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$THR
 
 ```bash
 # Submit a COMMENT review (not APPROVE if it's your own PR)
-gh api "repos/OWNER/REPO/pulls/N/reviews" -X POST -f "body"="All issues addressed in recent commits" -f "event"="COMMENT"
+gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/reviews" -X POST -f "body"="All issues addressed in recent commits" -f "event"="COMMENT"
 ```
 
 **4. Common causes:**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the `SKILL.md` file to improve the clarity of example `gh api` commands. Generic placeholders like `OWNER`, `REPO`, and `N` have been replaced with more explicit `<OWNER>`, `<REPO>`, and `<PR_NUMBER>` to guide users on how to resolve GitHub review threads.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized GitHub API examples to use parameterized pull request numbers (e.g., <PR_NUMBER>) and explicit owner/repo placeholders for clarity.
  * Updated REST and GraphQL example calls to reflect the parameterized endpoints and queries for submitting clearing review comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->