### PR TITLE
test: cover storemodel drop dispatch & MIME round-trip (#239)

### DIFF
--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -37,6 +37,30 @@ struct dragAndDropInfoPasswordStore {
   QString path;                     /**< Full path to the dragged item */
 };
 
+class QDataStream;
+
+/**
+ * @brief Serialize a dragAndDropInfoPasswordStore for the QtPass MIME type.
+ * @param out Stream to write to.
+ * @param info Drag/drop info to serialize.
+ * @return The same stream, for chaining.
+ */
+auto operator<<(QDataStream &out, const dragAndDropInfoPasswordStore &info)
+    -> QDataStream &;
+
+/**
+ * @brief Deserialize a dragAndDropInfoPasswordStore from the QtPass MIME type.
+ *
+ * Unrecognised kind bytes resolve to ItemKind::Unknown rather than being
+ * rejected, so a future protocol bump remains decode-safe.
+ *
+ * @param in Stream to read from.
+ * @param info Drag/drop info to populate.
+ * @return The same stream, for chaining.
+ */
+auto operator>>(QDataStream &in, dragAndDropInfoPasswordStore &info)
+    -> QDataStream &;
+
 class StoreModel : public QSortFilterProxyModel {
   Q_OBJECT
 

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
 // SPDX-License-Identifier: GPL-3.0-or-later
+#include <QDataStream>
 #include <QDir>
 #include <QFileSystemModel>
+#include <QMimeData>
 #include <QtTest>
 
 #include "../../../src/storemodel.h"
@@ -16,6 +18,17 @@ private Q_SLOTS:
   void flagsWithInvalidIndex();
   void mimeTypes();
   void mimeData();
+  void mimeDataRoundTripFile();
+  void mimeDataRoundTripDirectory();
+  void mimeDataDeserializeUnknownKind();
+  void canDropNullData();
+  void canDropWrongMimeType();
+  void canDropEmptyEncodedData();
+  void canDropColumnGreaterThanZero();
+  void canDropDirOnDir();
+  void canDropFileOnDir();
+  void canDropFileOnFile();
+  void canDropDirOnFile();
   void lessThan();
   void lessThanDirsFirst();
   void supportedDropActions();
@@ -266,6 +279,177 @@ void tst_storemodel::filterRegularExpression() {
   sm.setFilterRegularExpression(QRegularExpression("test"));
   QRegularExpression result = sm.filterRegularExpression();
   QVERIFY2(result.pattern() == "test", "Filter should match test");
+}
+
+namespace {
+auto makeMimeData(dragAndDropInfoPasswordStore::ItemKind kind,
+                  const QString &path) -> QMimeData * {
+  dragAndDropInfoPasswordStore info;
+  info.kind = kind;
+  info.path = path;
+
+  QByteArray encoded;
+  QDataStream stream(&encoded, QIODevice::WriteOnly);
+  stream << info;
+
+  auto *mime = new QMimeData;
+  mime->setData("application/vnd+qtpass.dragAndDropInfoPasswordStore", encoded);
+  return mime;
+}
+
+struct DropFixture {
+  QTemporaryDir tempDir;
+  QFileSystemModel fsm;
+  StoreModel sm;
+  QString filePath;
+  QString folderPath;
+
+  DropFixture() {
+    QFile f(tempDir.path() + "/file.gpg");
+    [[maybe_unused]] const bool fileOpened = f.open(QFile::WriteOnly);
+    Q_ASSERT(fileOpened);
+    f.close();
+    filePath = tempDir.path() + "/file.gpg";
+
+    [[maybe_unused]] const bool folderCreated =
+        QDir(tempDir.path()).mkdir("folder");
+    Q_ASSERT(folderCreated);
+    folderPath = tempDir.path() + "/folder";
+
+    fsm.setRootPath(tempDir.path());
+    sm.setModelAndStore(&fsm, tempDir.path());
+
+    // QFileSystemModel populates rows asynchronously; spin until both
+    // entries are visible to the proxy before exercising drop logic.
+    QTRY_VERIFY(fsm.index(filePath).isValid());
+    QTRY_VERIFY(fsm.index(folderPath).isValid());
+  }
+
+  [[nodiscard]] auto fileProxy() const -> QModelIndex {
+    return sm.mapFromSource(fsm.index(filePath));
+  }
+  [[nodiscard]] auto folderProxy() const -> QModelIndex {
+    return sm.mapFromSource(fsm.index(folderPath));
+  }
+};
+} // namespace
+
+void tst_storemodel::mimeDataRoundTripFile() {
+  dragAndDropInfoPasswordStore in;
+  in.kind = dragAndDropInfoPasswordStore::ItemKind::File;
+  in.path = "/path/to/file.gpg";
+
+  QByteArray buf;
+  QDataStream out(&buf, QIODevice::WriteOnly);
+  out << in;
+
+  dragAndDropInfoPasswordStore back;
+  QDataStream stream(&buf, QIODevice::ReadOnly);
+  stream >> back;
+
+  QCOMPARE(back.kind, dragAndDropInfoPasswordStore::ItemKind::File);
+  QCOMPARE(back.path, in.path);
+}
+
+void tst_storemodel::mimeDataRoundTripDirectory() {
+  dragAndDropInfoPasswordStore in;
+  in.kind = dragAndDropInfoPasswordStore::ItemKind::Directory;
+  in.path = "/path/to/folder";
+
+  QByteArray buf;
+  QDataStream out(&buf, QIODevice::WriteOnly);
+  out << in;
+
+  dragAndDropInfoPasswordStore back;
+  QDataStream stream(&buf, QIODevice::ReadOnly);
+  stream >> back;
+
+  QCOMPARE(back.kind, dragAndDropInfoPasswordStore::ItemKind::Directory);
+  QCOMPARE(back.path, in.path);
+}
+
+void tst_storemodel::mimeDataDeserializeUnknownKind() {
+  // An on-the-wire kind byte that doesn't map to File or Directory must
+  // resolve to ItemKind::Unknown rather than aliasing onto a real kind.
+  QByteArray buf;
+  QDataStream out(&buf, QIODevice::WriteOnly);
+  out << static_cast<quint8>(99) << QString("/some/path");
+
+  dragAndDropInfoPasswordStore back;
+  QDataStream stream(&buf, QIODevice::ReadOnly);
+  stream >> back;
+
+  QCOMPARE(back.kind, dragAndDropInfoPasswordStore::ItemKind::Unknown);
+  QCOMPARE(back.path, QString("/some/path"));
+}
+
+void tst_storemodel::canDropNullData() {
+  DropFixture fx;
+  QVERIFY(
+      !fx.sm.canDropMimeData(nullptr, Qt::MoveAction, 0, 0, fx.folderProxy()));
+}
+
+void tst_storemodel::canDropWrongMimeType() {
+  DropFixture fx;
+  QMimeData mime;
+  mime.setText("not the right format");
+  QVERIFY(
+      !fx.sm.canDropMimeData(&mime, Qt::MoveAction, 0, 0, fx.folderProxy()));
+}
+
+void tst_storemodel::canDropEmptyEncodedData() {
+  DropFixture fx;
+  QMimeData mime;
+  mime.setData("application/vnd+qtpass.dragAndDropInfoPasswordStore",
+               QByteArray());
+  QVERIFY(
+      !fx.sm.canDropMimeData(&mime, Qt::MoveAction, 0, 0, fx.folderProxy()));
+}
+
+void tst_storemodel::canDropColumnGreaterThanZero() {
+  DropFixture fx;
+  QScopedPointer<QMimeData> mime(
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath));
+  // The first column is the only meaningful drop target in a file
+  // browser; secondary columns (size/date/etc.) must reject drops.
+  QVERIFY(!fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 1,
+                                 fx.folderProxy()));
+}
+
+void tst_storemodel::canDropDirOnDir() {
+  DropFixture fx;
+  QScopedPointer<QMimeData> mime(makeMimeData(
+      dragAndDropInfoPasswordStore::ItemKind::Directory, fx.folderPath));
+  QVERIFY(fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0,
+                                fx.folderProxy()));
+}
+
+void tst_storemodel::canDropFileOnDir() {
+  DropFixture fx;
+  QScopedPointer<QMimeData> mime(
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath));
+  QVERIFY(fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0,
+                                fx.folderProxy()));
+}
+
+void tst_storemodel::canDropFileOnFile() {
+  // file-on-file is allowed at the canDrop layer; dropMimeData() then
+  // surfaces an overwrite confirmation dialog before the actual move.
+  DropFixture fx;
+  QScopedPointer<QMimeData> mime(
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath));
+  QVERIFY(
+      fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0, fx.fileProxy()));
+}
+
+void tst_storemodel::canDropDirOnFile() {
+  // The one combination explicitly disallowed by the #239 spec: a
+  // folder dropped onto a file has no sensible interpretation.
+  DropFixture fx;
+  QScopedPointer<QMimeData> mime(makeMimeData(
+      dragAndDropInfoPasswordStore::ItemKind::Directory, fx.folderPath));
+  QVERIFY(!fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0,
+                                 fx.fileProxy()));
 }
 
 QTEST_MAIN(tst_storemodel)

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -294,7 +294,10 @@ auto makeMimeData(dragAndDropInfoPasswordStore::ItemKind kind,
   QDataStream stream(&encoded, QIODevice::WriteOnly);
   stream << info;
 
-  auto mime = std::make_unique<QMimeData>();
+  // std::unique_ptr<T>(new T) rather than std::make_unique<T>() because
+  // tests/tests.pri pins the test build to c++11 (see Qt 5.15 CI), and
+  // make_unique is c++14.
+  std::unique_ptr<QMimeData> mime(new QMimeData);
   mime->setData("application/vnd+qtpass.dragAndDropInfoPasswordStore", encoded);
   return mime;
 }

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -6,6 +6,8 @@
 #include <QMimeData>
 #include <QtTest>
 
+#include <memory>
+
 #include "../../../src/storemodel.h"
 
 class tst_storemodel : public QObject {
@@ -283,7 +285,7 @@ void tst_storemodel::filterRegularExpression() {
 
 namespace {
 auto makeMimeData(dragAndDropInfoPasswordStore::ItemKind kind,
-                  const QString &path) -> QMimeData * {
+                  const QString &path) -> std::unique_ptr<QMimeData> {
   dragAndDropInfoPasswordStore info;
   info.kind = kind;
   info.path = path;
@@ -292,7 +294,7 @@ auto makeMimeData(dragAndDropInfoPasswordStore::ItemKind kind,
   QDataStream stream(&encoded, QIODevice::WriteOnly);
   stream << info;
 
-  auto *mime = new QMimeData;
+  auto mime = std::make_unique<QMimeData>();
   mime->setData("application/vnd+qtpass.dragAndDropInfoPasswordStore", encoded);
   return mime;
 }
@@ -407,27 +409,27 @@ void tst_storemodel::canDropEmptyEncodedData() {
 
 void tst_storemodel::canDropColumnGreaterThanZero() {
   DropFixture fx;
-  QScopedPointer<QMimeData> mime(
-      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath));
+  auto mime =
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath);
   // The first column is the only meaningful drop target in a file
   // browser; secondary columns (size/date/etc.) must reject drops.
-  QVERIFY(!fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 1,
+  QVERIFY(!fx.sm.canDropMimeData(mime.get(), Qt::MoveAction, 0, 1,
                                  fx.folderProxy()));
 }
 
 void tst_storemodel::canDropDirOnDir() {
   DropFixture fx;
-  QScopedPointer<QMimeData> mime(makeMimeData(
-      dragAndDropInfoPasswordStore::ItemKind::Directory, fx.folderPath));
-  QVERIFY(fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0,
+  auto mime = makeMimeData(dragAndDropInfoPasswordStore::ItemKind::Directory,
+                           fx.folderPath);
+  QVERIFY(fx.sm.canDropMimeData(mime.get(), Qt::MoveAction, 0, 0,
                                 fx.folderProxy()));
 }
 
 void tst_storemodel::canDropFileOnDir() {
   DropFixture fx;
-  QScopedPointer<QMimeData> mime(
-      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath));
-  QVERIFY(fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0,
+  auto mime =
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath);
+  QVERIFY(fx.sm.canDropMimeData(mime.get(), Qt::MoveAction, 0, 0,
                                 fx.folderProxy()));
 }
 
@@ -435,20 +437,20 @@ void tst_storemodel::canDropFileOnFile() {
   // file-on-file is allowed at the canDrop layer; dropMimeData() then
   // surfaces an overwrite confirmation dialog before the actual move.
   DropFixture fx;
-  QScopedPointer<QMimeData> mime(
-      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath));
+  auto mime =
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, fx.filePath);
   QVERIFY(
-      fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0, fx.fileProxy()));
+      fx.sm.canDropMimeData(mime.get(), Qt::MoveAction, 0, 0, fx.fileProxy()));
 }
 
 void tst_storemodel::canDropDirOnFile() {
   // The one combination explicitly disallowed by the #239 spec: a
   // folder dropped onto a file has no sensible interpretation.
   DropFixture fx;
-  QScopedPointer<QMimeData> mime(makeMimeData(
-      dragAndDropInfoPasswordStore::ItemKind::Directory, fx.folderPath));
-  QVERIFY(!fx.sm.canDropMimeData(mime.data(), Qt::MoveAction, 0, 0,
-                                 fx.fileProxy()));
+  auto mime = makeMimeData(dragAndDropInfoPasswordStore::ItemKind::Directory,
+                           fx.folderPath);
+  QVERIFY(
+      !fx.sm.canDropMimeData(mime.get(), Qt::MoveAction, 0, 0, fx.fileProxy()));
 }
 
 QTEST_MAIN(tst_storemodel)

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -306,14 +306,13 @@ struct DropFixture {
 
   DropFixture() {
     QFile f(tempDir.path() + "/file.gpg");
-    [[maybe_unused]] const bool fileOpened = f.open(QFile::WriteOnly);
-    Q_ASSERT(fileOpened);
+    const bool fileOpened = f.open(QFile::WriteOnly);
+    QVERIFY2(fileOpened, "QFile::open failed creating temp file.gpg");
     f.close();
     filePath = tempDir.path() + "/file.gpg";
 
-    [[maybe_unused]] const bool folderCreated =
-        QDir(tempDir.path()).mkdir("folder");
-    Q_ASSERT(folderCreated);
+    const bool folderCreated = QDir(tempDir.path()).mkdir("folder");
+    QVERIFY2(folderCreated, "QDir::mkdir failed creating folder");
     folderPath = tempDir.path() + "/folder";
 
     fsm.setRootPath(tempDir.path());


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Declares global serialization (`operator<<`) and deserialization (`operator>>`) operators for the `dragAndDropInfoPasswordStore` struct. These operators enable the conversion of drag-and-drop information to and from a `QDataStream`, specifically for handling the QtPass MIME type during drag-and-drop operations. The deserialization operator is designed to be robust against future protocol changes by resolving unrecognised item kinds to `ItemKind::Unknown`.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved drag-and-drop: MIME-style serialization for drag payloads and resilient decoding that maps unknown item kinds to "Unknown" without failing.
  * Stricter validation of drop targets and explicit rules for directory/file drop combinations.

* **Tests**
  * Added end-to-end tests for drag-and-drop serialization, MIME payload handling, unknown-kind decoding, and detailed drop-rule enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->