### PR TITLE
docs: Import wording correction

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1769,7 +1769,7 @@ void MainWindow::showShareHelp() {
          "<p>To share passwords with other users:</p>"
          "<ol>"
          "<li><b>Export your public key</b> and send it to teammates</li>"
-         "<li><b>Import teammates' public keys</b> to their own folders</li>"
+         "<li><b>Import teammates' public keys</b> into your GPG keyring</li>"
          "<li><b>Re-encrypt passwords</b> so all recipients can decrypt "
          "them</li>"
          "</ol>"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the help text for password sharing to clarify that teammates' public keys should be imported into the user's GPG keyring, rather than "to their own folders." This improves the accuracy and clarity of the instructions for key management.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sharing help dialog instructions for importing teammates' public keys. The dialog now properly directs users to import keys into their own GPG keyring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->