### PR TITLE
fix: code quality findings from AI analysis

### DIFF
--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -377,7 +377,7 @@ gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$THR
 
 ```bash
 # Submit a COMMENT review (not APPROVE if it's your own PR)
-gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/reviews" -X POST -f "body"="All issues addressed in recent commits" -f "event"="COMMENT"
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/reviews" -X POST -f "body"="All issues addressed in recent commits" -f "event"="COMMENT"
 ```
 
 **4. Common causes:**

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -199,7 +199,7 @@ gh pr view <PR_NUMBER> --json comments
 gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments
 
 # Get all issue comments via API
-gh api repos/<owner>/<repo>/issues/<ISSUE_NUMBER>/comments
+gh api repos/IJHack/QtPass/issues/<ISSUE_NUMBER>/comments
 ```
 
 ## Answering User Questions

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -362,7 +362,7 @@ When PR shows "All comments must be resolved" but you've fixed the issues:
 **1. Identify unresolved threads via GraphQL:**
 
 ```bash
-gh api graphql -f query='{ repository(owner: "<OWNER>", name: "<REPO>") { pullRequest(number: <PR_NUMBER>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
+gh api graphql -f query='{ repository(owner: "<owner>", name: "<repo>") { pullRequest(number: <PR_NUMBER>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
 ```
 
 **2. Resolve threads programmatically:**

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -199,7 +199,7 @@ gh pr view <PR_NUMBER> --json comments
 gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments
 
 # Get all issue comments via API
-gh api repos/IJHack/QtPass/issues/<ISSUE_NUMBER>/comments
+gh api repos/<owner>/<repo>/issues/<ISSUE_NUMBER>/comments
 ```
 
 ## Answering User Questions
@@ -362,7 +362,7 @@ When PR shows "All comments must be resolved" but you've fixed the issues:
 **1. Identify unresolved threads via GraphQL:**
 
 ```bash
-gh api graphql -f query='{ repository(owner: "<owner>", name: "<repo>") { pullRequest(number: <PR_NUMBER>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
+gh api graphql -f query='{ repository(owner: "<owner>", name: "<repo>") { pullRequest(number: <pr_number>) { id reviewThreads(first: 20) { nodes { id isResolved } } } } }' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | "\(.id) \(.isResolved)"'
 ```
 
 **2. Resolve threads programmatically:**

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -19,7 +19,7 @@ gh pr checks <PR_NUMBER>
 gh pr view <PR_NUMBER> --json state,mergeable
 
 # View PR comments
-gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments
+gh api repos/IJHack/QtPass/pulls/<PR_NUMBER>/comments
 ```
 
 ## Creating Branches


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the `.opencode/skills/qtpass-github/SKILL.md` file to improve the clarity and consistency of API command examples.

Specifically, this pull request:
- Hardcodes the repository `IJHack/QtPass` in `gh api` commands for viewing PR and issue comments, making the examples directly usable for the target repository.
- Standardizes the casing of placeholders (e.g., `<OWNER>` to `<owner>`, `<REPO>` to `<repo>`, `<PR_NUMBER>` to `<pr_number>`) in GraphQL and REST API examples for resolving review threads and submitting reviews.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub CLI/API examples to use an explicit repository reference for PR comments and standardized parameter placeholders to lowercase for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->