### PR TITLE
Fix: add ui null check in focusInput to prevent segfault

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -187,7 +187,7 @@ MainWindow::~MainWindow() { delete m_qtPass; }
  * compiled with SINGLE_APP=1 (default).
  */
 void MainWindow::focusInput() {
-  if (!ui->lineEdit || !ui->lineEdit->isVisible()) {
+  if (!ui || !ui->lineEdit || !ui->lineEdit->isVisible()) {
     return;
   }
   ui->lineEdit->selectAll();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds a null check for the `ui` pointer within the `MainWindow::focusInput()` function. This prevents a potential segmentation fault that could occur if `focusInput()` is called when the `ui` object itself is null, ensuring more robust handling of UI component access.
<!-- kody-pr-summary:end -->