### PR TITLE
fix: null check in focusInput to prevent segfault

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -187,6 +187,9 @@ MainWindow::~MainWindow() { delete m_qtPass; }
  * compiled with SINGLE_APP=1 (default).
  */
 void MainWindow::focusInput() {
+  if (!ui->lineEdit || !ui->lineEdit->isVisible()) {
+    return;
+  }
   ui->lineEdit->selectAll();
   ui->lineEdit->setFocus();
 }
@@ -1045,6 +1048,8 @@ void MainWindow::onUsers() {
  * @param message
  */
 void MainWindow::messageAvailable(const QString &message) {
+  show();
+  raise();
   if (message.isEmpty()) {
     focusInput();
   } else {
@@ -1052,8 +1057,6 @@ void MainWindow::messageAvailable(const QString &message) {
     ui->lineEdit->setText(message);
     on_lineEdit_returnPressed();
   }
-  show();
-  raise();
 }
 
 /**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds a null check and an `isEnabled()` check to the `MainWindow::focusInput()` function. This prevents a potential segfault (segmentation fault) that could occur if `ui->lineEdit` is null or disabled when the function attempts to select all text or set focus on the line edit.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented attempts to focus the input when it is missing or hidden, avoiding unexpected focus behavior.
  * Ensure the window is shown and raised before updating content and running search/focus logic, improving reliability when new messages arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->