### PR TITLE
fix: don't schedule initial focus pulse before init() completes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -161,14 +161,21 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 
   setUiElementsEnabled(true);
 
-  QTimer::singleShot(10, this, SLOT(focusInput()));
-
   ui->lineEdit->setText(searchText);
 
   if (!m_qtPass->init()) {
     // no working config so this should just quit
     QApplication::quit();
+    return;
   }
+
+  // Schedule the initial focus pulse only after init() has returned. init()
+  // can run a nested event loop (e.g. ConfigDialog::wizard for first-run
+  // setup), and a timer scheduled before that loop would fire focusInput()
+  // against a not-yet-shown window — QLineEdit::selectAll then crashes
+  // inside Qt because the widget hasn't been parented into a visible
+  // top-level yet.
+  QTimer::singleShot(10, this, SLOT(focusInput()));
 }
 
 MainWindow::~MainWindow() { delete m_qtPass; }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes a potential crash during the application's initial setup by ensuring that the `focusInput()` slot is scheduled only after the `init()` method has completed.

Previously, the timer to call `focusInput()` was set before `m_qtPass->init()`. If `init()` triggered a nested event loop (e.g., for a first-run configuration wizard), the `focusInput()` timer could fire prematurely. This would attempt to interact with the `QLineEdit` (specifically `selectAll()`) when the widget was not yet fully initialized or parented into a visible top-level window, leading to a crash within Qt.

By moving the `QTimer::singleShot` call to after `init()` returns, the application guarantees that the input field is focused and its content selected only when the main window and its widgets are properly set up and ready for user interaction.
<!-- kody-pr-summary:end -->