### PR TITLE
i18n(fi_FI): correct Finnish Rename + Exclude verb forms

### DIFF
--- a/localization/localization_fi_FI.ts
+++ b/localization/localization_fi_FI.ts
@@ -199,7 +199,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
         <source>Exclude numbers</source>
-        <translation>Poissulje numerot</translation>
+        <translation>Poissulkea numerot</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="493"/>
@@ -1452,12 +1452,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1386"/>
         <source>Rename folder</source>
-        <translation>Uudelleennimeä kansio</translation>
+        <translation>Nimeä kansio uudelleen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1390"/>
         <source>Rename password</source>
-        <translation>Uudelleennimeä salasana</translation>
+        <translation>Nimeä salasana uudelleen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>
@@ -1544,17 +1544,17 @@ p, li { white-space: pre-wrap; }
         <location filename="../src/mainwindow.cpp" line="1510"/>
         <location filename="../src/mainwindow.cpp" line="1546"/>
         <source>Rename file</source>
-        <translation>Uudelleennimeä tiedosto</translation>
+        <translation>Nimeä tiedosto uudelleen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>
         <source>Rename Folder To: </source>
-        <translation>Uudelleennimeä kansio seuraavaksi: </translation>
+        <translation>Nimeä kansio uudelleen seuraavaksi: </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1546"/>
         <source>Rename File To: </source>
-        <translation>Uudelleennimeä tiedosto seuraavaksi: </translation>
+        <translation>Nimeä tiedosto uudelleen seuraavaksi: </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1697"/>


### PR DESCRIPTION
## Summary

Fixes 4 reviewer findings on Finnish (fi_FI) translations, plus 2 related strings with the same pattern that the reviewer didn't flag but have the identical issue.

- **Exclude numbers**: \`Poissulje numerot\` → \`Poissulkea numerot\` (imperative was wrong; needs the noun form here).
- **Rename folder/password/file**: \`Uudelleennimeä X\` → \`Nimeä X uudelleen\`. Finnish doesn't form a single compound verb here; the natural form is the split phrase.
- **Rename Folder/File To**: same correction applied to the two \`...seuraavaksi\` variants (lines 1552, 1557) for consistency.

\`lrelease6\` reports 304 finished / 0 unfinished, no warnings.

## Test plan

- [x] CI lint passes
- [ ] Native Finnish speaker review (Weblate / native contributor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced Finnish translations for improved clarity and consistency across the interface, including updates to exclusion prompts and rename operation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->