### PR TITLE
fix: resolve focusInput's QLineEdit through findChild to survive widget rebuild

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,6 +29,7 @@
 #include <QFileInfo>
 #include <QInputDialog>
 #include <QLabel>
+#include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
 #include <QScrollBar>
@@ -169,13 +170,13 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
     return;
   }
 
-  // Schedule the initial focus pulse only after init() has returned. init()
-  // can run a nested event loop (e.g. ConfigDialog::wizard for first-run
-  // setup), and a timer scheduled before that loop would fire focusInput()
-  // against a not-yet-shown window — QLineEdit::selectAll then crashes
-  // inside Qt because the widget hasn't been parented into a visible
-  // top-level yet.
-  QTimer::singleShot(10, this, SLOT(focusInput()));
+  // Initial focus is handled in showEvent() once the window is actually
+  // mapped. Scheduling it here via a 10 ms QTimer was racy: if the timer
+  // fires while the window has not yet been realised — e.g. an
+  // ActivationChange queued by main()'s `activateWindow()` call before
+  // `show()`, or a nested QDialog::exec() inside init() — the
+  // QLineEdit's internal text engine hasn't been wired up and
+  // selectAll() segfaults inside Qt (see #1187, #1188).
 }
 
 MainWindow::~MainWindow() { delete m_qtPass; }
@@ -187,11 +188,30 @@ MainWindow::~MainWindow() { delete m_qtPass; }
  * compiled with SINGLE_APP=1 (default).
  */
 void MainWindow::focusInput() {
-  if (!ui || !ui->lineEdit || !ui->lineEdit->isVisible()) {
+  // Resolve the QLineEdit through the live widget tree rather than the
+  // cached `ui->lineEdit` pointer.
+  //
+  // On a fresh-config first launch the constructor calls
+  // `m_qtPass->init()` → `MainWindow::config()`, and `config()`'s
+  // `applyWindowFlagsSettings()` does `setWindowFlags(...)` + `show()`
+  // on the main window. `setWindowFlags` on a top-level widget rebuilds
+  // the native window via `setParent(nullptr, flags)`; under Qt 6.11
+  // we observed the QLineEdit attached to the centralWidget gets
+  // destroyed in that rebuild while `ui->lineEdit` still holds its old
+  // address — leading to a SIGSEGV inside `QWidget::testAttribute`
+  // (called from `QLineEdit::isVisible` / `selectAll`). `findChild<>()`
+  // walks the current hierarchy and returns null cleanly when the
+  // widget is gone, so `focusInput` becomes a safe no-op instead of a
+  // use-after-free.
+  if (!isVisible()) {
     return;
   }
-  ui->lineEdit->selectAll();
-  ui->lineEdit->setFocus();
+  QLineEdit *lineEdit = findChild<QLineEdit *>(QStringLiteral("lineEdit"));
+  if (lineEdit == nullptr || !lineEdit->isVisible()) {
+    return;
+  }
+  lineEdit->selectAll();
+  lineEdit->setFocus();
 }
 
 /**
@@ -200,11 +220,36 @@ void MainWindow::focusInput() {
  */
 void MainWindow::changeEvent(QEvent *event) {
   QWidget::changeEvent(event);
-  if (event->type() == QEvent::ActivationChange) {
-    if (isActiveWindow()) {
-      focusInput();
-    }
+  if (event->type() == QEvent::ActivationChange && isActiveWindow() &&
+      isVisible()) {
+    // Defer one event-loop tick so the synchronous activation dispatch
+    // chain (`QApplicationPrivate::setActiveWindow` → `notify_helper`)
+    // unwinds before we touch widget state — calling `focusInput()`
+    // inline from this stack has segfaulted in past iterations because
+    // mid-rebuild ui state isn't fully wired up yet.
+    QMetaObject::invokeMethod(this, &MainWindow::focusInput,
+                              Qt::QueuedConnection);
   }
+}
+
+/**
+ * @brief First-show hook: run the initial focusInput() pulse once the
+ *        window is actually mapped. The widget's internal data is fully
+ *        initialised by this point, so QLineEdit::selectAll() is safe.
+ * @param event Show event passed to the base class.
+ */
+void MainWindow::showEvent(QShowEvent *event) {
+  QMainWindow::showEvent(event);
+  if (m_initialShowDone) {
+    return;
+  }
+  m_initialShowDone = true;
+  // Defer one event loop tick so the X11/Wayland map round-trip can
+  // complete before we read widget visibility. Calling focusInput()
+  // directly here was crashing inside QWidget::testAttribute on first
+  // run.
+  QMetaObject::invokeMethod(this, &MainWindow::focusInput,
+                            Qt::QueuedConnection);
 }
 
 /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -129,6 +129,12 @@ protected:
    */
   void changeEvent(QEvent *event) override;
   /**
+   * @brief First-show hook used to focus the search input once the window
+   *        is actually mapped (avoids races with timers fired before show).
+   * @param event The show event.
+   */
+  void showEvent(QShowEvent *event) override;
+  /**
    * @brief Filter events from watched objects.
    * @param obj The object that received the event.
    * @param event The event to filter.
@@ -270,6 +276,7 @@ private:
   bool m_grepMode = false;
   bool m_grepBusy = false;
   bool m_grepCancelled = false;
+  bool m_initialShowDone = false;
   bool m_autoScroll = true;
   int m_outputCounter = 0;
   static constexpr int MaxOutputLines = 1000;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refactors the logic for setting initial focus on the search input (`QLineEdit`) in the main window to prevent crashes and improve reliability, particularly during first-run setup or when window properties are changed.

Key changes include:

1.  **Delayed Initial Focus:** The initial focus on the search input is no longer scheduled immediately in the constructor via a `QTimer`. Instead, it is now handled in the `showEvent()` method, ensuring the focus operation occurs only after the window is fully mapped and its internal widgets are properly initialized, preventing race conditions and crashes (e.g., `selectAll()` on an uninitialized widget).
2.  **Robust Widget Resolution:** The `focusInput()` method now dynamically resolves the `QLineEdit` widget using `findChild<QLineEdit *>()` instead of relying on a potentially stale `ui->lineEdit` pointer. This addresses a use-after-free vulnerability where `setWindowFlags()` could cause the `QLineEdit` to be destroyed and recreated, leading to crashes when the old pointer was used.
3.  **Asynchronous Focus on Activation:** When the window becomes active (`QEvent::ActivationChange`), the `focusInput()` call is now deferred using `QMetaObject::invokeMethod` with `Qt::QueuedConnection`. This ensures that the focus operation executes in a safe state, after any synchronous activation dispatch or widget rebuild processes have completed, preventing crashes due to accessing widgets in an inconsistent state.
4.  **First-Show Guard:** A new `m_initialShowDone` flag ensures that the initial focus logic within `showEvent()` is executed only once, on the very first display of the window.
<!-- kody-pr-summary:end -->