### PR TITLE
i18n(id_ID): full Bahasa Indonesia translation pass (0 → 304/304)

### DIFF
--- a/localization/localization_id_ID.ts
+++ b/localization/localization_id_ID.ts
@@ -19,19 +19,19 @@
         <location filename="../src/configdialog.ui" line="72"/>
         <location filename="../src/ui_configdialog.h" line="898"/>
         <source>Clipboard behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Perilaku clipboard:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
         <location filename="../src/ui_configdialog.h" line="899"/>
         <source>Use primary selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan seleksi utama</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="98"/>
         <location filename="../src/ui_configdialog.h" line="900"/>
         <source>Autoclear after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Bersihkan otomatis setelah:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="115"/>
@@ -39,271 +39,271 @@
         <location filename="../src/ui_configdialog.h" line="901"/>
         <location filename="../src/ui_configdialog.h" line="906"/>
         <source>Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Detik</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
         <location filename="../src/ui_configdialog.h" line="902"/>
         <source>Content panel behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Perilaku panel konten:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="159"/>
         <location filename="../src/ui_configdialog.h" line="903"/>
         <source>Hide content</source>
-        <translation type="unfinished"></translation>
+        <translation>Sembunyikan konten</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="166"/>
         <location filename="../src/ui_configdialog.h" line="904"/>
         <source>Hide password</source>
-        <translation type="unfinished"></translation>
+        <translation>Sembunyikan kata sandi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <location filename="../src/ui_configdialog.h" line="905"/>
         <source>Autoclear panel after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Bersihkan panel otomatis setelah:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <location filename="../src/ui_configdialog.h" line="907"/>
         <source>Use a monospace font</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan font monospace</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
         <location filename="../src/ui_configdialog.h" line="908"/>
         <source>Display the files content as-is</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan konten berkas apa adanya</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="238"/>
         <location filename="../src/ui_configdialog.h" line="909"/>
         <source>No line wrapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanpa pembungkusan baris</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="245"/>
         <location filename="../src/ui_configdialog.h" line="910"/>
         <source>Show process output</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan keluaran proses</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="277"/>
         <location filename="../src/ui_configdialog.h" line="911"/>
         <source>Password Generation:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pembuatan Kata Sandi:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="289"/>
         <location filename="../src/ui_configdialog.h" line="912"/>
         <source>Password Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Panjang Kata Sandi:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="323"/>
         <location filename="../src/ui_configdialog.h" line="913"/>
         <source>Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Karakter</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="351"/>
         <location filename="../src/ui_configdialog.h" line="914"/>
         <source>Use characters:</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan karakter:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="369"/>
         <location filename="../src/ui_configdialog.h" line="921"/>
         <source>Select character set for password generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih kumpulan karakter untuk pembuatan kata sandi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="373"/>
         <location filename="../src/ui_configdialog.h" line="915"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua Karakter</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <location filename="../src/ui_configdialog.h" line="916"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfabetis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
         <location filename="../src/ui_configdialog.h" line="917"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfanumerik</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="388"/>
         <location filename="../src/ui_configdialog.h" line="918"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustom</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <location filename="../src/ui_configdialog.h" line="923"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation type="unfinished"></translation>
+        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
         <location filename="../src/ui_configdialog.h" line="924"/>
         <source>Use PWGen</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <location filename="../src/ui_configdialog.h" line="925"/>
         <source>Exclude capital letters</source>
-        <translation type="unfinished"></translation>
+        <translation>Kecualikan huruf kapital</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
         <location filename="../src/ui_configdialog.h" line="926"/>
         <source>Include special symbols</source>
-        <translation type="unfinished"></translation>
+        <translation>Sertakan simbol khusus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <location filename="../src/ui_configdialog.h" line="927"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation type="unfinished"></translation>
+        <translation>Hasilkan kata sandi yang mudah diingat tetapi kurang aman</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
         <location filename="../src/ui_configdialog.h" line="928"/>
         <source>Exclude numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Kecualikan angka</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="493"/>
         <location filename="../src/ui_configdialog.h" line="929"/>
         <source>Git:</source>
-        <translation type="unfinished"></translation>
+        <translation>Git:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="505"/>
         <location filename="../src/ui_configdialog.h" line="930"/>
         <source>Use Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan Git</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="519"/>
         <location filename="../src/ui_configdialog.h" line="931"/>
         <source>Automatically add .gpg-id files</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambahkan berkas .gpg-id otomatis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
         <location filename="../src/ui_configdialog.h" line="932"/>
         <source>Automatically push</source>
-        <translation type="unfinished"></translation>
+        <translation>Push otomatis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="533"/>
         <location filename="../src/ui_configdialog.h" line="933"/>
         <source>Automatically pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Pull otomatis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>
         <location filename="../src/ui_configdialog.h" line="934"/>
         <source>Extensions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekstensi:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
         <location filename="../src/ui_configdialog.h" line="935"/>
         <source>Use QRencode</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan QRencode</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
         <location filename="../src/ui_configdialog.h" line="936"/>
         <source>Use pass-otp extension</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan ekstensi pass-otp</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="599"/>
         <location filename="../src/ui_configdialog.h" line="937"/>
         <source>Enable content search (pass grep)</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktifkan pencarian konten (pass grep)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
         <location filename="../src/ui_configdialog.h" line="939"/>
         <source>Allow searching inside password file contents. Requires decrypting every file and can be slow on large stores.</source>
-        <translation type="unfinished"></translation>
+        <translation>Izinkan pencarian di dalam isi berkas kata sandi. Membutuhkan dekripsi setiap berkas dan bisa lambat pada penyimpanan besar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="624"/>
         <location filename="../src/ui_configdialog.h" line="941"/>
         <source>System:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <location filename="../src/ui_configdialog.h" line="942"/>
         <source>Use TrayIcon</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan TrayIcon</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
         <location filename="../src/ui_configdialog.h" line="943"/>
         <source>Start minimized</source>
-        <translation type="unfinished"></translation>
+        <translation>Mulai dalam keadaan minimal</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <location filename="../src/ui_configdialog.h" line="944"/>
         <source>Hide on close</source>
-        <translation type="unfinished"></translation>
+        <translation>Sembunyikan saat ditutup</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>
         <location filename="../src/ui_configdialog.h" line="945"/>
         <source>Always on top</source>
-        <translation type="unfinished"></translation>
+        <translation>Selalu di atas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="682"/>
         <location filename="../src/ui_configdialog.h" line="966"/>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="700"/>
         <location filename="../src/ui_configdialog.h" line="947"/>
         <source>Select password storage program:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih program penyimpanan kata sandi:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <location filename="../src/ui_configdialog.h" line="948"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation type="unfinished"></translation>
+        <translation>Nati&amp;ve Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <location filename="../src/ui_configdialog.h" line="949"/>
         <source>&amp;Use pass</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Gunakan pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <location filename="../src/ui_configdialog.h" line="950"/>
         <source>Native</source>
-        <translation type="unfinished"></translation>
+        <translation>Native</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
         <location filename="../src/ui_configdialog.h" line="951"/>
         <source>Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Git</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="756"/>
@@ -317,145 +317,145 @@
         <location filename="../src/ui_configdialog.h" line="963"/>
         <location filename="../src/ui_configdialog.h" line="985"/>
         <source>…</source>
-        <translation type="unfinished"></translation>
+        <translation>…</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="776"/>
         <location filename="../src/ui_configdialog.h" line="954"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
         <location filename="../src/ui_configdialog.h" line="956"/>
         <source>Generate GPG key pair</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat pasangan kunci GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="786"/>
         <location filename="../src/ui_configdialog.h" line="958"/>
         <source>GPG</source>
-        <translation type="unfinished"></translation>
+        <translation>GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="799"/>
         <location filename="../src/ui_configdialog.h" line="959"/>
         <source>PWGen</source>
-        <translation type="unfinished"></translation>
+        <translation>PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="816"/>
         <location filename="../src/ui_configdialog.h" line="961"/>
         <source>Pass</source>
-        <translation type="unfinished"></translation>
+        <translation>Pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="827"/>
         <location filename="../src/ui_configdialog.h" line="962"/>
         <source>pass</source>
-        <translation type="unfinished"></translation>
+        <translation>pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="846"/>
         <location filename="../src/ui_configdialog.h" line="964"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="877"/>
         <location filename="../src/ui_configdialog.h" line="965"/>
         <source>Autodetect</source>
-        <translation type="unfinished"></translation>
+        <translation>Deteksi otomatis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="900"/>
         <location filename="../src/ui_configdialog.h" line="986"/>
         <source>Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="949"/>
         <location filename="../src/ui_configdialog.h" line="968"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="952"/>
         <location filename="../src/ui_configdialog.h" line="970"/>
         <source>Profile name, used to identify this configuration profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama profil, digunakan untuk mengidentifikasi profil konfigurasi ini</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
         <location filename="../src/ui_configdialog.h" line="973"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Jalur</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
         <location filename="../src/ui_configdialog.h" line="975"/>
         <source>Path to the password store directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Jalur ke direktori penyimpanan kata sandi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="965"/>
         <location filename="../src/ui_configdialog.h" line="978"/>
         <source>Signing Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci Penandatangan</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="968"/>
         <location filename="../src/ui_configdialog.h" line="980"/>
         <source>Optional: GPG key to sign .gpg-id files for integrity verification. Leave empty unless you need to protect the user list from tampering.</source>
-        <translation type="unfinished"></translation>
+        <translation>Opsional: kunci GPG untuk menandatangani berkas .gpg-id untuk verifikasi integritas. Biarkan kosong kecuali Anda perlu melindungi daftar pengguna dari manipulasi.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="978"/>
         <location filename="../src/ui_configdialog.h" line="982"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambah</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="993"/>
         <location filename="../src/ui_configdialog.h" line="983"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
         <location filename="../src/ui_configdialog.h" line="984"/>
         <source>Current path</source>
-        <translation type="unfinished"></translation>
+        <translation>Jalur saat ini</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1028"/>
         <location filename="../src/ui_configdialog.h" line="996"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Template</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1049"/>
         <location filename="../src/ui_configdialog.h" line="987"/>
         <source>Templates add extra fields in the password generation dialogue, and in the password view.</source>
-        <translation type="unfinished"></translation>
+        <translation>Template menambahkan kolom tambahan pada dialog pembuatan kata sandi dan pada tampilan kata sandi.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1058"/>
         <location filename="../src/ui_configdialog.h" line="988"/>
         <source>Use template</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunakan template</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1065"/>
         <location filename="../src/ui_configdialog.h" line="990"/>
         <source>Show all lines beginning with a word followed by a colon as fields in password fields, not only the listed ones</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan semua baris yang dimulai dengan kata diikuti titik dua sebagai kolom dalam kolom kata sandi, bukan hanya yang terdaftar</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1068"/>
         <location filename="../src/ui_configdialog.h" line="992"/>
         <source>Show all fields templated</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan semua kolom dengan template</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1080"/>
@@ -463,150 +463,152 @@
         <source>login
 URL
 e-mail</source>
-        <translation type="unfinished"></translation>
+        <translation>login
+URL
+email</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1095"/>
         <location filename="../src/ui_configdialog.h" line="997"/>
         <source>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; version </source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; versi </translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="68"/>
         <source>System tray is not available</source>
-        <translation type="unfinished"></translation>
+        <translation>Tray sistem tidak tersedia</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
         <source>Pass OTP extension needs to be installed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekstensi Pass OTP perlu diinstal</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="100"/>
         <source>qrencode needs to be installed</source>
-        <translation type="unfinished"></translation>
+        <translation>qrencode perlu diinstal</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="125"/>
         <source>No Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanpa Clipboard</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>
         <source>Always copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Selalu salin ke clipboard</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="127"/>
         <source>On-demand copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Salin ke clipboard sesuai permintaan</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="210"/>
         <location filename="../src/configdialog.cpp" line="226"/>
         <source>This field is required</source>
-        <translation type="unfinished"></translation>
+        <translation>Kolom ini wajib diisi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="720"/>
         <source>Create profile directory?</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat direktori profil?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="721"/>
         <source>Would you like to create a password store at %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>Apakah Anda ingin membuat penyimpanan kata sandi di %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="728"/>
         <location filename="../src/configdialog.cpp" line="985"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Galat</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>
         <source>Could not create profile directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membuat direktori profil: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="747"/>
         <source>Select recipients for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih penerima untuk %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="773"/>
         <source>New Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil Baru</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="810"/>
         <source>No profile selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada profil yang dipilih</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>
         <source>No profile selected to delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada profil yang dipilih untuk dihapus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
         <source>GnuPG not found</source>
-        <translation type="unfinished"></translation>
+        <translation>GnuPG tidak ditemukan</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="914"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store to get it.&lt;br&gt;If you already did so, make sure you started it once and&lt;br&gt;click &quot;Autodetect&quot; in the next dialog.</source>
-        <translation type="unfinished"></translation>
+        <translation>Silakan instal GnuPG pada sistem Anda.&lt;br&gt;Instal &lt;strong&gt;Ubuntu&lt;/strong&gt; dari Microsoft Store untuk mendapatkannya.&lt;br&gt;Jika sudah, pastikan Anda menjalankannya sekali dan&lt;br&gt;klik &quot;Deteksi otomatis&quot; di dialog berikutnya.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="919"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation type="unfinished"></translation>
+        <translation>Silakan instal GnuPG pada sistem Anda.&lt;br&gt;Instal &lt;strong&gt;Ubuntu&lt;/strong&gt; dari Microsoft Store&lt;br&gt;atau &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;unduh&lt;/a&gt; dari GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;gpg&lt;/strong&gt; using your favorite package manager&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation type="unfinished"></translation>
+        <translation>Silakan instal GnuPG pada sistem Anda.&lt;br&gt;Instal &lt;strong&gt;gpg&lt;/strong&gt; menggunakan pengelola paket favorit Anda&lt;br&gt;atau &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;unduh&lt;/a&gt; dari GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="979"/>
         <source>Create password-store?</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat penyimpanan kata sandi?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>Apakah Anda ingin membuat penyimpanan kata sandi di %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>
         <source>Failed to create password-store at: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal membuat penyimpanan kata sandi di: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation type="unfinished"></translation>
+        <translation>Penyimpanan kata sandi belum diinisialisasi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation type="unfinished"></translation>
+        <translation>Folder %1 sepertinya bukan penyimpanan kata sandi atau belum diinisialisasi.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
         <source>New profile: %1 at %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil baru: %1 di %2</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1267"/>
         <source>Profile: %1 at %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil: %1 di %2</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1272"/>
         <source>Fill in all required fields</source>
-        <translation type="unfinished"></translation>
+        <translation>Isi semua kolom yang wajib.</translation>
     </message>
 </context>
 <context>
@@ -615,57 +617,57 @@ e-mail</source>
         <location filename="../src/exportpublickeydialog.ui" line="14"/>
         <location filename="../src/ui_exportpublickeydialog.h" line="99"/>
         <source>Export Public Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor Kunci Publik</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="27"/>
         <location filename="../src/ui_exportpublickeydialog.h" line="100"/>
         <source>Public key</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci publik</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="52"/>
         <location filename="../src/ui_exportpublickeydialog.h" line="101"/>
         <source>Copy to Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Salin ke Clipboard</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="59"/>
         <location filename="../src/ui_exportpublickeydialog.h" line="102"/>
         <source>Save to File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Simpan ke Berkas…</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="28"/>
         <source>Public key for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci publik untuk %1</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="67"/>
         <source>Copied!</source>
-        <translation type="unfinished"></translation>
+        <translation>Disalin!</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="83"/>
         <location filename="../src/exportpublickeydialog.cpp" line="90"/>
         <location filename="../src/exportpublickeydialog.cpp" line="100"/>
         <source>Save Public Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Simpan Kunci Publik</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="84"/>
         <source>ASCII-armored key (*.asc);;All files (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci ASCII-armored (*.asc);;Semua berkas (*)</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="91"/>
         <source>Could not open %1 for writing: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membuka %1 untuk ditulis: %2</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="101"/>
         <source>Could not write to %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat menulis ke %1: %2</translation>
     </message>
 </context>
 <context>
@@ -675,136 +677,138 @@ e-mail</source>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
         <source>Check .gpgid file signature!</source>
-        <translation type="unfinished"></translation>
+        <translation>Periksa tanda tangan berkas .gpgid!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
         <source>Signature for %1 is invalid.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanda tangan untuk %1 tidak valid.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="149"/>
         <location filename="../src/imitatepass.cpp" line="598"/>
         <source>Can not edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat mengedit</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="150"/>
         <location filename="../src/imitatepass.cpp" line="599"/>
         <source>Could not read encryption key to use, .gpg-id file missing or invalid.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membaca kunci enkripsi yang akan digunakan, berkas .gpg-id hilang atau tidak valid.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat memperbarui</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal membuka .gpg-id untuk ditulis.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="274"/>
         <source>Check selected users!</source>
-        <translation type="unfinished"></translation>
+        <translation>Periksa pengguna yang dipilih!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="275"/>
         <source>None of the selected keys have a secret key available.
 You will not be able to decrypt any newly added passwords!</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada kunci yang dipilih memiliki kunci rahasia yang tersedia.
+Anda tidak akan dapat mendekripsi kata sandi yang baru ditambahkan!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="314"/>
         <source>GPG signing failed!</source>
-        <translation type="unfinished"></translation>
+        <translation>Penandatanganan GPG gagal!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="315"/>
         <source>Failed to sign %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal menandatangani %1.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="382"/>
         <source>No signing key!</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada kunci penandatangan!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="383"/>
         <source>None of the secret signing keys is available.
 You will not be able to change the user list!</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada kunci penandatangan rahasia yang tersedia.
+Anda tidak akan dapat mengubah daftar pengguna!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="662"/>
         <location filename="../src/imitatepass.cpp" line="769"/>
         <source>Re-encryption failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang gagal</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
         <source>Failed to replace %1. Original has been restored.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal mengganti %1. Yang asli telah dipulihkan.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
         <source>Creating backup commit</source>
-        <translation type="unfinished"></translation>
+        <translation>Membuat commit cadangan</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="698"/>
         <location filename="../src/imitatepass.cpp" line="706"/>
         <source>Backup commit failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Commit cadangan gagal</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="699"/>
         <source>Could not inspect git status. Re-encryption was aborted.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat memeriksa status git. Enkripsi ulang dibatalkan.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="707"/>
         <source>Re-encryption was aborted because a git backup could not be created.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang dibatalkan karena cadangan git tidak dapat dibuat.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="729"/>
         <source>Re-encrypting from folder %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Mengenkripsi ulang dari folder %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="732"/>
         <location filename="../src/imitatepass.cpp" line="787"/>
         <source>Updating password-store</source>
-        <translation type="unfinished"></translation>
+        <translation>Memperbarui penyimpanan kata sandi</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="757"/>
         <source>GPG ID verification failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifikasi GPG ID gagal</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="758"/>
         <source>Could not verify .gpg-id for directory.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat memverifikasi .gpg-id untuk direktori.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="770"/>
         <source>Failed to re-encrypt %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal mengenkripsi ulang %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="776"/>
         <source>Re-encryption completed: %1 succeeded, %2 failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang selesai: %1 berhasil, %2 gagal</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="782"/>
         <source>Re-encryption completed: %1 files re-encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang selesai: %1 berkas dienkripsi ulang</translation>
     </message>
 </context>
 <context>
@@ -814,47 +818,47 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.cpp" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="120"/>
         <source>Import GPG Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor Kunci GPG</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="27"/>
         <location filename="../src/ui_importkeydialog.h" line="121"/>
         <source>Import a GPG public key from file or paste it below. The key should be in ASCII-armored format.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor kunci publik GPG dari berkas atau tempel di bawah. Kunci harus dalam format ASCII-armored.</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="122"/>
         <source>From File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Dari Berkas…</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="49"/>
         <location filename="../src/ui_importkeydialog.h" line="123"/>
         <source>From Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Dari Clipboard</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="71"/>
         <location filename="../src/ui_importkeydialog.h" line="124"/>
         <source>Paste an ASCII-armored GPG key here...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempel kunci GPG ASCII-armored di sini…</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="93"/>
         <location filename="../src/ui_importkeydialog.h" line="125"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
         <source>ASCII-armored GPG key</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci GPG ASCII-armored</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
         <source>All Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua Berkas</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="51"/>
@@ -862,33 +866,34 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.cpp" line="167"/>
         <location filename="../src/importkeydialog.cpp" line="171"/>
         <source>Import Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor Kunci</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="52"/>
         <source>Could not open file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membuka berkas: %1</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="67"/>
         <source>%1 does not look like an ASCII-armored GPG key. Convert it with &lt;code&gt;gpg --armor --export&lt;/code&gt; first, or paste the armored block via &lt;b&gt;From Clipboard&lt;/b&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 tidak terlihat seperti kunci GPG ASCII-armored. Konversi terlebih dahulu dengan &lt;code&gt;gpg --armor --export&lt;/code&gt;, atau tempel blok ASCII-armored melalui &lt;b&gt;Dari Clipboard&lt;/b&gt;.</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="117"/>
         <source>GPG import failed:
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor GPG gagal:
+%1</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="127"/>
         <source>Could not parse imported key id from GPG output.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membaca ID kunci yang diimpor dari keluaran GPG.</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="172"/>
         <source>Successfully imported key: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci berhasil diimpor: %1</translation>
     </message>
 </context>
 <context>
@@ -897,86 +902,86 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="14"/>
         <location filename="../src/ui_keygendialog.h" line="230"/>
         <source>Generate GnuPG keypair</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat pasangan kunci GnuPG</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
         <location filename="../src/ui_keygendialog.h" line="231"/>
         <source>Generate a new key pair</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat pasangan kunci baru</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="91"/>
         <location filename="../src/ui_keygendialog.h" line="232"/>
         <source>Email</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="123"/>
         <location filename="../src/ui_keygendialog.h" line="233"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="155"/>
         <location filename="../src/ui_keygendialog.h" line="234"/>
         <source>Passphrase</source>
-        <translation type="unfinished"></translation>
+        <translation>Passphrase</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="200"/>
         <location filename="../src/ui_keygendialog.h" line="235"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;There is no limit on the length of a passphrase, and it should be carefully chosen. From the perspective of security, the passphrase to unlock the private key is one of the weakest points in GnuPG (and other public-key encryption systems as well) since it is the only protection you have if another individual gets your private key. &lt;br/&gt;Ideally, the passphrase should not use words from a dictionary and should mix the case of alphabetic characters as well as use non-alphabetic characters.&lt;br/&gt;A good passphrase is crucial to the secure use of GnuPG.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tidak ada batas panjang passphrase, dan passphrase harus dipilih dengan hati-hati. Dari sisi keamanan, passphrase untuk membuka kunci privat adalah salah satu titik terlemah di GnuPG (dan sistem enkripsi kunci publik lain) karena passphrase adalah satu-satunya perlindungan yang Anda miliki jika orang lain mendapatkan kunci privat Anda. &lt;br/&gt;Idealnya passphrase tidak menggunakan kata-kata dari kamus dan menggabungkan huruf besar/kecil serta karakter non-alfabet.&lt;br/&gt;Passphrase yang baik sangat penting untuk penggunaan GnuPG yang aman.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="210"/>
         <location filename="../src/ui_keygendialog.h" line="236"/>
         <source>Repeat pass</source>
-        <translation type="unfinished"></translation>
+        <translation>Ulangi passphrase</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="227"/>
         <location filename="../src/ui_keygendialog.h" line="237"/>
         <source>Expert</source>
-        <translation type="unfinished"></translation>
+        <translation>Pakar</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="246"/>
         <location filename="../src/ui_keygendialog.h" line="238"/>
         <source>Template contents will be set based on GPG version.</source>
-        <translation type="unfinished"></translation>
+        <translation>Konten template akan diatur berdasarkan versi GPG.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="259"/>
         <location filename="../src/ui_keygendialog.h" line="239"/>
         <source>For expert options check out the &lt;a href=&quot;https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html&quot;&gt;GnuPG manual&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Untuk opsi pakar, lihat &lt;a href=&quot;https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html&quot;&gt;manual GnuPG&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="168"/>
         <source>Invalid name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama tidak valid</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama harus minimal 5 karakter.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>
         <source>Invalid email</source>
-        <translation type="unfinished"></translation>
+        <translation>Email tidak valid</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="181"/>
         <source>The email address you typed is not a valid email address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Alamat email yang Anda ketik bukan alamat email yang valid.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="201"/>
         <source>This operation can take some minutes.&lt;br /&gt;We need to generate a lot of random bytes. It is a good idea to perform some other action (type on the keyboard, move the mouse, utilize the disks) during the prime generation; this gives the random number generator a better chance to gain enough entropy.</source>
-        <translation type="unfinished"></translation>
+        <translation>Operasi ini bisa memakan waktu beberapa menit.&lt;br /&gt;Banyak byte acak perlu dihasilkan. Sangat dianjurkan melakukan aktivitas lain (mengetik, menggerakkan mouse, menggunakan disk) selama pembuatan bilangan prima; hal ini memberi pembangkit bilangan acak peluang lebih baik mendapatkan entropi yang cukup.</translation>
     </message>
 </context>
 <context>
@@ -985,13 +990,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="14"/>
         <location filename="../src/ui_mainwindow.h" line="307"/>
         <source>QtPass</source>
-        <translation type="unfinished"></translation>
+        <translation>QtPass</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="68"/>
         <location filename="../src/ui_mainwindow.h" line="350"/>
         <source>Select profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih profil</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="120"/>
@@ -999,67 +1004,67 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="883"/>
         <location filename="../src/ui_mainwindow.h" line="352"/>
         <source>Search Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Cari Kata Sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="127"/>
         <location filename="../src/ui_mainwindow.h" line="354"/>
         <source>Search inside password content (pass grep)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cari di dalam konten kata sandi (pass grep)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="130"/>
         <location filename="../src/ui_mainwindow.h" line="356"/>
         <source>⌕</source>
-        <translation type="unfinished"></translation>
+        <translation>⌕</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="133"/>
         <location filename="../src/ui_mainwindow.h" line="358"/>
         <source>Content search toggle</source>
-        <translation type="unfinished"></translation>
+        <translation>Alihkan pencarian konten</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="136"/>
         <location filename="../src/ui_mainwindow.h" line="361"/>
         <source>Toggle content search mode to search inside password files</source>
-        <translation type="unfinished"></translation>
+        <translation>Alihkan mode pencarian konten untuk mencari di dalam berkas kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="146"/>
         <location filename="../src/ui_mainwindow.h" line="364"/>
         <source>Case-insensitive search</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencarian tidak peka huruf besar/kecil</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="149"/>
         <location filename="../src/ui_mainwindow.h" line="366"/>
         <source>Aa</source>
-        <translation type="unfinished"></translation>
+        <translation>Aa</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="152"/>
         <location filename="../src/ui_mainwindow.h" line="368"/>
         <source>Case-insensitive toggle</source>
-        <translation type="unfinished"></translation>
+        <translation>Alihkan kepekaan huruf besar/kecil</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="155"/>
         <location filename="../src/ui_mainwindow.h" line="371"/>
         <source>Toggle case-insensitive content search</source>
-        <translation type="unfinished"></translation>
+        <translation>Alihkan pencarian konten yang tidak peka huruf besar/kecil</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="211"/>
         <location filename="../src/ui_mainwindow.h" line="374"/>
         <source>Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Hasil</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="263"/>
         <location filename="../src/ui_mainwindow.h" line="375"/>
         <source>Welcome to QtPass</source>
-        <translation type="unfinished"></translation>
+        <translation>Selamat datang di QtPass</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="322"/>
@@ -1068,7 +1073,10 @@ You will not be able to change the user list!</source>
 &lt;p&gt;Please report any &lt;a href=&quot;https://github.com/IJHack/qtpass/issues&quot;&gt;issues&lt;/a&gt; you might have with this software.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&quot;https://qtpass.org/&quot;&gt;Documentation&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;&lt;a href=&quot;https://github.com/IJHack/qtpass&quot;&gt;SourceCode&lt;/a&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;QtPass adalah GUI untuk &lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;pass&lt;/a&gt;, pengelola kata sandi standar unix.&lt;/p&gt;
+&lt;p&gt;Silakan laporkan &lt;a href=&quot;https://github.com/IJHack/qtpass/issues&quot;&gt;masalah&lt;/a&gt; apa pun yang Anda temui dengan perangkat lunak ini.&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://qtpass.org/&quot;&gt;Dokumentasi&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://github.com/IJHack/qtpass&quot;&gt;Kode sumber&lt;/a&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="379"/>
@@ -1077,13 +1085,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="308"/>
         <location filename="../src/ui_mainwindow.h" line="310"/>
         <source>Add password</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambah kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="385"/>
         <location filename="../src/ui_mainwindow.h" line="313"/>
         <source>Ctrl+N</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+N</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="390"/>
@@ -1092,7 +1100,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="315"/>
         <location filename="../src/ui_mainwindow.h" line="317"/>
         <source>Add folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambah folder</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="398"/>
@@ -1101,7 +1109,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="319"/>
         <location filename="../src/ui_mainwindow.h" line="321"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="406"/>
@@ -1110,302 +1118,304 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="323"/>
         <location filename="../src/ui_mainwindow.h" line="325"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="414"/>
         <location filename="../src/ui_mainwindow.h" line="327"/>
         <source>OTP</source>
-        <translation type="unfinished"></translation>
+        <translation>OTP</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="417"/>
         <location filename="../src/ui_mainwindow.h" line="329"/>
         <source>Generate OTP and copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat OTP dan salin ke clipboard</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="420"/>
         <location filename="../src/ui_mainwindow.h" line="332"/>
         <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+G</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="425"/>
         <location filename="../src/ui_mainwindow.h" line="334"/>
         <source>Push</source>
-        <translation type="unfinished"></translation>
+        <translation>Push</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>
         <location filename="../src/ui_mainwindow.h" line="336"/>
         <source>Git push</source>
-        <translation type="unfinished"></translation>
+        <translation>Git push</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="433"/>
         <location filename="../src/ui_mainwindow.h" line="338"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Perbarui</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="436"/>
         <location filename="../src/ui_mainwindow.h" line="340"/>
         <source>Git pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Git pull</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="441"/>
         <location filename="../src/mainwindow.cpp" line="1374"/>
         <location filename="../src/ui_mainwindow.h" line="342"/>
         <source>Users</source>
-        <translation type="unfinished"></translation>
+        <translation>Pengguna</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="444"/>
         <location filename="../src/ui_mainwindow.h" line="344"/>
         <source>Manage who can read password in folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Kelola siapa yang dapat membaca kata sandi dalam folder</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="449"/>
         <location filename="../src/ui_mainwindow.h" line="346"/>
         <source>Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfigurasi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
         <location filename="../src/ui_mainwindow.h" line="348"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfigurasi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="293"/>
         <source>Welcome to QtPass %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Selamat datang di QtPass %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="322"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Bersihkan</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="323"/>
         <source>Clear output</source>
-        <translation type="unfinished"></translation>
+        <translation>Bersihkan keluaran</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="331"/>
         <source>Process Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluaran Proses</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="501"/>
         <location filename="../src/mainwindow.cpp" line="514"/>
         <source>Updating password-store</source>
-        <translation type="unfinished"></translation>
+        <translation>Memperbarui penyimpanan kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="625"/>
         <location filename="../src/mainwindow.cpp" line="924"/>
         <source>Content hidden</source>
-        <translation type="unfinished"></translation>
+        <translation>Konten disembunyikan</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="629"/>
         <location filename="../src/mainwindow.cpp" line="1641"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="666"/>
         <source>OTP Code</source>
-        <translation type="unfinished"></translation>
+        <translation>Kode OTP</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="668"/>
         <source>OTP code copied to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Kode OTP disalin ke clipboard</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
         <source>No OTP code found in this password entry</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada kode OTP yang ditemukan di entri kata sandi ini</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="704"/>
         <source>Password and Content hidden</source>
-        <translation type="unfinished"></translation>
+        <translation>Kata sandi dan konten disembunyikan</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="784"/>
         <source>Looking for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Mencari: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>
         <source>Searching…</source>
-        <translation type="unfinished"></translation>
+        <translation>Mencari…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="865"/>
         <source>Search content (regex)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cari konten (regex)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="911"/>
         <source>No matches found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada kecocokan ditemukan.</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="934"/>
         <source>Found %n match(es)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Ditemukan %n kecocokan</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="935"/>
         <source>in %n entr(ies).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>di %n entri.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1036"/>
         <location filename="../src/mainwindow.cpp" line="1467"/>
         <source>New file</source>
-        <translation type="unfinished"></translation>
+        <translation>Berkas baru</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation>Berkas kata sandi baru: 
+(Akan ditempatkan di %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1074"/>
         <source> and the whole content?</source>
-        <translation type="unfinished"></translation>
+        <translation> dan seluruh isinya?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1084"/>
         <source> and the whole content? &lt;br&gt;&lt;strong&gt;Attention: there are unexpected files in the given folder, check them before continue.&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation> dan seluruh isinya? &lt;br&gt;&lt;strong&gt;Perhatian: ada berkas tidak terduga di folder yang diberikan, periksa sebelum melanjutkan.&lt;/strong&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1093"/>
         <source>Delete folder?</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus folder?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1093"/>
         <source>Delete password?</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus kata sandi?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1094"/>
         <source>Are you sure you want to delete %1%2?</source>
-        <translation type="unfinished"></translation>
+        <translation>Apakah Anda yakin ingin menghapus %1%2?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1114"/>
         <source>No password selected for OTP generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada kata sandi yang dipilih untuk pembuatan OTP</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1242"/>
         <source>Profile changed to %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil diubah ke %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1371"/>
         <source>Open folder with file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Buka folder dengan pengelola berkas</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1386"/>
         <source>Rename folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Ubah nama folder</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1390"/>
         <source>Rename password</source>
-        <translation type="unfinished"></translation>
+        <translation>Ubah nama kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>
         <source>Share</source>
-        <translation type="unfinished"></translation>
+        <translation>Bagikan</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1412"/>
         <source>Re-encrypt all passwords</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang semua kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1417"/>
         <source>Export my public key...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor kunci publik saya…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1423"/>
         <source>Add recipient...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambah penerima…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1428"/>
         <source>What is this?</source>
-        <translation type="unfinished"></translation>
+        <translation>Apa ini?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation>Folder Baru: 
+(Akan ditempatkan di %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1478"/>
         <location filename="../src/mainwindow.cpp" line="1487"/>
         <location filename="../src/mainwindow.cpp" line="1696"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Galat</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
         <source>Failed to create folder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal membuat folder: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
         <source>Failed to create .gpg-id file in: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal membuat berkas .gpg-id di: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>
         <location filename="../src/mainwindow.cpp" line="1546"/>
         <source>Rename file</source>
-        <translation type="unfinished"></translation>
+        <translation>Ubah nama berkas</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>
         <source>Rename Folder To: </source>
-        <translation type="unfinished"></translation>
+        <translation>Ubah Nama Folder Menjadi: </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1546"/>
         <source>Rename File To: </source>
-        <translation type="unfinished"></translation>
+        <translation>Ubah Nama Berkas Menjadi: </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1697"/>
         <source>Directory does not exist: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Direktori tidak ada: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1702"/>
         <source>Re-encrypt passwords</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang kata sandi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1703"/>
@@ -1416,40 +1426,48 @@ This will re-encrypt ALL password files in this folder using the current recipie
 This may rewrite many files and cannot be undone easily.
 
 Continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi ulang semua kata sandi di %1?
+
+Ini akan mengenkripsi ulang SEMUA berkas kata sandi di folder ini menggunakan penerima saat ini yang didefinisikan di .gpg-id.
+
+Ini dapat menulis ulang banyak berkas dan tidak mudah dibatalkan.
+
+Lanjutkan?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1747"/>
         <location filename="../src/mainwindow.cpp" line="1767"/>
         <source>Export Public Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor Kunci Publik</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1748"/>
         <source>&lt;h3&gt;Export Your Public Key&lt;/h3&gt;&lt;p&gt;No signing key is configured. Set one in QtPass Settings &amp;gt; GPG keys, or run this in a terminal:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;your-key-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Then send the file to your teammates.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h3&gt;Ekspor Kunci Publik Anda&lt;/h3&gt;&lt;p&gt;Tidak ada kunci penandatangan yang dikonfigurasi. Atur satu di Pengaturan QtPass &amp;gt; Kunci GPG, atau jalankan ini di terminal:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;your-key-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Lalu kirim berkas tersebut ke rekan tim Anda.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1768"/>
         <source>Could not export public key for %1.
 
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat mengekspor kunci publik untuk %1.
+
+%2</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1770"/>
         <source>No output from gpg.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada keluaran dari gpg.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1797"/>
         <source>Sharing Passwords with GPG</source>
-        <translation type="unfinished"></translation>
+        <translation>Berbagi Kata Sandi dengan GPG</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1798"/>
         <source>&lt;h3&gt;Sharing Passwords with GPG&lt;/h3&gt;&lt;p&gt;To share passwords with other users:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;&lt;b&gt;Export your public key&lt;/b&gt; and send it to teammates&lt;/li&gt;&lt;li&gt;&lt;b&gt;Import teammates&apos; public keys&lt;/b&gt; into your GPG keyring&lt;/li&gt;&lt;li&gt;&lt;b&gt;Re-encrypt passwords&lt;/b&gt; so all recipients can decrypt them&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Only people who have a matching secret key can decrypt the passwords.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Tip:&lt;/b&gt; Use the same GPG key for all shared folders.&lt;/p&gt;&lt;p&gt;See the FAQ for more details.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h3&gt;Berbagi Kata Sandi dengan GPG&lt;/h3&gt;&lt;p&gt;Untuk berbagi kata sandi dengan pengguna lain:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;&lt;b&gt;Ekspor kunci publik Anda&lt;/b&gt; dan kirim ke rekan tim&lt;/li&gt;&lt;li&gt;&lt;b&gt;Impor kunci publik rekan tim&lt;/b&gt; ke keyring GPG Anda&lt;/li&gt;&lt;li&gt;&lt;b&gt;Enkripsi ulang kata sandi&lt;/b&gt; agar semua penerima dapat mendekripsinya&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Hanya orang dengan kunci rahasia yang cocok yang dapat mendekripsi kata sandi.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Tip:&lt;/b&gt; Gunakan kunci GPG yang sama untuk semua folder bersama.&lt;/p&gt;&lt;p&gt;Lihat FAQ untuk detail lebih lanjut.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -1457,46 +1475,46 @@ Continue?</source>
     <message>
         <location filename="../src/pass.cpp" line="158"/>
         <source>Invalid password length</source>
-        <translation type="unfinished"></translation>
+        <translation>Panjang kata sandi tidak valid</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="159"/>
         <source>Can&apos;t generate password with zero length.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membuat kata sandi dengan panjang nol.</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="202"/>
         <source>No characters chosen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada karakter yang dipilih</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="203"/>
         <source>Can&apos;t generate password, there are no characters to choose from set in the configuration!</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membuat kata sandi, tidak ada karakter yang dapat dipilih di konfigurasi!</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="546"/>
         <location filename="../src/pass.cpp" line="565"/>
         <source>Encryption failed: GPG key has expired. Please renew or replace it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi gagal: kunci GPG telah kedaluwarsa. Silakan perbarui atau ganti kunci.</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="551"/>
         <location filename="../src/pass.cpp" line="570"/>
         <source>Encryption failed: GPG key has been revoked.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi gagal: kunci GPG telah dicabut.</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="555"/>
         <location filename="../src/pass.cpp" line="575"/>
         <source>Encryption failed: recipient GPG key not found or invalid. Check that the key ID in .gpg-id is correct and imported.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi gagal: kunci GPG penerima tidak ditemukan atau tidak valid. Periksa bahwa ID kunci di .gpg-id benar dan telah diimpor.</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="559"/>
         <location filename="../src/pass.cpp" line="579"/>
         <source>Encryption failed. Check that your GPG key is valid.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkripsi gagal. Periksa bahwa kunci GPG Anda valid.</translation>
     </message>
 </context>
 <context>
@@ -1507,55 +1525,55 @@ Continue?</source>
         <location filename="../src/ui_passworddialog.h" line="174"/>
         <location filename="../src/ui_passworddialog.h" line="176"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Kata sandi</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="75"/>
         <location filename="../src/ui_passworddialog.h" line="177"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Buat</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="86"/>
         <location filename="../src/ui_passworddialog.h" line="178"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan kata sandi</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="106"/>
         <location filename="../src/ui_passworddialog.h" line="179"/>
         <source>Character Set:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kumpulan Karakter:</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="114"/>
         <location filename="../src/ui_passworddialog.h" line="180"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua Karakter</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="119"/>
         <location filename="../src/ui_passworddialog.h" line="181"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfabetis</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="124"/>
         <location filename="../src/ui_passworddialog.h" line="182"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfanumerik</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="129"/>
         <location filename="../src/ui_passworddialog.h" line="183"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustom</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="143"/>
         <location filename="../src/ui_passworddialog.h" line="185"/>
         <source>Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Panjang:</translation>
     </message>
 </context>
 <context>
@@ -1564,7 +1582,7 @@ Continue?</source>
         <location filename="../main/main.cpp" line="155"/>
         <location filename="../main/main.cpp" line="159"/>
         <source>LTR</source>
-        <translation type="unfinished"></translation>
+        <translation>LTR</translation>
     </message>
 </context>
 <context>
@@ -1572,90 +1590,93 @@ Continue?</source>
     <message>
         <location filename="../src/qtpass.cpp" line="160"/>
         <source>Generating GPG key pair</source>
-        <translation type="unfinished"></translation>
+        <translation>Membuat pasangan kunci GPG</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="223"/>
         <source>Failed to connect WebDAV:
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal terhubung ke WebDAV:
+</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="240"/>
         <source>QtPass WebDAV password</source>
-        <translation type="unfinished"></translation>
+        <translation>Kata sandi WebDAV QtPass</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="241"/>
         <source>Enter password to connect to WebDAV:</source>
-        <translation type="unfinished"></translation>
+        <translation>Masukkan kata sandi untuk terhubung ke WebDAV:</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="258"/>
         <source>fusedav exited unexpectedly
 </source>
-        <translation type="unfinished"></translation>
+        <translation>fusedav keluar secara tak terduga
+</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="262"/>
         <source>Failed to start fusedav to connect WebDAV:
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Gagal memulai fusedav untuk terhubung ke WebDAV:
+</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="275"/>
         <source>QProcess::FailedToStart</source>
-        <translation type="unfinished"></translation>
+        <translation>QProcess::FailedToStart</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="278"/>
         <source>QProcess::Crashed</source>
-        <translation type="unfinished"></translation>
+        <translation>QProcess::Crashed</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="281"/>
         <source>QProcess::Timedout</source>
-        <translation type="unfinished"></translation>
+        <translation>QProcess::Timedout</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="284"/>
         <source>QProcess::ReadError</source>
-        <translation type="unfinished"></translation>
+        <translation>QProcess::ReadError</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="287"/>
         <source>QProcess::WriteError</source>
-        <translation type="unfinished"></translation>
+        <translation>QProcess::WriteError</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="290"/>
         <source>QProcess::UnknownError</source>
-        <translation type="unfinished"></translation>
+        <translation>QProcess::UnknownError</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Pembuatan pasangan kunci GPG gagal</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>
         <source>GPG key pair generated successfully</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasangan kunci GPG berhasil dibuat</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="465"/>
         <source>Clipboard cleared</source>
-        <translation type="unfinished"></translation>
+        <translation>Clipboard dibersihkan</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="467"/>
         <source>Clipboard not cleared</source>
-        <translation type="unfinished"></translation>
+        <translation>Clipboard tidak dibersihkan</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="512"/>
         <source>Copied to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Disalin ke clipboard</translation>
     </message>
 </context>
 <context>
@@ -1663,12 +1684,12 @@ Continue?</source>
     <message>
         <location filename="../src/storemodel.cpp" line="411"/>
         <source>Force overwrite?</source>
-        <translation type="unfinished"></translation>
+        <translation>Paksa timpa?</translation>
     </message>
     <message>
         <location filename="../src/storemodel.cpp" line="412"/>
         <source>overwrite %1 with %2?</source>
-        <translation type="unfinished"></translation>
+        <translation>timpa %1 dengan %2?</translation>
     </message>
 </context>
 <context>
@@ -1676,32 +1697,32 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="67"/>
         <source>&amp;Show</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Tampilkan</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>
         <source>&amp;Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sembunyikan</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation type="unfinished"></translation>
+        <translation>Mi&amp;nimalkan</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation type="unfinished"></translation>
+        <translation>Ma&amp;ksimalkan</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Pulihkan</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>
         <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Keluar</translation>
     </message>
 </context>
 <context>
@@ -1710,7 +1731,7 @@ Continue?</source>
         <location filename="../src/usersdialog.ui" line="20"/>
         <location filename="../src/ui_usersdialog.h" line="111"/>
         <source>Read access users</source>
-        <translation type="unfinished"></translation>
+        <translation>Pengguna dengan akses baca</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="45"/>
@@ -1720,71 +1741,75 @@ Note: Existing files will not be modified, and retain the old permissions until 
 Blue entries have a secret key available, select one of these to be able to decrypt.
 Black entries have an encryption key available and it is trusted, select one of these to allow other people to decrypt.
 Red entries are not valid, you will not be able to encrypt to these.</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih pengguna mana yang dapat mendekripsi kata sandi yang disimpan di folder ini.
+Catatan: berkas yang sudah ada tidak akan diubah, dan tetap memiliki izin lama sampai Anda mengeditnya.
+Entri biru memiliki kunci rahasia yang tersedia, pilih salah satu agar dapat mendekripsi.
+Entri hitam memiliki kunci enkripsi yang tersedia dan dipercaya, pilih salah satu agar orang lain dapat mendekripsi.
+Entri merah tidak valid, Anda tidak akan dapat mengenkripsi ke entri ini.</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="70"/>
         <location filename="../src/ui_usersdialog.h" line="117"/>
         <source>Search for users</source>
-        <translation type="unfinished"></translation>
+        <translation>Cari pengguna</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="77"/>
         <location filename="../src/ui_usersdialog.h" line="118"/>
         <source>Show unusable keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan kunci yang tidak dapat digunakan</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="84"/>
         <location filename="../src/ui_usersdialog.h" line="119"/>
         <source>Import key...</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor kunci…</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="87"/>
         <location filename="../src/ui_usersdialog.h" line="121"/>
         <source>Import a GPG key from file or clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor kunci GPG dari berkas atau clipboard</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="76"/>
         <source>Keylist missing</source>
-        <translation type="unfinished"></translation>
+        <translation>Daftar kunci hilang</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="77"/>
         <source>Could not fetch list of available GPG keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat mengambil daftar kunci GPG yang tersedia</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="153"/>
         <source>Key not found in keyring</source>
-        <translation type="unfinished"></translation>
+        <translation>Kunci tidak ditemukan di keyring</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="306"/>
         <source>created</source>
-        <translation type="unfinished"></translation>
+        <translation>dibuat</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="310"/>
         <source>expires</source>
-        <translation type="unfinished"></translation>
+        <translation>kedaluwarsa</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="333"/>
         <source>[INVALID] </source>
-        <translation type="unfinished"></translation>
+        <translation>[TIDAK VALID] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="336"/>
         <source>[EXPIRED] </source>
-        <translation type="unfinished"></translation>
+        <translation>[KEDALUWARSA] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="340"/>
         <source>[PARTIAL] </source>
-        <translation type="unfinished"></translation>
+        <translation>[PARSIAL] </translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Ringkasan / Summary

The Indonesian locale (\`id_ID\`) was bootstrapped in [#1201](https://github.com/IJHack/QtPass/pull/1201) but stayed at 2/304 translated — essentially empty. This PR fills all 302 unfinished entries with natural-Indonesian software UI strings.

## Translation conventions

| Concept | Indonesian |
| --- | --- |
| Register | neutral / imperative; \`Anda\` only where source clearly addresses the user |
| file | \`berkas\` |
| folder | \`folder\` (kept as loanword) |
| password | \`kata sandi\` |
| public / private key | \`kunci publik\` / \`kunci privat\` |
| encryption / decryption | \`enkripsi\` / \`dekripsi\` |
| Save / Open / Cancel / Delete / Add | \`Simpan / Buka / Batal / Hapus / Tambah\` |
| Import / Export | \`Impor / Ekspor\` |
| Share / Recipient | \`Bagikan / Penerima\` |
| Clipboard | \`clipboard\` (loanword — more common in modern Indonesian software UI than \`papan klip\`) |

Technical terms kept literal: \`GPG\`, \`ASCII-armored\`, \`OTP\`, \`regex\`, \`WebDAV\`, \`PWGen\`, \`fusedav\`, \`QRencode\`, \`.gpg-id\`, \`push\`, \`pull\`, \`OK\`, \`Ctrl+G\`, \`Ctrl+N\`, \`LTR\`, the \`Aa\` case-insensitive toggle, etc.

**Numerus forms:** Indonesian doesn't grammatically distinguish singular vs plural, so the \`<numerusform>\` block has a single entry (Qt's \`<TS language="id_ID">\` plural rule) — \"Found %n match(es)\" → \"Ditemukan %n kecocokan\", \"in %n entr(ies).\" → \"di %n entri.\".

## Coverage

Multi-line / long-HTML translations covered:

- ConfigDialog + KeygenDialog + UsersDialog walkthrough strings
- Three \`GnuPG not found\` install prompts (gpg / Ubuntu-Microsoft-Store variants)
- Passphrase-strength explanation HTML
- QtPass welcome HTML (passwordstore.org / Issues / Documentation / Source code)
- Sharing-help and Export-Public-Key-help blocks (matching the v1.8.0 feature work)
- Re-encrypt confirmation prompt
- WebDAV connection error messages

A few strings stayed as-is because they're identical in any locale: brand names (\`QtPass / GPG / PWGen / Pass\`), keyboard shortcuts, the \`⌕\` / \`Aa\` UI glyphs.

## Test plan

- [x] \`make distclean && qmake6 && make -j4\` — clean build
- [x] \`make check\` — 12/12 suites green
- [x] Completeness: \`done=304 unfinished=0\`
- [x] lrelease accepts the .ts (no missing-placeholder errors on \`%1\`/\`%2\` strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Indonesian language translations across the application, including UI elements, dialogs, status messages, and error notifications. Users will now see fully translated content instead of incomplete translation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->