### PR TITLE
i18n(zh_Hant): more Simplified→Traditional + 新資料夾 typo

### DIFF
--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -509,7 +509,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
         <source>Pass OTP extension needs to be installed</source>
-        <translation>需要安装 Pass OTP 扩展</translation>
+        <translation>需要安裝 Pass OTP 擴展</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="100"/>
@@ -544,7 +544,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
         <source>Use pass-otp extension</source>
-        <translation>使用 pass-otp 扩展</translation>
+        <translation>使用 pass-otp 擴展</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
@@ -1366,7 +1366,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder: 
 (Will be placed in %1 )</source>
-        <translation>新資料夾r: 
+        <translation>新資料夾: 
 (會被放置在 %1 )</translation>
     </message>
     <message>


### PR DESCRIPTION
## Summary

Three reviewer findings on \`localization_zh_Hant.ts\`, all verified valid against current code:

| Source | Was | Now |
|---|---|---|
| Pass OTP extension needs to be installed | 需要安**装** Pass OTP **扩**展 | 需要安**裝** Pass OTP **擴**展 |
| Use pass-otp extension | 使用 pass-otp **扩**展 | 使用 pass-otp **擴**展 |
| New Folder: ↵(Will be placed in %1 ) | 新資料夾**r**: | 新資料夾: *(stray 'r' removed; trailing space preserved to match source formatting)* |

Re-ran the Simplified-character contamination scan after applying these — no further hits in active translations.

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Traditional Chinese localization strings for Pass OTP extension-related messages with proper character usage
  * Fixed typo in "New Folder" label translation for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->