### PR TITLE
chore: post-merge cleanups across tests and SettingsConstants

### DIFF
--- a/src/settingsconstants.cpp
+++ b/src/settingsconstants.cpp
@@ -8,8 +8,6 @@
  * This class contains static const QString members that define the keys
  * used for storing and retrieving application settings.
  */
-SettingsConstants::SettingsConstants() = default;
-
 const QString SettingsConstants::version = "version";
 const QString SettingsConstants::groupMainwindow = "mainwindow";
 const QString SettingsConstants::geometry =

--- a/src/settingsconstants.h
+++ b/src/settingsconstants.h
@@ -78,8 +78,8 @@ public:
   static const QString showProcessOutput;
   static const QString clipBoardType;
 
-private:
-  explicit SettingsConstants();
+  // Static-only namespace-like class — instantiation is meaningless.
+  SettingsConstants() = delete;
 };
 
 #endif // SRC_SETTINGSCONSTANTS_H_

--- a/tests/auto/exportpublickeydialog/exportpublickeydialog.pro
+++ b/tests/auto/exportpublickeydialog/exportpublickeydialog.pro
@@ -15,5 +15,5 @@ win32 {
     # Keep linker command size manageable on Windows toolchains.
     # 24 is a conservative cap chosen to stay below Windows linker
     # command-line/object-list limits across supported toolchains.
-    QMAKE_LINK_OBJECT_MAX=24
+    QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/exportpublickeydialog/tst_exportpublickeydialog.cpp
+++ b/tests/auto/exportpublickeydialog/tst_exportpublickeydialog.cpp
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QScopeGuard>
 #include <QtTest>
 
 #include "../../../src/exportpublickeydialog.h"
@@ -77,13 +78,16 @@ void tst_exportpublickeydialog::copyButtonCopiesToClipboardAndRelabels() {
   // perform a round-trip test to verify clipboard capability before proceeding.
   QClipboard *clipboard = QApplication::clipboard();
   const QString originalClipboard = clipboard->text();
+  // RAII restore so the user's clipboard is reset on every exit path
+  // (early QSKIP, normal completion, or QVERIFY/QCOMPARE failure).
+  const auto restoreClipboard = qScopeGuard([clipboard, originalClipboard]() {
+    clipboard->setText(originalClipboard);
+  });
   const QString probeString = QStringLiteral("__qtpass_clipboard_probe__");
   clipboard->setText(probeString);
   if (clipboard->text() != probeString) {
-    clipboard->setText(originalClipboard); // restore
     QSKIP("Clipboard is not functional on this platform");
   }
-  clipboard->setText(originalClipboard); // restore
 
   const QString armored = QStringLiteral("clipboard-test-payload");
   ExportPublicKeyDialog dialog(QStringLiteral("DEADBEEF"), armored);
@@ -92,10 +96,7 @@ void tst_exportpublickeydialog::copyButtonCopiesToClipboardAndRelabels() {
   const QString originalText = button->text();
   QVERIFY(!originalText.isEmpty());
 
-  // Trigger the click handler directly to avoid relying on event delivery
-  // and the platform's window manager.
-  QMetaObject::invokeMethod(&dialog, "on_copyButton_clicked",
-                            Qt::DirectConnection);
+  button->click();
 
   QCOMPARE(clipboard->text(), armored);
   QCOMPARE(button->text(), QStringLiteral("Copied!"));

--- a/tests/auto/filecontent/filecontent.pro
+++ b/tests/auto/filecontent/filecontent.pro
@@ -14,5 +14,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
     RC_FILE = ../../../windows.rc
-    QMAKE_LINK_OBJECT_MAX=24
+    QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/gpgkeystate/gpgkeystate.pro
+++ b/tests/auto/gpgkeystate/gpgkeystate.pro
@@ -15,5 +15,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
     RC_FILE = ../../../windows.rc
-    QMAKE_LINK_OBJECT_MAX=24
+    QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/importkeydialog/importkeydialog.pro
+++ b/tests/auto/importkeydialog/importkeydialog.pro
@@ -14,5 +14,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
     RC_FILE = ../../../windows.rc
-    QMAKE_LINK_OBJECT_MAX=24
+    QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/importkeydialog/tst_importkeydialog.cpp
+++ b/tests/auto/importkeydialog/tst_importkeydialog.cpp
@@ -4,6 +4,7 @@
 #include <QClipboard>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QScopeGuard>
 #include <QtTest>
 
 #include "../../../src/importkeydialog.h"
@@ -270,31 +271,33 @@ void tst_importkeydialog::pasteButtonSetsTextFromClipboard() {
   // Verify clipboard round-trip capability before proceeding.
   QClipboard *clipboard = QApplication::clipboard();
   const QString originalClipboard = clipboard->text();
+  // RAII restore so the user's clipboard is reset on every exit path
+  // (early QSKIP, normal completion, or QVERIFY/QCOMPARE failure).
+  const auto restoreClipboard = qScopeGuard([clipboard, originalClipboard]() {
+    clipboard->setText(originalClipboard);
+  });
   const QString probe = QStringLiteral("__qtpass_clipboard_probe__");
   clipboard->setText(probe);
   if (clipboard->text() != probe) {
-    clipboard->setText(originalClipboard);
     QSKIP("Clipboard is not functional on this platform");
   }
-  clipboard->setText(originalClipboard);
 
   ImportKeyDialog dialog;
   auto *edit =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("inputTextEdit"));
   QVERIFY(edit != nullptr);
+  auto *pasteButton =
+      dialog.findChild<QPushButton *>(QStringLiteral("pasteButton"));
+  QVERIFY(pasteButton != nullptr);
 
   const QString payload =
       QStringLiteral("-----BEGIN PGP PUBLIC KEY BLOCK-----\nABC\n"
                      "-----END PGP PUBLIC KEY BLOCK-----\n");
   clipboard->setText(payload);
 
-  QMetaObject::invokeMethod(&dialog, "on_pasteButton_clicked",
-                            Qt::DirectConnection);
+  pasteButton->click();
 
   QCOMPARE(edit->toPlainText(), payload);
-
-  // Restore clipboard
-  clipboard->setText(originalClipboard);
 }
 
 QTEST_MAIN(tst_importkeydialog)

--- a/tests/auto/integration/integration.pro
+++ b/tests/auto/integration/integration.pro
@@ -14,5 +14,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
 	RC_FILE = ../../../windows.rc
-	QMAKE_LINK_OBJECT_MAX=24
+	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/model/model.pro
+++ b/tests/auto/model/model.pro
@@ -14,5 +14,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
 	RC_FILE = ../../../windows.rc     
-	QMAKE_LINK_OBJECT_MAX=24
+	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/passwordconfig/passwordconfig.pro
+++ b/tests/auto/passwordconfig/passwordconfig.pro
@@ -14,5 +14,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
 	RC_FILE = ../../../windows.rc     
-	QMAKE_LINK_OBJECT_MAX=24
+	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/settings/settings.pro
+++ b/tests/auto/settings/settings.pro
@@ -14,5 +14,5 @@ INCLUDEPATH += ../../../src
 
 win32 {
 	RC_FILE = ../../../windows.rc     
-	QMAKE_LINK_OBJECT_MAX=24
+	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/ui/ui.pro
+++ b/tests/auto/ui/ui.pro
@@ -21,7 +21,7 @@ INCLUDEPATH += ../../../src
 win32 {
   RC_FILE = ../../../windows.rc
 #	temporary workaround for QTBUG-6453
-  QMAKE_LINK_OBJECT_MAX=24
+  QMAKE_LINK_OBJECT_MAX = 24
 #	setting this may also work, but I can't find appropriate value right now
 #	QMAKE_LINK_OBJECT_SCRIPT =
 }

--- a/tests/auto/util/util.pro
+++ b/tests/auto/util/util.pro
@@ -16,7 +16,7 @@ INCLUDEPATH += ../../../src
 win32 {
 	RC_FILE = ../../../windows.rc     
 #	temporary workaround for QTBUG-6453
-	QMAKE_LINK_OBJECT_MAX=24
+	QMAKE_LINK_OBJECT_MAX = 24
 #	setting this may also work, but I can't find appropriate value right now
 #	QMAKE_LINK_OBJECT_SCRIPT = 
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactors the `SettingsConstants` class to explicitly prevent its instantiation. The constructor is now deleted, reinforcing its design as a static-only utility class intended solely for holding constant string keys for application settings. This change clarifies the class's purpose and prevents accidental or incorrect usage.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved class instantiation prevention for internal constants class.

* **Tests**
  * Enhanced test robustness with safer resource cleanup patterns and more realistic user interaction simulation.

* **Style**
  * Standardized build configuration formatting across test projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->