### PR TITLE
feat: move process output panel to a QDockWidget; add scroll hysteresis (#252)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -151,24 +151,6 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
             }
           });
 
-  // Hysteresis: while the user is actively dragging the slider, don't
-  // touch m_autoScroll on every tick — a brief overshoot at maximum
-  // would silently re-arm auto-scroll without an explicit release. Only
-  // commit on slider release. Wheel/keyboard scroll never sets
-  // isSliderDown(), so they still update immediately.
-  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
-          this, [this]() {
-            auto *sb = m_processOutputEdit->verticalScrollBar();
-            if (sb->isSliderDown())
-              return;
-            m_autoScroll = sb->value() >= sb->maximum();
-          });
-  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::sliderReleased,
-          this, [this]() {
-            auto *sb = m_processOutputEdit->verticalScrollBar();
-            m_autoScroll = sb->value() >= sb->maximum();
-          });
-
   ui->lineEdit->setClearButtonEnabled(true);
   updateGrepButtonVisibility();
 
@@ -344,8 +326,6 @@ void MainWindow::initProcessOutputPanel() {
   m_processOutputEdit->setObjectName(QStringLiteral("processOutputEdit"));
   m_processOutputEdit->setReadOnly(true);
   m_processOutputEdit->setAcceptRichText(false);
-  m_processOutputEdit->setMinimumSize(0, 80);
-  m_processOutputEdit->setMaximumSize(QWIDGETSIZE_MAX, 150);
   outputLayout->addWidget(m_processOutputEdit);
 
   m_processOutputDock = new QDockWidget(tr("Process Output"), this);
@@ -355,11 +335,35 @@ void MainWindow::initProcessOutputPanel() {
   m_processOutputDock->setAllowedAreas(Qt::BottomDockWidgetArea |
                                        Qt::TopDockWidgetArea);
   m_processOutputDock->setWidget(m_processOutputWidget);
-  m_processOutputDock->setVisible(QtPassSettings::isShowProcessOutput());
   addDockWidget(Qt::BottomDockWidgetArea, m_processOutputDock);
+  // setVisible after addDockWidget so our explicit preference wins
+  // even if QMainWindow applies any cached state when the dock is
+  // attached. restoreWindow() runs before this method (it's called
+  // from the QtPass ctor, which is constructed at the top of the
+  // MainWindow ctor), so the saved layout has already been processed
+  // by the time we get here.
+  m_processOutputDock->setVisible(QtPassSettings::isShowProcessOutput());
 
   connect(m_clearOutputButton, &QToolButton::clicked, this,
           &MainWindow::on_clearOutputButton_clicked);
+
+  // Hysteresis: while the user is actively dragging the slider, don't
+  // touch m_autoScroll on every tick — a brief overshoot at maximum
+  // would silently re-arm auto-scroll without an explicit release. Only
+  // commit on slider release. Wheel/keyboard scroll never sets
+  // isSliderDown(), so they still update immediately.
+  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
+          this, [this]() {
+            auto *sb = m_processOutputEdit->verticalScrollBar();
+            if (sb->isSliderDown())
+              return;
+            m_autoScroll = sb->value() >= sb->maximum();
+          });
+  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::sliderReleased,
+          this, [this]() {
+            auto *sb = m_processOutputEdit->verticalScrollBar();
+            m_autoScroll = sb->value() >= sb->maximum();
+          });
 }
 
 auto MainWindow::getCurrentTreeViewIndex() -> QModelIndex {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -26,7 +26,9 @@
 #include <QDesktopServices>
 #include <QDialog>
 #include <QDirIterator>
+#include <QDockWidget>
 #include <QFileInfo>
+#include <QHBoxLayout>
 #include <QInputDialog>
 #include <QLabel>
 #include <QLineEdit>
@@ -35,7 +37,9 @@
 #include <QScrollBar>
 #include <QShortcut>
 #include <QTextCursor>
+#include <QTextEdit>
 #include <QTimer>
+#include <QToolButton>
 #include <QTreeWidget>
 #include <utility>
 
@@ -124,6 +128,7 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 
   initToolBarButtons();
   initStatusBar();
+  initProcessOutputPanel();
 
   connect(QtPassSettings::getPass(), &Pass::finishedAnyWithPid, this,
           [this](const QString &out, const QString &err, Enums::PROCESS pid) {
@@ -146,12 +151,19 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
             }
           });
 
-  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::sliderPressed,
+  // Hysteresis: while the user is actively dragging the slider, don't
+  // touch m_autoScroll on every tick — a brief overshoot at maximum
+  // would silently re-arm auto-scroll without an explicit release. Only
+  // commit on slider release. Wheel/keyboard scroll never sets
+  // isSliderDown(), so they still update immediately.
+  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
           this, [this]() {
             auto *sb = m_processOutputEdit->verticalScrollBar();
+            if (sb->isSliderDown())
+              return;
             m_autoScroll = sb->value() >= sb->maximum();
           });
-  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::valueChanged,
+  connect(m_processOutputEdit->verticalScrollBar(), &QScrollBar::sliderReleased,
           this, [this]() {
             auto *sb = m_processOutputEdit->verticalScrollBar();
             m_autoScroll = sb->value() >= sb->maximum();
@@ -303,16 +315,22 @@ void MainWindow::initStatusBar() {
   auto *logoApp = new QLabel(statusBar());
   logoApp->setPixmap(logo);
   statusBar()->addPermanentWidget(logoApp);
+}
 
-  // Build the process-output panel programmatically rather than from .ui:
-  // QMainWindow's uic only places its top-level children into the
-  // centralWidget / statusBar / menuBar / toolBars / dock-widget slots.
-  // Defining processOutputWidget at that level in the .ui leaves it
-  // unplaced and obscuring centralWidget; nesting it inside centralWidget
-  // and reparenting on the fly works but leaves a residual empty grid
-  // slot below the main content. Owning the construction here keeps the
-  // widget's lifetime tied to the status bar from the start.
-  m_processOutputWidget = new QWidget(statusBar());
+/**
+ * @brief Build the process-output panel as a bottom QDockWidget.
+ *
+ * The panel is constructed programmatically rather than declared in
+ * mainwindow.ui: uic only places QMainWindow's top-level children into
+ * the centralWidget / statusBar / menuBar / toolBars / dock-widget
+ * slots, and the previous home (statusBar()->addPermanentWidget()) made
+ * an 80–150 px tall QTextEdit sit inside what is otherwise a thin
+ * status row. A QDockWidget at the bottom dock area is the conventional
+ * place for an IDE-style output console, and it gives users
+ * detach/move for free.
+ */
+void MainWindow::initProcessOutputPanel() {
+  m_processOutputWidget = new QWidget;
   m_processOutputWidget->setObjectName(QStringLiteral("processOutputWidget"));
   auto *outputLayout = new QHBoxLayout(m_processOutputWidget);
   outputLayout->setObjectName(QStringLiteral("processOutputLayout"));
@@ -329,10 +347,17 @@ void MainWindow::initStatusBar() {
   m_processOutputEdit->setMinimumSize(0, 80);
   m_processOutputEdit->setMaximumSize(QWIDGETSIZE_MAX, 150);
   outputLayout->addWidget(m_processOutputEdit);
-  // Hide before adding so the status bar doesn't pre-allocate the panel's
-  // 80 px minimum height when the user has the option turned off.
-  m_processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
-  statusBar()->addPermanentWidget(m_processOutputWidget);
+
+  m_processOutputDock = new QDockWidget(tr("Process Output"), this);
+  m_processOutputDock->setObjectName(QStringLiteral("processOutputDock"));
+  m_processOutputDock->setFeatures(QDockWidget::DockWidgetMovable |
+                                   QDockWidget::DockWidgetFloatable);
+  m_processOutputDock->setAllowedAreas(Qt::BottomDockWidgetArea |
+                                       Qt::TopDockWidgetArea);
+  m_processOutputDock->setWidget(m_processOutputWidget);
+  m_processOutputDock->setVisible(QtPassSettings::isShowProcessOutput());
+  addDockWidget(Qt::BottomDockWidgetArea, m_processOutputDock);
+
   connect(m_clearOutputButton, &QToolButton::clicked, this,
           &MainWindow::on_clearOutputButton_clicked);
 }
@@ -561,7 +586,7 @@ void MainWindow::executeWrapperStarted() {
   setUiElementsEnabled(false);
   clearPanelTimer.stop();
   if (QtPassSettings::isShowProcessOutput()) {
-    m_processOutputWidget->setVisible(true);
+    m_processOutputDock->setVisible(true);
   }
 }
 
@@ -1990,7 +2015,7 @@ auto MainWindow::isSensitiveProcess(Enums::PROCESS pid) -> bool {
  * showProcessOutput setting.
  */
 void MainWindow::updateProcessOutputVisibility() {
-  m_processOutputWidget->setVisible(QtPassSettings::isShowProcessOutput());
+  m_processOutputDock->setVisible(QtPassSettings::isShowProcessOutput());
 }
 
 /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -28,6 +28,7 @@ class MainWindow;
 }
 
 class QDialog;
+class QDockWidget;
 class QTextEdit;
 class QToolButton;
 class QTreeWidgetItem;
@@ -282,11 +283,13 @@ private:
   bool m_autoScroll = true;
   int m_outputCounter = 0;
   static constexpr int MaxOutputLines = 1000;
-  // The process output panel lives in the status bar (created in
-  // initStatusBar()); it isn't part of the .ui because uic places its
-  // QMainWindow children in centralWidget/statusBar/etc. slots only —
-  // a sibling widget at the QMainWindow level isn't laid out and ends
-  // up obscuring the centralWidget. See #1192 for the symptom.
+  // The process output panel is a QDockWidget at the bottom dock area,
+  // created programmatically in initProcessOutputPanel(). It isn't part
+  // of the .ui because uic places its QMainWindow children in
+  // centralWidget / statusBar / menuBar / toolBars / dock-widget slots
+  // only — a sibling widget at the QMainWindow level isn't laid out and
+  // ends up obscuring the centralWidget. See #1192 for the symptom.
+  QDockWidget *m_processOutputDock = nullptr;
   QWidget *m_processOutputWidget = nullptr;
   QTextEdit *m_processOutputEdit = nullptr;
   QToolButton *m_clearOutputButton = nullptr;
@@ -300,6 +303,7 @@ private:
 
   void initToolBarButtons();
   void initStatusBar();
+  void initProcessOutputPanel();
 
   void updateText();
   void selectFirstFile();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces two main functional changes:

1.  **Relocated Process Output Panel to a QDockWidget:** The "Process Output" panel, which previously resided within the status bar, has been re-implemented as a `QDockWidget`. This change allows users to dock the panel at the bottom (default) or top of the main window, or float it as a separate window, providing greater flexibility in workspace organization.
2.  **Added Scroll Hysteresis to Auto-Scroll Behavior:** The auto-scrolling functionality of the process output text edit has been improved. When a user manually drags the scrollbar, the auto-scroll feature will now only re-evaluate its state (whether to re-engage auto-scrolling) upon the `sliderReleased` event, rather than on every `valueChanged` event. This prevents auto-scroll from silently re-arming if the slider briefly overshoots the maximum position during a drag, while still allowing immediate updates for wheel or keyboard scrolling.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Process output panel moved to a movable bottom panel for improved layout.
  * Auto-scroll now only re-enables when scroll handle is released, avoiding unintended re-activation during dragging.
  * Hiding the process output panel now persists across sessions, so the panel stays hidden when dismissed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->