### PR TITLE
fix: only set m_initialShowDone after focusInput actually focuses

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -212,6 +212,11 @@ void MainWindow::focusInput() {
   }
   lineEdit->selectAll();
   lineEdit->setFocus();
+  // Only mark the first-show focus pulse as done once it's actually
+  // landed; setting it eagerly in showEvent() would consume the
+  // one-shot if focusInput returned early (mid-rebuild widget state)
+  // and we'd never retry.
+  m_initialShowDone = true;
 }
 
 /**
@@ -243,11 +248,12 @@ void MainWindow::showEvent(QShowEvent *event) {
   if (m_initialShowDone) {
     return;
   }
-  m_initialShowDone = true;
-  // Defer one event loop tick so the X11/Wayland map round-trip can
-  // complete before we read widget visibility. Calling focusInput()
-  // directly here was crashing inside QWidget::testAttribute on first
-  // run.
+  // Queue the focus pulse for the next event-loop tick so the platform
+  // map round-trip and any pending widget rebuilds (e.g. setWindowFlags
+  // from the config wizard path) settle before we look up the line
+  // edit. The `m_initialShowDone` latch is set inside focusInput()
+  // *after* it actually focuses, so a transient failed lookup just
+  // re-queues on the next show rather than silently dropping.
   QMetaObject::invokeMethod(this, &MainWindow::focusInput,
                             Qt::QueuedConnection);
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactors the initial input focus logic to improve reliability when the main window is first displayed.

Previously, the `m_initialShowDone` flag was set in `showEvent()` before the `focusInput()` method was invoked. If `focusInput()` failed to set focus due to transient widget state (e.g., during window mapping or pending widget rebuilds), the `m_initialShowDone` flag would prevent any subsequent attempts to focus the input field.

This change defers setting `m_initialShowDone` until *after* `lineEdit->setFocus()` is called within `focusInput()`. This ensures that the focus operation is retried on subsequent `showEvent()` calls if the initial attempt fails, guaranteeing the input field reliably receives focus once the window and its widgets are fully ready.
<!-- kody-pr-summary:end -->