### PR TITLE
fix: code quality findings from AI analysis

### DIFF
--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -47,7 +47,7 @@ gh pr create --base main --title "Fix" --body "Fixes #issue"
 **Before pushing or merging, always update with latest main:**
 
 ```bash
-# (If not already set) add upstream remote pointing to main repository
+# If upstream remote is not set, add it (one-time setup):
 git remote add upstream https://github.com/IJHack/QtPass.git
 # Fetch and rebase on main
 git fetch upstream

--- a/.opencode/skills/qtpass-github/SKILL.md
+++ b/.opencode/skills/qtpass-github/SKILL.md
@@ -369,7 +369,8 @@ gh api graphql -f query='{ repository(owner: "<owner>", name: "<repo>") { pullRe
 
 ```bash
 # Get thread IDs and resolve them
-THREAD_ID="PRRT_xxx"
+# Use an unresolved thread ID from step 1 output (format typically starts with PRRT_)
+THREAD_ID="PRRT_FROM_STEP_1"
 gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }"
 ```
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Documentation improvements for `.opencode/skills/qtpass-github/SKILL.md`:

*   Clarified the comment regarding adding an upstream remote, specifying it as a "one-time setup."
*   Enhanced instructions for resolving GitHub pull request review threads by adding a comment explaining how to obtain the `THREAD_ID` from previous step output and updating the placeholder value.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for syncing with the main branch, including one-time remote setup guidance
  * Improved thread resolution examples with concrete reference values for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->