### PR TITLE
chore: strip trailing whitespace and dangling backslashes in test .pro

### DIFF
--- a/tests/auto/executor/executor.pro
+++ b/tests/auto/executor/executor.pro
@@ -1,6 +1,6 @@
 !include(../auto.pri) { error("Couldn't find the auto.pri file!") }
 
-SOURCES += tst_executor.cpp \
+SOURCES += tst_executor.cpp
 
 LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
 clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"

--- a/tests/auto/integration/integration.pro
+++ b/tests/auto/integration/integration.pro
@@ -1,6 +1,6 @@
 !include(../auto.pri) { error("Couldn't find the auto.pri file!") }
 
-SOURCES += tst_integration.cpp \
+SOURCES += tst_integration.cpp
 
 LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
 clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"

--- a/tests/auto/model/model.pro
+++ b/tests/auto/model/model.pro
@@ -13,6 +13,6 @@ VPATH += ../../../src
 INCLUDEPATH += ../../../src
 
 win32 {
-	RC_FILE = ../../../windows.rc     
+	RC_FILE = ../../../windows.rc
 	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/passwordconfig/passwordconfig.pro
+++ b/tests/auto/passwordconfig/passwordconfig.pro
@@ -1,6 +1,6 @@
 !include(../auto.pri) { error("Couldn't find the auto.pri file!") }
 
-SOURCES += tst_passwordconfig.cpp \
+SOURCES += tst_passwordconfig.cpp
 
 LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
 clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
@@ -13,6 +13,6 @@ VPATH += ../../../src
 INCLUDEPATH += ../../../src
 
 win32 {
-	RC_FILE = ../../../windows.rc     
+	RC_FILE = ../../../windows.rc
 	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/settings/settings.pro
+++ b/tests/auto/settings/settings.pro
@@ -1,6 +1,6 @@
 !include(../auto.pri) { error("Couldn't find the auto.pri file!") }
 
-SOURCES += tst_settings.cpp \
+SOURCES += tst_settings.cpp
 
 LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
 clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
@@ -13,6 +13,6 @@ VPATH += ../../../src
 INCLUDEPATH += ../../../src
 
 win32 {
-	RC_FILE = ../../../windows.rc     
+	RC_FILE = ../../../windows.rc
 	QMAKE_LINK_OBJECT_MAX = 24
 }

--- a/tests/auto/util/util.pro
+++ b/tests/auto/util/util.pro
@@ -1,6 +1,6 @@
 !include(../auto.pri) { error("Couldn't find the auto.pri file!") }
 
-SOURCES += tst_util.cpp \
+SOURCES += tst_util.cpp
 
 LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
 clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
@@ -14,9 +14,9 @@ VPATH += ../../../src
 INCLUDEPATH += ../../../src
 
 win32 {
-	RC_FILE = ../../../windows.rc     
+	RC_FILE = ../../../windows.rc
 #	temporary workaround for QTBUG-6453
 	QMAKE_LINK_OBJECT_MAX = 24
 #	setting this may also work, but I can't find appropriate value right now
-#	QMAKE_LINK_OBJECT_SCRIPT = 
+#	QMAKE_LINK_OBJECT_SCRIPT =
 }


### PR DESCRIPTION
## Summary

Two stylistic issues flagged on \`main\` after the test-suite additions:

- **Trailing whitespace** on \`RC_FILE = ../../../windows.rc\` in \`model.pro\`, \`passwordconfig.pro\`, \`settings.pro\`, \`util.pro\`, plus a commented-out line in \`util.pro\`. Stripped every line.
- **Dangling backslash continuation** on \`SOURCES += tst_<name>.cpp \\\` in \`executor.pro\`, \`integration.pro\`, \`passwordconfig.pro\`, \`settings.pro\`, \`util.pro\`. The next line was blank, so the backslash continued nothing. Removed the backslash; preserved the blank line for visual separation from the \`LIBS\` block below.

No behavioural change — qmake parses the same target list either way.

## Test plan

- [x] \`make distclean && qmake6 && make -j4\` — 0 warnings / 0 errors
- [x] \`make check\` — 12/12 suites green (106+46+19+107+7+21+8+16+15+33+21/1+19)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized build configuration formatting across test project files by removing unnecessary line continuations and trailing whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->