### PR TITLE
ci: add biome.json so AI reviewers ignore Qt Linguist .ts files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "files": {
+    "includes": ["**", "!localization/**"]
+  }
+}


### PR DESCRIPTION
## Summary

Some AI review plugins run Biome and try to parse `localization/*.ts` as TypeScript, since both share the `.ts` extension. Those files are XML (Qt Linguist), so every translation entry trips a syntax error and the bot ends up filing a stream of false-positive findings about \"the Biome TypeScript parser failing to parse XML\".

Add a minimal `biome.json` that excludes `localization/**` from Biome's file set:

```json
{
  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
  "files": {
    "includes": ["**", "!localization/**"]
  }
}
```

The repo has no JS/TS source code, so this config only affects what Biome scans — it doesn't change anything about the build or what ships.

## Test plan

- [x] `biome.json` is valid JSON
- [ ] Next AI review on a localization-only PR no longer reports Biome/TypeScript parse errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling configuration to enforce consistent standards across the project, with localization files excluded from processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->