### PR TITLE
i18n(fr_BE, fr_LU): fix translation bugs (Alphabetic untranslated, register inconsistencies)

### DIFF
--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -425,7 +425,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <source>Alphabetical</source>
-        <translation>Alphabetic</translation>
+        <translation>Alphabétique</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
@@ -488,7 +488,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
         <source>Use PWGen</source>
-        <translation>Utilisez PWGen</translation>
+        <translation>Utiliser PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
@@ -725,7 +725,7 @@ Vous ne serez pas en mesure de déchiffrer les mots de passe nouvellement ajout�
         <location filename="../src/imitatepass.cpp" line="662"/>
         <location filename="../src/imitatepass.cpp" line="769"/>
         <source>Re-encryption failed</source>
-        <translation>Réencryptage a échoué</translation>
+        <translation>Le re-chiffrement a échoué</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
@@ -746,7 +746,7 @@ Vous ne serez pas en mesure de déchiffrer les mots de passe nouvellement ajout�
     <message>
         <location filename="../src/imitatepass.cpp" line="699"/>
         <source>Could not inspect git status. Re-encryption was aborted.</source>
-        <translation>Il n&apos;a pas pu inspecter l&apos;état du git. Le chiffrement a été annulé.</translation>
+        <translation>Impossible d&apos;inspecter l&apos;état du git. Le re-chiffrement a été annulé.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="707"/>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -425,7 +425,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <source>Alphabetical</source>
-        <translation>Alphabetic</translation>
+        <translation>Alphabétique</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
@@ -746,7 +746,7 @@ Vous ne serez pas en mesure de déchiffrer les mots de passe nouvellement ajout�
     <message>
         <location filename="../src/imitatepass.cpp" line="699"/>
         <source>Could not inspect git status. Re-encryption was aborted.</source>
-        <translation>Il n&apos;a pas pu inspecter l&apos;état du git. Le chiffrement a été annulé.</translation>
+        <translation>Impossible d&apos;inspecter l&apos;état du git. Le re-chiffrement a été annulé.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="707"/>


### PR DESCRIPTION
## Summary

Honest answer to "what about the Frenches?": **French software UI doesn't have crisp regional register splits the way Spanish (formal usted / voseo / tú) and Dutch (je / u) do**. The three French locales already differ by 326–334 lines from Weblate translator-preference variations (e.g. "monoespace" vs "monospacée", "Pas de retour à la ligne" vs "Aucune rupture de ligne"). I'm not going to manufacture artificial distinctions.

What the diff did reveal is a handful of actual translation **bugs** in fr_BE and fr_LU. Fixing those:

### fr_BE + fr_LU

- **"Alphabetic"** — the source string "Alphabetical" was rendered as the untranslated English word in both locales. Now \`Alphabétique\`.
- **\`Il n'a pas pu inspecter l'état du git\`** — wrong subject (\`Il\` = "he") for an impersonal error message, and the second clause dropped the \`Re-\` prefix from "encryption". Now \`Impossible d'inspecter l'état du git. Le re-chiffrement a été annulé.\`

### fr_BE only

- **"Utilisez PWGen"** — formal imperative where surrounding settings labels (and the fr_LU sibling) use the infinitive. Now \`Utiliser PWGen\`.
- **"Réencryptage a échoué"** — odd noun + missing article. Now \`Le re-chiffrement a échoué\` matching the standard French "chiffrement" terminology used elsewhere in the file.

## On regional differentiation

Unlike Spanish or Dutch where I added clean axes (vocabulary + register), French software UI doesn't lend itself to that:
- French numbers (septante / nonante) are **the** classic BE/LU vs FR marker, but they don't appear in QtPass strings.
- "courriel" vs "e-mail" — already aligned across all three (each uses "courriel" 3 times).
- Punctuation (non-breaking spaces) is consistent.
- Both BE/LU and FR use formal imperatives in software UI.

The 326–334 lines of natural Weblate-driven divergence are enough; this PR fixes quality, not artificially differentiates.

## Test plan

- [x] \`make distclean && qmake6 && make -j4\` — clean build
- [x] \`make check\` — 12/12 suites green
- [x] No new differences between fr_BE/fr_LU on shared bug-fixes; the few extra lines vs fr_FR remain Weblate translator-preference territory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved French (Belgian and Luxembourgish) translations for password operations and character-set options.
  * Enhanced error message clarity and grammatical accuracy in French localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->