### PR TITLE
i18n: partial pass on lt_LT, lv_LV, sl_SI, si_LK

### DIFF
--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -7,31 +7,31 @@
         <location filename="../src/configdialog.ui" line="20"/>
         <location filename="../src/ui_configdialog.h" line="897"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfigūracija</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="46"/>
         <location filename="../src/ui_configdialog.h" line="946"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Nustatymai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="72"/>
         <location filename="../src/ui_configdialog.h" line="898"/>
         <source>Clipboard behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Iškarpinės veikimas:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
         <location filename="../src/ui_configdialog.h" line="899"/>
         <source>Use primary selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti pirminį pasirinkimą</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="98"/>
         <location filename="../src/ui_configdialog.h" line="900"/>
         <source>Autoclear after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatiškai išvalyti po:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="115"/>
@@ -39,109 +39,109 @@
         <location filename="../src/ui_configdialog.h" line="901"/>
         <location filename="../src/ui_configdialog.h" line="906"/>
         <source>Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Sekundės</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
         <location filename="../src/ui_configdialog.h" line="902"/>
         <source>Content panel behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Turinio skydelio veikimas:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="159"/>
         <location filename="../src/ui_configdialog.h" line="903"/>
         <source>Hide content</source>
-        <translation type="unfinished"></translation>
+        <translation>Slėpti turinį</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="166"/>
         <location filename="../src/ui_configdialog.h" line="904"/>
         <source>Hide password</source>
-        <translation type="unfinished"></translation>
+        <translation>Slėpti slaptažodį</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <location filename="../src/ui_configdialog.h" line="905"/>
         <source>Autoclear panel after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatiškai išvalyti skydelį po:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <location filename="../src/ui_configdialog.h" line="907"/>
         <source>Use a monospace font</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti vienodo pločio šriftą</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
         <location filename="../src/ui_configdialog.h" line="908"/>
         <source>Display the files content as-is</source>
-        <translation type="unfinished"></translation>
+        <translation>Rodyti failo turinį kaip yra</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="238"/>
         <location filename="../src/ui_configdialog.h" line="909"/>
         <source>No line wrapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Be eilučių laužymo</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="245"/>
         <location filename="../src/ui_configdialog.h" line="910"/>
         <source>Show process output</source>
-        <translation type="unfinished"></translation>
+        <translation>Rodyti proceso išvestį</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="277"/>
         <location filename="../src/ui_configdialog.h" line="911"/>
         <source>Password Generation:</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaptažodžio generavimas:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="289"/>
         <location filename="../src/ui_configdialog.h" line="912"/>
         <source>Password Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaptažodžio ilgis:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="323"/>
         <location filename="../src/ui_configdialog.h" line="913"/>
         <source>Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Simboliai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="351"/>
         <location filename="../src/ui_configdialog.h" line="914"/>
         <source>Use characters:</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti simbolius:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="369"/>
         <location filename="../src/ui_configdialog.h" line="921"/>
         <source>Select character set for password generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasirinkti simbolių rinkinį slaptažodžio generavimui</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="373"/>
         <location filename="../src/ui_configdialog.h" line="915"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Visi simboliai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <location filename="../src/ui_configdialog.h" line="916"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Abėcėliniai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
         <location filename="../src/ui_configdialog.h" line="917"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Raidiniai-skaitiniai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="388"/>
         <location filename="../src/ui_configdialog.h" line="918"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasirinktinis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
@@ -153,31 +153,31 @@
         <location filename="../src/configdialog.ui" line="443"/>
         <location filename="../src/ui_configdialog.h" line="924"/>
         <source>Use PWGen</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <location filename="../src/ui_configdialog.h" line="925"/>
         <source>Exclude capital letters</source>
-        <translation type="unfinished"></translation>
+        <translation>Neįtraukti didžiųjų raidžių</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
         <location filename="../src/ui_configdialog.h" line="926"/>
         <source>Include special symbols</source>
-        <translation type="unfinished"></translation>
+        <translation>Įtraukti specialius simbolius</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <location filename="../src/ui_configdialog.h" line="927"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation type="unfinished"></translation>
+        <translation>Generuoti lengvai įsimenamus, bet mažiau saugius slaptažodžius</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
         <location filename="../src/ui_configdialog.h" line="928"/>
         <source>Exclude numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Neįtraukti skaitmenų</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="493"/>
@@ -189,49 +189,49 @@
         <location filename="../src/configdialog.ui" line="505"/>
         <location filename="../src/ui_configdialog.h" line="930"/>
         <source>Use Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti Git</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="519"/>
         <location filename="../src/ui_configdialog.h" line="931"/>
         <source>Automatically add .gpg-id files</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatiškai pridėti .gpg-id failus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
         <location filename="../src/ui_configdialog.h" line="932"/>
         <source>Automatically push</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatiškai siųsti (push)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="533"/>
         <location filename="../src/ui_configdialog.h" line="933"/>
         <source>Automatically pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatiškai gauti (pull)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>
         <location filename="../src/ui_configdialog.h" line="934"/>
         <source>Extensions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Plėtiniai:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
         <location filename="../src/ui_configdialog.h" line="935"/>
         <source>Use QRencode</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti QRencode</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
         <location filename="../src/ui_configdialog.h" line="936"/>
         <source>Use pass-otp extension</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti pass-otp plėtinį</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="599"/>
         <location filename="../src/ui_configdialog.h" line="937"/>
         <source>Enable content search (pass grep)</source>
-        <translation type="unfinished"></translation>
+        <translation>Įjungti turinio paiešką (pass grep)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
@@ -243,61 +243,61 @@
         <location filename="../src/configdialog.ui" line="624"/>
         <location filename="../src/ui_configdialog.h" line="941"/>
         <source>System:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistema:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <location filename="../src/ui_configdialog.h" line="942"/>
         <source>Use TrayIcon</source>
-        <translation type="unfinished"></translation>
+        <translation>Naudoti dėklo piktogramą</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
         <location filename="../src/ui_configdialog.h" line="943"/>
         <source>Start minimized</source>
-        <translation type="unfinished"></translation>
+        <translation>Paleisti sumažinta</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <location filename="../src/ui_configdialog.h" line="944"/>
         <source>Hide on close</source>
-        <translation type="unfinished"></translation>
+        <translation>Slėpti uždarant</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>
         <location filename="../src/ui_configdialog.h" line="945"/>
         <source>Always on top</source>
-        <translation type="unfinished"></translation>
+        <translation>Visada viršuje</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="682"/>
         <location filename="../src/ui_configdialog.h" line="966"/>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Programos</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="700"/>
         <location filename="../src/ui_configdialog.h" line="947"/>
         <source>Select password storage program:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasirinkti slaptažodžių saugojimo programą:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <location filename="../src/ui_configdialog.h" line="948"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Vietinis Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <location filename="../src/ui_configdialog.h" line="949"/>
         <source>&amp;Use pass</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Naudoti pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <location filename="../src/ui_configdialog.h" line="950"/>
         <source>Native</source>
-        <translation type="unfinished"></translation>
+        <translation>Vietinis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -323,7 +323,7 @@
         <location filename="../src/configdialog.ui" line="776"/>
         <location filename="../src/ui_configdialog.h" line="954"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Generuoti</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
@@ -371,13 +371,13 @@
         <location filename="../src/configdialog.ui" line="900"/>
         <location filename="../src/ui_configdialog.h" line="986"/>
         <source>Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>Profiliai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="949"/>
         <location filename="../src/ui_configdialog.h" line="968"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Vardas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="952"/>
@@ -389,7 +389,7 @@
         <location filename="../src/configdialog.ui" line="957"/>
         <location filename="../src/ui_configdialog.h" line="973"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Kelias</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
@@ -413,13 +413,13 @@
         <location filename="../src/configdialog.ui" line="978"/>
         <location filename="../src/ui_configdialog.h" line="982"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Pridėti</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="993"/>
         <location filename="../src/ui_configdialog.h" line="983"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Ištrinti</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
@@ -431,7 +431,7 @@
         <location filename="../src/configdialog.ui" line="1028"/>
         <location filename="../src/ui_configdialog.h" line="996"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Šablonas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1049"/>
@@ -521,7 +521,7 @@ e-mail</source>
         <location filename="../src/configdialog.cpp" line="728"/>
         <location filename="../src/configdialog.cpp" line="985"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Klaida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>
@@ -546,7 +546,7 @@ e-mail</source>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>
         <source>No profile selected to delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepasirinktas profilis ištrinimui</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
@@ -586,7 +586,7 @@ e-mail</source>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaptažodžių saugykla neinicializuota</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
@@ -643,7 +643,7 @@ e-mail</source>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="67"/>
         <source>Copied!</source>
-        <translation type="unfinished"></translation>
+        <translation>Nukopijuota!</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="83"/>
@@ -699,7 +699,7 @@ e-mail</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepavyko atnaujinti</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
@@ -814,7 +814,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.cpp" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="120"/>
         <source>Import GPG Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Importuoti GPG raktą</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="27"/>
@@ -826,13 +826,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.ui" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="122"/>
         <source>From File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Iš failo...</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="49"/>
         <location filename="../src/ui_importkeydialog.h" line="123"/>
         <source>From Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Iš iškarpinės</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="71"/>
@@ -844,7 +844,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.ui" line="93"/>
         <location filename="../src/ui_importkeydialog.h" line="125"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importuoti</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
@@ -854,7 +854,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
         <source>All Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Visi failai</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="51"/>
@@ -897,7 +897,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="14"/>
         <location filename="../src/ui_keygendialog.h" line="230"/>
         <source>Generate GnuPG keypair</source>
-        <translation type="unfinished"></translation>
+        <translation>Generuoti GnuPG raktų porą</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
@@ -909,13 +909,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="91"/>
         <location filename="../src/ui_keygendialog.h" line="232"/>
         <source>Email</source>
-        <translation type="unfinished"></translation>
+        <translation>El. paštas</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="123"/>
         <location filename="../src/ui_keygendialog.h" line="233"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Vardas</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="155"/>
@@ -939,7 +939,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="227"/>
         <location filename="../src/ui_keygendialog.h" line="237"/>
         <source>Expert</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspertas</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="246"/>
@@ -999,7 +999,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="883"/>
         <location filename="../src/ui_mainwindow.h" line="352"/>
         <source>Search Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Ieškoti slaptažodžio</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="127"/>
@@ -1035,7 +1035,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="149"/>
         <location filename="../src/ui_mainwindow.h" line="366"/>
         <source>Aa</source>
-        <translation type="unfinished"></translation>
+        <translation>Aa</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="152"/>
@@ -1053,7 +1053,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="211"/>
         <location filename="../src/ui_mainwindow.h" line="374"/>
         <source>Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Rezultatai</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="263"/>
@@ -1101,7 +1101,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="319"/>
         <location filename="../src/ui_mainwindow.h" line="321"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Redaguoti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="406"/>
@@ -1110,7 +1110,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="323"/>
         <location filename="../src/ui_mainwindow.h" line="325"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Ištrinti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="414"/>
@@ -1134,32 +1134,32 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="425"/>
         <location filename="../src/ui_mainwindow.h" line="334"/>
         <source>Push</source>
-        <translation type="unfinished"></translation>
+        <translation>Siųsti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>
         <location filename="../src/ui_mainwindow.h" line="336"/>
         <source>Git push</source>
-        <translation type="unfinished"></translation>
+        <translation>Git siuntimas</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="433"/>
         <location filename="../src/ui_mainwindow.h" line="338"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Atnaujinti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="436"/>
         <location filename="../src/ui_mainwindow.h" line="340"/>
         <source>Git pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Git gavimas</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="441"/>
         <location filename="../src/mainwindow.cpp" line="1374"/>
         <location filename="../src/ui_mainwindow.h" line="342"/>
         <source>Users</source>
-        <translation type="unfinished"></translation>
+        <translation>Vartotojai</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="444"/>
@@ -1171,13 +1171,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="449"/>
         <location filename="../src/ui_mainwindow.h" line="346"/>
         <source>Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfig.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
         <location filename="../src/ui_mainwindow.h" line="348"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfigūracija</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="293"/>
@@ -1187,7 +1187,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="322"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Išvalyti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="323"/>
@@ -1215,7 +1215,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="629"/>
         <location filename="../src/mainwindow.cpp" line="1641"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaptažodis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="666"/>
@@ -1245,7 +1245,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>
         <source>Searching…</source>
-        <translation type="unfinished"></translation>
+        <translation>Ieškoma…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="865"/>
@@ -1279,7 +1279,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1036"/>
         <location filename="../src/mainwindow.cpp" line="1467"/>
         <source>New file</source>
-        <translation type="unfinished"></translation>
+        <translation>Naujas failas</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
@@ -1340,7 +1340,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>
         <source>Share</source>
-        <translation type="unfinished"></translation>
+        <translation>Bendrinti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1412"/>
@@ -1373,7 +1373,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1487"/>
         <location filename="../src/mainwindow.cpp" line="1696"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Klaida</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
@@ -1511,13 +1511,13 @@ Continue?</source>
         <location filename="../src/ui_passworddialog.h" line="174"/>
         <location filename="../src/ui_passworddialog.h" line="176"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaptažodis</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="75"/>
         <location filename="../src/ui_passworddialog.h" line="177"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Generuoti</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="86"/>
@@ -1535,31 +1535,31 @@ Continue?</source>
         <location filename="../src/passworddialog.ui" line="114"/>
         <location filename="../src/ui_passworddialog.h" line="180"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Visi simboliai</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="119"/>
         <location filename="../src/ui_passworddialog.h" line="181"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Abėcėliniai</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="124"/>
         <location filename="../src/ui_passworddialog.h" line="182"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Raidiniai-skaitiniai</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="129"/>
         <location filename="../src/ui_passworddialog.h" line="183"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasirinktinis</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="143"/>
         <location filename="../src/ui_passworddialog.h" line="185"/>
         <source>Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ilgis:</translation>
     </message>
 </context>
 <context>
@@ -1680,32 +1680,32 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="67"/>
         <source>&amp;Show</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Rodyti</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>
         <source>&amp;Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Slėpti</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation type="unfinished"></translation>
+        <translation>Su&amp;mažinti</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation type="unfinished"></translation>
+        <translation>Pa&amp;didinti</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Atkurti</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>
         <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Uždaryti</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -7,31 +7,31 @@
         <location filename="../src/configdialog.ui" line="20"/>
         <location filename="../src/ui_configdialog.h" line="897"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfigurācija</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="46"/>
         <location filename="../src/ui_configdialog.h" line="946"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatījumi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="72"/>
         <location filename="../src/ui_configdialog.h" line="898"/>
         <source>Clipboard behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Starpliktuves uzvedība:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
         <location filename="../src/ui_configdialog.h" line="899"/>
         <source>Use primary selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot primāro atlasi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="98"/>
         <location filename="../src/ui_configdialog.h" line="900"/>
         <source>Autoclear after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Automātiski notīrīt pēc:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="115"/>
@@ -39,109 +39,109 @@
         <location filename="../src/ui_configdialog.h" line="901"/>
         <location filename="../src/ui_configdialog.h" line="906"/>
         <source>Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Sekundes</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
         <location filename="../src/ui_configdialog.h" line="902"/>
         <source>Content panel behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Satura paneļa uzvedība:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="159"/>
         <location filename="../src/ui_configdialog.h" line="903"/>
         <source>Hide content</source>
-        <translation type="unfinished"></translation>
+        <translation>Slēpt saturu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="166"/>
         <location filename="../src/ui_configdialog.h" line="904"/>
         <source>Hide password</source>
-        <translation type="unfinished"></translation>
+        <translation>Slēpt paroli</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <location filename="../src/ui_configdialog.h" line="905"/>
         <source>Autoclear panel after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Automātiski notīrīt paneli pēc:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <location filename="../src/ui_configdialog.h" line="907"/>
         <source>Use a monospace font</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot vienplatuma fontu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
         <location filename="../src/ui_configdialog.h" line="908"/>
         <source>Display the files content as-is</source>
-        <translation type="unfinished"></translation>
+        <translation>Attēlot faila saturu, kāds tas ir</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="238"/>
         <location filename="../src/ui_configdialog.h" line="909"/>
         <source>No line wrapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Bez rindu pārnešanas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="245"/>
         <location filename="../src/ui_configdialog.h" line="910"/>
         <source>Show process output</source>
-        <translation type="unfinished"></translation>
+        <translation>Rādīt procesa izvadi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="277"/>
         <location filename="../src/ui_configdialog.h" line="911"/>
         <source>Password Generation:</source>
-        <translation type="unfinished"></translation>
+        <translation>Paroles ģenerēšana:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="289"/>
         <location filename="../src/ui_configdialog.h" line="912"/>
         <source>Password Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Paroles garums:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="323"/>
         <location filename="../src/ui_configdialog.h" line="913"/>
         <source>Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Rakstzīmes</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="351"/>
         <location filename="../src/ui_configdialog.h" line="914"/>
         <source>Use characters:</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot rakstzīmes:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="369"/>
         <location filename="../src/ui_configdialog.h" line="921"/>
         <source>Select character set for password generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Atlasīt rakstzīmju kopu paroles ģenerēšanai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="373"/>
         <location filename="../src/ui_configdialog.h" line="915"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Visas rakstzīmes</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <location filename="../src/ui_configdialog.h" line="916"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfabētiski</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
         <location filename="../src/ui_configdialog.h" line="917"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Burtciparu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="388"/>
         <location filename="../src/ui_configdialog.h" line="918"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Pielāgots</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
@@ -153,31 +153,31 @@
         <location filename="../src/configdialog.ui" line="443"/>
         <location filename="../src/ui_configdialog.h" line="924"/>
         <source>Use PWGen</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <location filename="../src/ui_configdialog.h" line="925"/>
         <source>Exclude capital letters</source>
-        <translation type="unfinished"></translation>
+        <translation>Neiekļaut lielos burtus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
         <location filename="../src/ui_configdialog.h" line="926"/>
         <source>Include special symbols</source>
-        <translation type="unfinished"></translation>
+        <translation>Iekļaut īpašās rakstzīmes</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <location filename="../src/ui_configdialog.h" line="927"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation type="unfinished"></translation>
+        <translation>Ģenerēt viegli iegaumējamas, bet mazāk drošas paroles</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
         <location filename="../src/ui_configdialog.h" line="928"/>
         <source>Exclude numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Neiekļaut ciparus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="493"/>
@@ -189,49 +189,49 @@
         <location filename="../src/configdialog.ui" line="505"/>
         <location filename="../src/ui_configdialog.h" line="930"/>
         <source>Use Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot Git</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="519"/>
         <location filename="../src/ui_configdialog.h" line="931"/>
         <source>Automatically add .gpg-id files</source>
-        <translation type="unfinished"></translation>
+        <translation>Automātiski pievienot .gpg-id failus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
         <location filename="../src/ui_configdialog.h" line="932"/>
         <source>Automatically push</source>
-        <translation type="unfinished"></translation>
+        <translation>Automātiski nosūtīt (push)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="533"/>
         <location filename="../src/ui_configdialog.h" line="933"/>
         <source>Automatically pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Automātiski saņemt (pull)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>
         <location filename="../src/ui_configdialog.h" line="934"/>
         <source>Extensions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Paplašinājumi:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
         <location filename="../src/ui_configdialog.h" line="935"/>
         <source>Use QRencode</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot QRencode</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
         <location filename="../src/ui_configdialog.h" line="936"/>
         <source>Use pass-otp extension</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot pass-otp paplašinājumu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="599"/>
         <location filename="../src/ui_configdialog.h" line="937"/>
         <source>Enable content search (pass grep)</source>
-        <translation type="unfinished"></translation>
+        <translation>Iespējot satura meklēšanu (pass grep)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
@@ -243,61 +243,61 @@
         <location filename="../src/configdialog.ui" line="624"/>
         <location filename="../src/ui_configdialog.h" line="941"/>
         <source>System:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistēma:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <location filename="../src/ui_configdialog.h" line="942"/>
         <source>Use TrayIcon</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietot paplātes ikonu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
         <location filename="../src/ui_configdialog.h" line="943"/>
         <source>Start minimized</source>
-        <translation type="unfinished"></translation>
+        <translation>Sākt minimizētu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <location filename="../src/ui_configdialog.h" line="944"/>
         <source>Hide on close</source>
-        <translation type="unfinished"></translation>
+        <translation>Slēpt aizverot</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>
         <location filename="../src/ui_configdialog.h" line="945"/>
         <source>Always on top</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienmēr augšpusē</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="682"/>
         <location filename="../src/ui_configdialog.h" line="966"/>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Programmas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="700"/>
         <location filename="../src/ui_configdialog.h" line="947"/>
         <source>Select password storage program:</source>
-        <translation type="unfinished"></translation>
+        <translation>Atlasiet paroļu glabāšanas programmu:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <location filename="../src/ui_configdialog.h" line="948"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Vietējs Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <location filename="../src/ui_configdialog.h" line="949"/>
         <source>&amp;Use pass</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Lietot pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <location filename="../src/ui_configdialog.h" line="950"/>
         <source>Native</source>
-        <translation type="unfinished"></translation>
+        <translation>Vietējais</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -323,7 +323,7 @@
         <location filename="../src/configdialog.ui" line="776"/>
         <location filename="../src/ui_configdialog.h" line="954"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Ģenerēt</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
@@ -371,13 +371,13 @@
         <location filename="../src/configdialog.ui" line="900"/>
         <location filename="../src/ui_configdialog.h" line="986"/>
         <source>Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>Profili</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="949"/>
         <location filename="../src/ui_configdialog.h" line="968"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Vārds</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="952"/>
@@ -389,7 +389,7 @@
         <location filename="../src/configdialog.ui" line="957"/>
         <location filename="../src/ui_configdialog.h" line="973"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Ceļš</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
@@ -413,13 +413,13 @@
         <location filename="../src/configdialog.ui" line="978"/>
         <location filename="../src/ui_configdialog.h" line="982"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="993"/>
         <location filename="../src/ui_configdialog.h" line="983"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
@@ -431,7 +431,7 @@
         <location filename="../src/configdialog.ui" line="1028"/>
         <location filename="../src/ui_configdialog.h" line="996"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Veidne</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1049"/>
@@ -521,7 +521,7 @@ e-mail</source>
         <location filename="../src/configdialog.cpp" line="728"/>
         <location filename="../src/configdialog.cpp" line="985"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Kļūda</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>
@@ -546,7 +546,7 @@ e-mail</source>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>
         <source>No profile selected to delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Nav atlasīts profils dzēšanai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
@@ -586,7 +586,7 @@ e-mail</source>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation type="unfinished"></translation>
+        <translation>Paroļu krātuve nav inicializēta</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
@@ -643,7 +643,7 @@ e-mail</source>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="67"/>
         <source>Copied!</source>
-        <translation type="unfinished"></translation>
+        <translation>Nokopēts!</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="83"/>
@@ -699,7 +699,7 @@ e-mail</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
-        <translation type="unfinished"></translation>
+        <translation>Nevar atjaunināt</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
@@ -814,7 +814,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.cpp" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="120"/>
         <source>Import GPG Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt GPG atslēgu</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="27"/>
@@ -826,13 +826,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.ui" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="122"/>
         <source>From File...</source>
-        <translation type="unfinished"></translation>
+        <translation>No faila...</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="49"/>
         <location filename="../src/ui_importkeydialog.h" line="123"/>
         <source>From Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>No starpliktuves</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="71"/>
@@ -844,7 +844,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.ui" line="93"/>
         <location filename="../src/ui_importkeydialog.h" line="125"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
@@ -854,7 +854,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
         <source>All Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Visi faili</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="51"/>
@@ -897,7 +897,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="14"/>
         <location filename="../src/ui_keygendialog.h" line="230"/>
         <source>Generate GnuPG keypair</source>
-        <translation type="unfinished"></translation>
+        <translation>Ģenerēt GnuPG atslēgu pāri</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
@@ -909,13 +909,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="91"/>
         <location filename="../src/ui_keygendialog.h" line="232"/>
         <source>Email</source>
-        <translation type="unfinished"></translation>
+        <translation>E-pasts</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="123"/>
         <location filename="../src/ui_keygendialog.h" line="233"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Vārds</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="155"/>
@@ -939,7 +939,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="227"/>
         <location filename="../src/ui_keygendialog.h" line="237"/>
         <source>Expert</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksperts</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="246"/>
@@ -999,7 +999,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="883"/>
         <location filename="../src/ui_mainwindow.h" line="352"/>
         <source>Search Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Meklēt paroli</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="127"/>
@@ -1035,7 +1035,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="149"/>
         <location filename="../src/ui_mainwindow.h" line="366"/>
         <source>Aa</source>
-        <translation type="unfinished"></translation>
+        <translation>Aa</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="152"/>
@@ -1053,7 +1053,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="211"/>
         <location filename="../src/ui_mainwindow.h" line="374"/>
         <source>Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Rezultāti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="263"/>
@@ -1101,7 +1101,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="319"/>
         <location filename="../src/ui_mainwindow.h" line="321"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Rediģēt</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="406"/>
@@ -1110,7 +1110,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="323"/>
         <location filename="../src/ui_mainwindow.h" line="325"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="414"/>
@@ -1134,32 +1134,32 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="425"/>
         <location filename="../src/ui_mainwindow.h" line="334"/>
         <source>Push</source>
-        <translation type="unfinished"></translation>
+        <translation>Nosūtīt</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>
         <location filename="../src/ui_mainwindow.h" line="336"/>
         <source>Git push</source>
-        <translation type="unfinished"></translation>
+        <translation>Git nosūtīšana</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="433"/>
         <location filename="../src/ui_mainwindow.h" line="338"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Atjaunināt</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="436"/>
         <location filename="../src/ui_mainwindow.h" line="340"/>
         <source>Git pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Git saņemšana</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="441"/>
         <location filename="../src/mainwindow.cpp" line="1374"/>
         <location filename="../src/ui_mainwindow.h" line="342"/>
         <source>Users</source>
-        <translation type="unfinished"></translation>
+        <translation>Lietotāji</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="444"/>
@@ -1171,13 +1171,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="449"/>
         <location filename="../src/ui_mainwindow.h" line="346"/>
         <source>Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfig.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
         <location filename="../src/ui_mainwindow.h" line="348"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfigurācija</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="293"/>
@@ -1187,7 +1187,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="322"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Notīrīt</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="323"/>
@@ -1215,7 +1215,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="629"/>
         <location filename="../src/mainwindow.cpp" line="1641"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Parole</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="666"/>
@@ -1245,7 +1245,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>
         <source>Searching…</source>
-        <translation type="unfinished"></translation>
+        <translation>Meklē…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="865"/>
@@ -1279,7 +1279,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1036"/>
         <location filename="../src/mainwindow.cpp" line="1467"/>
         <source>New file</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns fails</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
@@ -1340,7 +1340,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>
         <source>Share</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopīgot</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1412"/>
@@ -1373,7 +1373,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1487"/>
         <location filename="../src/mainwindow.cpp" line="1696"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Kļūda</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
@@ -1511,13 +1511,13 @@ Continue?</source>
         <location filename="../src/ui_passworddialog.h" line="174"/>
         <location filename="../src/ui_passworddialog.h" line="176"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Parole</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="75"/>
         <location filename="../src/ui_passworddialog.h" line="177"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Ģenerēt</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="86"/>
@@ -1535,31 +1535,31 @@ Continue?</source>
         <location filename="../src/passworddialog.ui" line="114"/>
         <location filename="../src/ui_passworddialog.h" line="180"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Visas rakstzīmes</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="119"/>
         <location filename="../src/ui_passworddialog.h" line="181"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfabētiski</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="124"/>
         <location filename="../src/ui_passworddialog.h" line="182"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Burtciparu</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="129"/>
         <location filename="../src/ui_passworddialog.h" line="183"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Pielāgots</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="143"/>
         <location filename="../src/ui_passworddialog.h" line="185"/>
         <source>Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Garums:</translation>
     </message>
 </context>
 <context>
@@ -1680,32 +1680,32 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="67"/>
         <source>&amp;Show</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Rādīt</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>
         <source>&amp;Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Slēpt</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation type="unfinished"></translation>
+        <translation>Mi&amp;nimizēt</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation type="unfinished"></translation>
+        <translation>Ma&amp;ksimizēt</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;tjaunot</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>
         <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Iziet</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -146,7 +146,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="776"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>ජනනය කරන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
@@ -262,7 +262,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="682"/>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>වැඩසටහන්</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="700"/>
@@ -316,17 +316,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="900"/>
         <source>Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>පැතිකඩ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="949"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>නම</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>මාර්ගය</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="978"/>
@@ -336,7 +336,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="993"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>මකන්න</translation>
     </message>
     <message>
         <source>Current password-store</source>
@@ -459,7 +459,7 @@ email</translation>
         <location filename="../src/configdialog.cpp" line="728"/>
         <location filename="../src/configdialog.cpp" line="985"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>දෝෂය</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>
@@ -880,12 +880,12 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/keygendialog.ui" line="91"/>
         <source>Email</source>
-        <translation type="unfinished"></translation>
+        <translation>විද්‍යුත් තැපෑල</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="123"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>නම</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="200"/>
@@ -954,14 +954,14 @@ You will not be able to decrypt any newly added passwords!</source>
         <location filename="../src/mainwindow.ui" line="401"/>
         <location filename="../src/mainwindow.cpp" line="1380"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>සංස්කරණය</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="406"/>
         <location filename="../src/mainwindow.ui" line="409"/>
         <location filename="../src/mainwindow.cpp" line="1394"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>මකන්න</translation>
     </message>
     <message>
         <source>git push</source>
@@ -1027,7 +1027,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="433"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>යාවත්කාල කරන්න</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1049,7 +1049,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../src/mainwindow.ui" line="441"/>
         <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>Users</source>
-        <translation type="unfinished"></translation>
+        <translation>පරිශීලකයින්</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1105,7 +1105,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="149"/>
         <source>Aa</source>
-        <translation type="unfinished"></translation>
+        <translation>Aa</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="152"/>
@@ -1135,7 +1135,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="322"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>හිස් කරන්න</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="120"/>
@@ -1215,7 +1215,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../src/mainwindow.cpp" line="629"/>
         <location filename="../src/mainwindow.cpp" line="1641"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>මුරපදය</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="666"/>
@@ -1483,7 +1483,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../src/mainwindow.cpp" line="1487"/>
         <location filename="../src/mainwindow.cpp" line="1696"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>දෝෂය</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
@@ -1594,12 +1594,12 @@ Continue?</source>
         <location filename="../src/passworddialog.ui" line="14"/>
         <location filename="../src/passworddialog.ui" line="65"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>මුරපදය</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="75"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>ජනනය කරන්න</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="86"/>

--- a/localization/localization_sl_SI.ts
+++ b/localization/localization_sl_SI.ts
@@ -19,19 +19,19 @@
         <location filename="../src/configdialog.ui" line="72"/>
         <location filename="../src/ui_configdialog.h" line="898"/>
         <source>Clipboard behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Vedenje odložišča:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
         <location filename="../src/ui_configdialog.h" line="899"/>
         <source>Use primary selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi primarno izbiro</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="98"/>
         <location filename="../src/ui_configdialog.h" line="900"/>
         <source>Autoclear after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Samodejno počisti po:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="115"/>
@@ -39,109 +39,109 @@
         <location filename="../src/ui_configdialog.h" line="901"/>
         <location filename="../src/ui_configdialog.h" line="906"/>
         <source>Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Sekunde</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
         <location filename="../src/ui_configdialog.h" line="902"/>
         <source>Content panel behaviour:</source>
-        <translation type="unfinished"></translation>
+        <translation>Vedenje pulta z vsebino:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="159"/>
         <location filename="../src/ui_configdialog.h" line="903"/>
         <source>Hide content</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrij vsebino</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="166"/>
         <location filename="../src/ui_configdialog.h" line="904"/>
         <source>Hide password</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrij geslo</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <location filename="../src/ui_configdialog.h" line="905"/>
         <source>Autoclear panel after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Samodejno počisti pult po:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <location filename="../src/ui_configdialog.h" line="907"/>
         <source>Use a monospace font</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi pisavo enake širine</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
         <location filename="../src/ui_configdialog.h" line="908"/>
         <source>Display the files content as-is</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži vsebino datoteke takšno, kot je</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="238"/>
         <location filename="../src/ui_configdialog.h" line="909"/>
         <source>No line wrapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Brez prelamljanja vrstic</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="245"/>
         <location filename="../src/ui_configdialog.h" line="910"/>
         <source>Show process output</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaži izhod procesa</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="277"/>
         <location filename="../src/ui_configdialog.h" line="911"/>
         <source>Password Generation:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustvarjanje gesla:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="289"/>
         <location filename="../src/ui_configdialog.h" line="912"/>
         <source>Password Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Dolžina gesla:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="323"/>
         <location filename="../src/ui_configdialog.h" line="913"/>
         <source>Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Znaki</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="351"/>
         <location filename="../src/ui_configdialog.h" line="914"/>
         <source>Use characters:</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi znake:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="369"/>
         <location filename="../src/ui_configdialog.h" line="921"/>
         <source>Select character set for password generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberite nabor znakov za ustvarjanje gesla</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="373"/>
         <location filename="../src/ui_configdialog.h" line="915"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Vsi znaki</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <location filename="../src/ui_configdialog.h" line="916"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Abecedni</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
         <location filename="../src/ui_configdialog.h" line="917"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfanumerični</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="388"/>
         <location filename="../src/ui_configdialog.h" line="918"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Po meri</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
@@ -153,31 +153,31 @@
         <location filename="../src/configdialog.ui" line="443"/>
         <location filename="../src/ui_configdialog.h" line="924"/>
         <source>Use PWGen</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <location filename="../src/ui_configdialog.h" line="925"/>
         <source>Exclude capital letters</source>
-        <translation type="unfinished"></translation>
+        <translation>Izključi velike črke</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
         <location filename="../src/ui_configdialog.h" line="926"/>
         <source>Include special symbols</source>
-        <translation type="unfinished"></translation>
+        <translation>Vključi posebne znake</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <location filename="../src/ui_configdialog.h" line="927"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustvari gesla, ki si jih je lahko zapomniti, a so manj varna</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
         <location filename="../src/ui_configdialog.h" line="928"/>
         <source>Exclude numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Izključi števila</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="493"/>
@@ -189,49 +189,49 @@
         <location filename="../src/configdialog.ui" line="505"/>
         <location filename="../src/ui_configdialog.h" line="930"/>
         <source>Use Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi Git</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="519"/>
         <location filename="../src/ui_configdialog.h" line="931"/>
         <source>Automatically add .gpg-id files</source>
-        <translation type="unfinished"></translation>
+        <translation>Samodejno dodaj datoteke .gpg-id</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
         <location filename="../src/ui_configdialog.h" line="932"/>
         <source>Automatically push</source>
-        <translation type="unfinished"></translation>
+        <translation>Samodejno pošlji (push)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="533"/>
         <location filename="../src/ui_configdialog.h" line="933"/>
         <source>Automatically pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Samodejno povleci (pull)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>
         <location filename="../src/ui_configdialog.h" line="934"/>
         <source>Extensions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Razširitve:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
         <location filename="../src/ui_configdialog.h" line="935"/>
         <source>Use QRencode</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi QRencode</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
         <location filename="../src/ui_configdialog.h" line="936"/>
         <source>Use pass-otp extension</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi razširitev pass-otp</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="599"/>
         <location filename="../src/ui_configdialog.h" line="937"/>
         <source>Enable content search (pass grep)</source>
-        <translation type="unfinished"></translation>
+        <translation>Omogoči iskanje po vsebini (pass grep)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
@@ -243,61 +243,61 @@
         <location filename="../src/configdialog.ui" line="624"/>
         <location filename="../src/ui_configdialog.h" line="941"/>
         <source>System:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <location filename="../src/ui_configdialog.h" line="942"/>
         <source>Use TrayIcon</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi ikono v sistemski vrstici</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
         <location filename="../src/ui_configdialog.h" line="943"/>
         <source>Start minimized</source>
-        <translation type="unfinished"></translation>
+        <translation>Začni pomanjšano</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <location filename="../src/ui_configdialog.h" line="944"/>
         <source>Hide on close</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrij ob zapiranju</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>
         <location filename="../src/ui_configdialog.h" line="945"/>
         <source>Always on top</source>
-        <translation type="unfinished"></translation>
+        <translation>Vedno na vrhu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="682"/>
         <location filename="../src/ui_configdialog.h" line="966"/>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Programi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="700"/>
         <location filename="../src/ui_configdialog.h" line="947"/>
         <source>Select password storage program:</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberite program za shranjevanje gesel:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <location filename="../src/ui_configdialog.h" line="948"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Domorodni Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <location filename="../src/ui_configdialog.h" line="949"/>
         <source>&amp;Use pass</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Uporabi pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <location filename="../src/ui_configdialog.h" line="950"/>
         <source>Native</source>
-        <translation type="unfinished"></translation>
+        <translation>Domorodno</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -323,7 +323,7 @@
         <location filename="../src/configdialog.ui" line="776"/>
         <location filename="../src/ui_configdialog.h" line="954"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustvari</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
@@ -371,13 +371,13 @@
         <location filename="../src/configdialog.ui" line="900"/>
         <location filename="../src/ui_configdialog.h" line="986"/>
         <source>Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>Profili</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="949"/>
         <location filename="../src/ui_configdialog.h" line="968"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="952"/>
@@ -389,7 +389,7 @@
         <location filename="../src/configdialog.ui" line="957"/>
         <location filename="../src/ui_configdialog.h" line="973"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Pot</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
@@ -413,13 +413,13 @@
         <location filename="../src/configdialog.ui" line="978"/>
         <location filename="../src/ui_configdialog.h" line="982"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Dodaj</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="993"/>
         <location filename="../src/ui_configdialog.h" line="983"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
@@ -431,7 +431,7 @@
         <location filename="../src/configdialog.ui" line="1028"/>
         <location filename="../src/ui_configdialog.h" line="996"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Predloga</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1049"/>
@@ -521,7 +521,7 @@ e-mail</source>
         <location filename="../src/configdialog.cpp" line="728"/>
         <location filename="../src/configdialog.cpp" line="985"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>
@@ -546,7 +546,7 @@ e-mail</source>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>
         <source>No profile selected to delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Za brisanje ni izbran noben profil</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
@@ -586,7 +586,7 @@ e-mail</source>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation type="unfinished"></translation>
+        <translation>Shramba gesel ni inicializirana</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
@@ -643,7 +643,7 @@ e-mail</source>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="67"/>
         <source>Copied!</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopirano!</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="83"/>
@@ -699,7 +699,7 @@ e-mail</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni mogoče posodobiti</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
@@ -814,7 +814,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.cpp" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="120"/>
         <source>Import GPG Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi ključ GPG</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="27"/>
@@ -826,13 +826,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.ui" line="42"/>
         <location filename="../src/ui_importkeydialog.h" line="122"/>
         <source>From File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Iz datoteke...</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="49"/>
         <location filename="../src/ui_importkeydialog.h" line="123"/>
         <source>From Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Iz odložišča</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="71"/>
@@ -844,7 +844,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/importkeydialog.ui" line="93"/>
         <location filename="../src/ui_importkeydialog.h" line="125"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
@@ -854,7 +854,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
         <source>All Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Vse datoteke</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="51"/>
@@ -897,7 +897,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="14"/>
         <location filename="../src/ui_keygendialog.h" line="230"/>
         <source>Generate GnuPG keypair</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustvari par ključev GnuPG</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
@@ -909,13 +909,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="91"/>
         <location filename="../src/ui_keygendialog.h" line="232"/>
         <source>Email</source>
-        <translation type="unfinished"></translation>
+        <translation>E-pošta</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="123"/>
         <location filename="../src/ui_keygendialog.h" line="233"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="155"/>
@@ -939,7 +939,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/keygendialog.ui" line="227"/>
         <location filename="../src/ui_keygendialog.h" line="237"/>
         <source>Expert</source>
-        <translation type="unfinished"></translation>
+        <translation>Strokovni</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="246"/>
@@ -999,7 +999,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="883"/>
         <location filename="../src/ui_mainwindow.h" line="352"/>
         <source>Search Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Iskanje gesla</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="127"/>
@@ -1035,7 +1035,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="149"/>
         <location filename="../src/ui_mainwindow.h" line="366"/>
         <source>Aa</source>
-        <translation type="unfinished"></translation>
+        <translation>Aa</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="152"/>
@@ -1053,7 +1053,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="211"/>
         <location filename="../src/ui_mainwindow.h" line="374"/>
         <source>Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Rezultati</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="263"/>
@@ -1101,7 +1101,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="319"/>
         <location filename="../src/ui_mainwindow.h" line="321"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Uredi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="406"/>
@@ -1110,7 +1110,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/ui_mainwindow.h" line="323"/>
         <location filename="../src/ui_mainwindow.h" line="325"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="414"/>
@@ -1134,32 +1134,32 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="425"/>
         <location filename="../src/ui_mainwindow.h" line="334"/>
         <source>Push</source>
-        <translation type="unfinished"></translation>
+        <translation>Pošlji</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>
         <location filename="../src/ui_mainwindow.h" line="336"/>
         <source>Git push</source>
-        <translation type="unfinished"></translation>
+        <translation>Git pošiljanje</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="433"/>
         <location filename="../src/ui_mainwindow.h" line="338"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Posodobi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="436"/>
         <location filename="../src/ui_mainwindow.h" line="340"/>
         <source>Git pull</source>
-        <translation type="unfinished"></translation>
+        <translation>Git povlek</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="441"/>
         <location filename="../src/mainwindow.cpp" line="1374"/>
         <location filename="../src/ui_mainwindow.h" line="342"/>
         <source>Users</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabniki</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="444"/>
@@ -1171,13 +1171,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.ui" line="449"/>
         <location filename="../src/ui_mainwindow.h" line="346"/>
         <source>Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfig.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
         <location filename="../src/ui_mainwindow.h" line="348"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfiguracija</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="293"/>
@@ -1187,7 +1187,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="322"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Počisti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="323"/>
@@ -1215,7 +1215,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="629"/>
         <location filename="../src/mainwindow.cpp" line="1641"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Geslo</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="666"/>
@@ -1245,7 +1245,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>
         <source>Searching…</source>
-        <translation type="unfinished"></translation>
+        <translation>Iskanje…</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="865"/>
@@ -1281,7 +1281,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1036"/>
         <location filename="../src/mainwindow.cpp" line="1467"/>
         <source>New file</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova datoteka</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
@@ -1342,7 +1342,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>
         <source>Share</source>
-        <translation type="unfinished"></translation>
+        <translation>Deli</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1412"/>
@@ -1375,7 +1375,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1487"/>
         <location filename="../src/mainwindow.cpp" line="1696"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
@@ -1513,13 +1513,13 @@ Continue?</source>
         <location filename="../src/ui_passworddialog.h" line="174"/>
         <location filename="../src/ui_passworddialog.h" line="176"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Geslo</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="75"/>
         <location filename="../src/ui_passworddialog.h" line="177"/>
         <source>Generate</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustvari</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="86"/>
@@ -1537,31 +1537,31 @@ Continue?</source>
         <location filename="../src/passworddialog.ui" line="114"/>
         <location filename="../src/ui_passworddialog.h" line="180"/>
         <source>All Characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Vsi znaki</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="119"/>
         <location filename="../src/ui_passworddialog.h" line="181"/>
         <source>Alphabetical</source>
-        <translation type="unfinished"></translation>
+        <translation>Abecedni</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="124"/>
         <location filename="../src/ui_passworddialog.h" line="182"/>
         <source>Alphanumerical</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfanumerični</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="129"/>
         <location filename="../src/ui_passworddialog.h" line="183"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Po meri</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="143"/>
         <location filename="../src/ui_passworddialog.h" line="185"/>
         <source>Length:</source>
-        <translation type="unfinished"></translation>
+        <translation>Dolžina:</translation>
     </message>
 </context>
 <context>
@@ -1682,32 +1682,32 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="67"/>
         <source>&amp;Show</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Pokaži</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>
         <source>&amp;Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Skrij</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation type="unfinished"></translation>
+        <translation>Po&amp;manjšaj</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation type="unfinished"></translation>
+        <translation>Po&amp;večaj</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Obnovi</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>
         <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Končaj</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Summary

Conservative partial pass on the four locales the earlier 1.8.0 sweep skipped because they were near-empty (304/304 unfinished on lt_LT/lv_LV, 302/304 on sl_SI, 284/354 on si_LK).

| Locale | Before | After | Coverage |
|---|---|---|---|
| lt_LT (Lithuanian) | 0/304 | 98/304 | 32% |
| lv_LV (Latvian) | 0/304 | 98/304 | 32% |
| sl_SI (Slovenian) | 2/304 | 98/304 | 32% |
| si_LK (Sinhala) | 70/354 | 89/354 | 25% |

### What's translated

Universally-canonical Qt strings + most-visible UI labels:

- Standard buttons: OK, Cancel, Apply, Close, Edit, Add, Delete, Update
- Common labels: Email, Password, Path, Name, Settings, Configuration, Users, Profile
- Configuration dialog: Clipboard behaviour, Hide content, Use Git, Always on top, etc.
- Main toolbar: Push, Pull, Update password store, About QtPass
- Tray menu: Minimize, Maximize, Restore, Quit
- Import GPG Key dialog (1.8.0): Import, From File, From Clipboard

### What's skipped

- Long sentence-level strings (paragraph-style help text)
- Error messages with language-specific grammar
- Anything where the safest default is "leave for native review"

For \`si_LK\` (Sinhala) I scoped tighter — non-Latin script is harder to audit, so only the most universal Qt strings.

### Caveat

These are machine-quality starting points. They should clear native-speaker review through Weblate (or via PR comments) before being relied on.

\`lrelease6\` reports all four files clean.

## Test plan

- [ ] CI lint passes
- [ ] Native-speaker review (especially Lithuanian/Latvian declension and Slovenian dual number — none of which I can audit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Lithuanian, Latvian, Sinhala, and Slovenian language translations across all interface elements including dialogs, menus, buttons, and status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->