### PR TITLE
i18n(sq_AL): translate verbatim-English strings flagged in review

### DIFF
--- a/localization/localization_sq_AL.ts
+++ b/localization/localization_sq_AL.ts
@@ -166,12 +166,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
         <source>Automatically push</source>
-        <translation>Automatically push</translation>
+        <translation>Shty automatikisht</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="533"/>
         <source>Automatically pull</source>
-        <translation>Automatically pull</translation>
+        <translation>Tërhiq automatikisht</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>
@@ -231,7 +231,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <source>Native</source>
-        <translation>Native</translation>
+        <translation>Vendase</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="776"/>
@@ -281,7 +281,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
         <source>Path</source>
-        <translation>Path</translation>
+        <translation>Shtegu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
@@ -493,7 +493,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Native Git/GPG</translation>
+        <translation>Natyral Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -1049,7 +1049,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.ui" line="425"/>
         <source>Push</source>
-        <translation>Push</translation>
+        <translation>Shty</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`localization_sq_AL.ts\` where the Albanian translation was the English source verbatim. Plus the standalone \`Push\` button (line 1051) for consistency with the now-translated \`Automatically push\`.

| Source | Was | Now |
|---|---|---|
| Automatically push | \`Automatically push\` | Shty automatikisht |
| Automatically pull | \`Automatically pull\` | Tërhiq automatikisht |
| Native | \`Native\` | Vendase |
| Path | \`Path\` | Shtegu |
| Nati&ve Git/GPG | \`Native Git/GPG\` | Natyral Git/GPG |
| Push | \`Push\` | Shty *(consistency with Shty automatikisht)* |

Other verbatim-English strings still in the file (system-tray Mi/Maximize/Restore/Quit, Email, …) were left alone — those need native-speaker review.

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

## Test plan

- [ ] CI lint passes
- [ ] Native Albanian speaker review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Albanian language translations for user interface elements, replacing English text with proper Albanian translations for push, pull, native, and path operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->