### PR TITLE
fix: build process output panel programmatically (was obscuring central UI)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -146,14 +146,14 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
             }
           });
 
-  connect(ui->processOutputEdit->verticalScrollBar(),
-          &QScrollBar::sliderPressed, this, [this]() {
-            auto *sb = ui->processOutputEdit->verticalScrollBar();
+  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::sliderPressed,
+          this, [this]() {
+            auto *sb = m_processOutputEdit->verticalScrollBar();
             m_autoScroll = sb->value() >= sb->maximum();
           });
-  connect(ui->processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
+  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
           this, [this]() {
-            auto *sb = ui->processOutputEdit->verticalScrollBar();
+            auto *sb = m_processOutputEdit->verticalScrollBar();
             m_autoScroll = sb->value() >= sb->maximum();
           });
 
@@ -304,9 +304,37 @@ void MainWindow::initStatusBar() {
   logoApp->setPixmap(logo);
   statusBar()->addPermanentWidget(logoApp);
 
-  statusBar()->addPermanentWidget(ui->processOutputWidget);
-
-  updateProcessOutputVisibility();
+  // Build the process-output panel programmatically rather than from .ui:
+  // QMainWindow's uic only places its top-level children into the
+  // centralWidget / statusBar / menuBar / toolBars / dock-widget slots.
+  // Defining processOutputWidget at that level in the .ui leaves it
+  // unplaced and obscuring centralWidget; nesting it inside centralWidget
+  // and reparenting on the fly works but leaves a residual empty grid
+  // slot below the main content. Owning the construction here keeps the
+  // widget's lifetime tied to the status bar from the start.
+  m_processOutputWidget = new QWidget(statusBar());
+  m_processOutputWidget->setObjectName(QStringLiteral("processOutputWidget"));
+  auto *outputLayout = new QHBoxLayout(m_processOutputWidget);
+  outputLayout->setObjectName(QStringLiteral("processOutputLayout"));
+  outputLayout->setContentsMargins(0, 0, 0, 0);
+  m_clearOutputButton = new QToolButton(m_processOutputWidget);
+  m_clearOutputButton->setObjectName(QStringLiteral("clearOutputButton"));
+  m_clearOutputButton->setText(tr("Clear"));
+  m_clearOutputButton->setToolTip(tr("Clear output"));
+  outputLayout->addWidget(m_clearOutputButton);
+  m_processOutputEdit = new QTextEdit(m_processOutputWidget);
+  m_processOutputEdit->setObjectName(QStringLiteral("processOutputEdit"));
+  m_processOutputEdit->setReadOnly(true);
+  m_processOutputEdit->setAcceptRichText(false);
+  m_processOutputEdit->setMinimumSize(0, 80);
+  m_processOutputEdit->setMaximumSize(QWIDGETSIZE_MAX, 150);
+  outputLayout->addWidget(m_processOutputEdit);
+  // Hide before adding so the status bar doesn't pre-allocate the panel's
+  // 80 px minimum height when the user has the option turned off.
+  m_processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
+  statusBar()->addPermanentWidget(m_processOutputWidget);
+  connect(m_clearOutputButton, &QToolButton::clicked, this,
+          &MainWindow::on_clearOutputButton_clicked);
 }
 
 auto MainWindow::getCurrentTreeViewIndex() -> QModelIndex {
@@ -533,7 +561,7 @@ void MainWindow::executeWrapperStarted() {
   setUiElementsEnabled(false);
   clearPanelTimer.stop();
   if (QtPassSettings::isShowProcessOutput()) {
-    ui->processOutputWidget->setVisible(true);
+    m_processOutputWidget->setVisible(true);
   }
 }
 
@@ -1830,7 +1858,7 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError,
 
     QColor textColor =
         isError ? QColor(Qt::red)
-                : ui->processOutputEdit->palette().color(QPalette::Text);
+                : m_processOutputEdit->palette().color(QPalette::Text);
     QString colorHex = textColor.name();
     // Apply the optional prefix per line so multi-line output stays
     // attributed to its command (e.g. all 3 lines of a `git push` show
@@ -1841,14 +1869,14 @@ void MainWindow::appendProcessOutput(const QString &output, bool isError,
         QString("<span style=\"color: %1;\">%2: %3</span>")
             .arg(colorHex, lineNumber, prefixed.toHtmlEscaped());
 
-    ui->processOutputEdit->append(coloredOutput);
+    m_processOutputEdit->append(coloredOutput);
   }
 
   limitOutputLines();
 
   if (m_autoScroll) {
-    ui->processOutputEdit->verticalScrollBar()->setValue(
-        ui->processOutputEdit->verticalScrollBar()->maximum());
+    m_processOutputEdit->verticalScrollBar()->setValue(
+        m_processOutputEdit->verticalScrollBar()->maximum());
   }
 }
 
@@ -1962,7 +1990,7 @@ auto MainWindow::isSensitiveProcess(Enums::PROCESS pid) -> bool {
  * showProcessOutput setting.
  */
 void MainWindow::updateProcessOutputVisibility() {
-  ui->processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
+  m_processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
 }
 
 /**
@@ -1972,7 +2000,7 @@ void MainWindow::updateProcessOutputVisibility() {
  * Called after each append to prevent unbounded growth.
  */
 void MainWindow::limitOutputLines() {
-  QTextDocument *doc = ui->processOutputEdit->document();
+  QTextDocument *doc = m_processOutputEdit->document();
   int excess = doc->blockCount() - MaxOutputLines;
   if (excess <= 0) {
     return;
@@ -1990,7 +2018,7 @@ void MainWindow::limitOutputLines() {
  * Clears all output, resets the line counter, and re-enables auto-scroll.
  */
 void MainWindow::on_clearOutputButton_clicked() {
-  ui->processOutputEdit->clear();
+  m_processOutputEdit->clear();
   m_outputCounter = 0;
   m_autoScroll = true;
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -28,6 +28,8 @@ class MainWindow;
 }
 
 class QDialog;
+class QTextEdit;
+class QToolButton;
 class QTreeWidgetItem;
 class QtPass;
 class TrayIcon;
@@ -280,6 +282,14 @@ private:
   bool m_autoScroll = true;
   int m_outputCounter = 0;
   static constexpr int MaxOutputLines = 1000;
+  // The process output panel lives in the status bar (created in
+  // initStatusBar()); it isn't part of the .ui because uic places its
+  // QMainWindow children in centralWidget/statusBar/etc. slots only —
+  // a sibling widget at the QMainWindow level isn't laid out and ends
+  // up obscuring the centralWidget. See #1192 for the symptom.
+  QWidget *m_processOutputWidget = nullptr;
+  QTextEdit *m_processOutputEdit = nullptr;
+  QToolButton *m_clearOutputButton = nullptr;
   QFileSystemModel model;
   StoreModel proxyModel;
   QScopedPointer<QItemSelectionModel> selectionModel;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -338,42 +338,6 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="processOutputWidget">
-   <layout class="QHBoxLayout" name="processOutputLayout">
-    <item>
-     <widget class="QToolButton" name="clearOutputButton">
-      <property name="toolTip">
-       <string>Clear output</string>
-      </property>
-      <property name="text">
-       <string>Clear</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QTextEdit" name="processOutputEdit">
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>80</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>150</height>
-       </size>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-      <property name="acceptRichText">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="contextMenuPolicy">


### PR DESCRIPTION
## Summary

Fixes the empty-centre regression introduced by #1172: \`./main/qtpass\` came up with the toolbar at top and the status bar at the bottom but a **blank middle** — no profile selector, search box, tree view, or welcome browser.

## Bug

#1172 declared \`processOutputWidget\` (along with \`clearOutputButton\` and \`processOutputEdit\`) as a **sibling** of \`centralWidget\` at the QMainWindow level in \`mainwindow.ui\`:

\`\`\`xml
<widget class=\"QMainWindow\" name=\"MainWindow\">
  <widget class=\"QWidget\" name=\"centralWidget\"> ... </widget>
  <widget class=\"QWidget\" name=\"processOutputWidget\"> ... </widget>  <!-- here -->
  <widget class=\"QStatusBar\" name=\"statusBar\"/>
  <widget class=\"QToolBar\" name=\"toolBar\"> ... </widget>
</widget>
\`\`\`

QMainWindow only recognises a fixed set of named slots for its top-level children (\`centralWidget\` / \`statusBar\` / \`menuBar\` / toolbars / dock widgets). Anything else parented at that level is created by uic but never placed in QMainWindowLayout, so it gets rendered on top of and obscures the central widget content.

Bisected against pre-#1172 (\`8e257d633\`) where the same .ui structure modulo this addition renders correctly. Even with the runtime \`statusBar()->addPermanentWidget(ui->processOutputWidget)\` call disabled, the empty centre persists — so the issue is structural in the .ui rather than in the reparent.

## Fix

Build the panel programmatically inside \`MainWindow::initStatusBar()\` and add it to the status bar from there, rather than declaring it in \`mainwindow.ui\` and reparenting at runtime. The reviewer's proposed approach: keeps the panel's lifetime tied to the status bar from the start, and avoids the alternative-fix tradeoff (placing it inside \`centralWidget\`'s grid then reparenting away leaves a residual empty grid slot below the main content).

Concretely:
- Drop the \`processOutputWidget\` / \`processOutputLayout\` / \`clearOutputButton\` / \`processOutputEdit\` block from \`mainwindow.ui\`.
- Add three private members on \`MainWindow\` — \`m_processOutputWidget\`, \`m_processOutputEdit\`, \`m_clearOutputButton\` — with forward declarations.
- In \`initStatusBar()\`, construct the QWidget + QHBoxLayout + QToolButton + QTextEdit, set the same properties (read-only / non-rich-text / 80–150 px height bounds / labels / tooltips), connect the clear button to \`on_clearOutputButton_clicked\`, and call \`statusBar()->addPermanentWidget(...)\`.
- Update every \`ui->processOutput*\` / \`ui->clearOutputButton\` reference in \`mainwindow.cpp\` to use the new \`m_*\` members.

## Test plan

- [x] **Before** (\`HEAD\` of main): \`./main/qtpass\` shows an empty centre. (Confirmed by screenshot.)
- [x] **After**: profile selector, search box, tree view, welcome browser all visible again; status bar with the lock icon still renders; process output panel hidden by default and appears in the status bar when \`Show process output\` is enabled.
- [x] \`make distclean && qmake6 && make -j4\` — 0 warnings, 0 errors.
- [x] \`make check\` — 12/12 suites green.
- [x] \`doxygen Doxyfile\` — 0 warnings.
- [x] \`clang-format --style=file --dry-run\` on \`src/mainwindow.{cpp,h}\` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured process output panel creation for improved code organization and maintainability. User-facing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->