### PR TITLE
docs: clarify legacy clipBoardType key for backward compat

### DIFF
--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -85,4 +85,7 @@ const QString SettingsConstants::passTemplate = "passTemplate";
 const QString SettingsConstants::useTemplate = "useTemplate";
 const QString SettingsConstants::templateAllFields = "templateAllFields";
 const QString SettingsConstants::showProcessOutput = "showProcessOutput";
+// actual persisted legacy key (capital B, lowercase t); keep unchanged for
+// backward compatibility with existing user settings - QtPassSettings reads
+// this key
 const QString SettingsConstants::clipBoardType = "clipBoardType";


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Added a comment to `src/settingsconstants.cpp` to clarify the purpose and specific casing of the `clipBoardType` setting key. This clarification emphasizes that the key's casing (`clipBoardType` with capital 'B' and 'T') is maintained for backward compatibility with existing user settings, as it represents the actual persisted legacy key read by `QtPassSettings`.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that a legacy persisted settings key (including its exact casing) must remain unchanged to preserve backward compatibility with existing settings.
  * Noted that this change is documentation-only and does not alter any runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->