### PR TITLE
i18n(sq_AL): grammar fixes + standardise Clipboard term as klipboard

### DIFF
--- a/localization/localization_sq_AL.ts
+++ b/localization/localization_sq_AL.ts
@@ -16,7 +16,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="72"/>
         <source>Clipboard behaviour:</source>
-        <translation>Sjellja e Clipboard:</translation>
+        <translation>Sjellja e klipboardit:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
@@ -196,7 +196,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <source>Use TrayIcon</source>
-        <translation>Përdorni ikonë e trayit</translation>
+        <translation>Përdorni ikonën e trayit</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
@@ -432,7 +432,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>Dëshiron të krijosh një password-store në% 1?</translation>
+        <translation>Dëshiron të krijosh një password-store në %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="728"/>
@@ -549,7 +549,7 @@ e-mail</translation>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="52"/>
         <source>Copy to Clipboard</source>
-        <translation>Kopjo në Tabelën e kopjimit</translation>
+        <translation>Kopjo në klipboard</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="59"/>
@@ -751,7 +751,7 @@ Ju nuk do të jeni në gjendje të deshifroni ndonjë fjalëkalim të shtuar ris
     <message>
         <location filename="../src/importkeydialog.ui" line="49"/>
         <source>From Clipboard</source>
-        <translation>Nga Tabela e kopjimit</translation>
+        <translation>Nga klipboardi</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="71"/>
@@ -789,7 +789,7 @@ Ju nuk do të jeni në gjendje të deshifroni ndonjë fjalëkalim të shtuar ris
     <message>
         <location filename="../src/importkeydialog.cpp" line="67"/>
         <source>%1 does not look like an ASCII-armored GPG key. Convert it with &lt;code&gt;gpg --armor --export&lt;/code&gt; first, or paste the armored block via &lt;b&gt;From Clipboard&lt;/b&gt;.</source>
-        <translation>%1 nuk duket si një çelës GPG ASCII-armored. Konvertoje fillimisht me &lt;code&gt;gpg --armor --export&lt;/code&gt;, ose ngjit blokun ASCII-armored përmes &lt;b&gt;Nga Tabela e kopjimit&lt;/b&gt;.</translation>
+        <translation>%1 nuk duket si një çelës GPG ASCII-armored. Konvertoje fillimisht me &lt;code&gt;gpg --armor --export&lt;/code&gt;, ose ngjit blokun ASCII-armored përmes &lt;b&gt;Nga klipboardi&lt;/b&gt;.</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="117"/>
@@ -1131,7 +1131,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="668"/>
         <source>OTP code copied to clipboard</source>
-        <translation>Kodi OTP u kopjua në kujtesën e përkohshme</translation>
+        <translation>Kodi OTP u kopjua në klipboard</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
@@ -1584,12 +1584,12 @@ Të vazhdohet?</translation>
     <message>
         <location filename="../src/qtpass.cpp" line="467"/>
         <source>Clipboard not cleared</source>
-        <translation>Clipboard nuk është pastruar</translation>
+        <translation>Klipboardi nuk është pastruar</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="512"/>
         <source>Copied to clipboard</source>
-        <translation>Kopjuar në clipboard</translation>
+        <translation>Kopjuar në klipboard</translation>
     </message>
 </context>
 <context>
@@ -1670,7 +1670,7 @@ Hyrjet e kuqe nuk janë të vlefshme, nuk do të jeni në gjendje të enkriptoni
     <message>
         <location filename="../src/usersdialog.ui" line="87"/>
         <source>Import a GPG key from file or clipboard</source>
-        <translation>Importo një çelës GPG nga skedari ose nga Tabela e kopjimit</translation>
+        <translation>Importo një çelës GPG nga skedari ose nga klipboardi</translation>
     </message>
     <message>
         <source>Select which users should be able to decrypt passwords stored in this folder.


### PR DESCRIPTION
## Summary

Five reviewer findings on \`localization_sq_AL.ts\`. Two are direct grammar fixes; the other three flag inconsistent \"Clipboard\" translation across the file, with the specific suggestions partly contradicting each other — addressed the underlying consistency issue.

### Direct fixes

| Source | Was | Now |
|---|---|---|
| Use TrayIcon | Përdorni **ikonë** e trayit | Përdorni **ikonën** e trayit *(definite accusative — verb \`përdor\` requires accusative case)* |
| Would you like to create a password-store at %1? | …password-store **në% 1** | …password-store **në %1** *(stray space inside the Qt placeholder)* |

### Clipboard standardisation

The file previously used four different terms: \`Clipboard\`, \`klipboard\` (already 6×), \`Tabela/Tabelën e kopjimit\` (4×), and \`kujtesën e përkohshme\` (1×). Standardised on \`klipboard\` since it was already the most common form, with case endings adjusted per Albanian grammar.

| Source | Was | Now |
|---|---|---|
| Clipboard behaviour: | Sjellja e **Clipboard:** | Sjellja e **klipboardit:** |
| Copy to Clipboard | Kopjo në **Tabelën e kopjimit** | Kopjo në **klipboard** |
| From Clipboard | Nga **Tabela e kopjimit** | Nga **klipboardi** |
| ASCII-armored hint (\`<b>From Clipboard</b>\`) | …**Nga Tabela e kopjimit**… | …**Nga klipboardi**… |
| OTP code copied to clipboard | …**kujtesën e përkohshme** | …**klipboard** |
| Clipboard not cleared | **Clipboard** nuk është pastruar | **Klipboardi** nuk është pastruar |
| Copied to clipboard | Kopjuar në **clipboard** | Kopjuar në **klipboard** |
| Import a GPG key from file or clipboard | …ose nga **Tabela e kopjimit** | …ose nga **klipboardi** |

### Note on the L552 reviewer suggestion

Reviewer suggested \`Tabelën\` → \`Tabela\` (accusative → nominative). This would have been grammatically wrong: Albanian preposition \`në\` requires accusative, so the original \`Tabelën\` was correct in that respect. The actual fix was the term, not the case. New translation \`Kopjo në klipboard\` uses indefinite accusative \`klipboard\`, matching the existing convention in lines 359/364/1042.

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

## Test plan

- [ ] CI lint passes
- [ ] Native Albanian speaker review (case-form choices in particular)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Albanian translations with standardized terminology for clipboard-related UI elements across multiple dialogs
  * Corrected spacing and adjusted wording in translation strings for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->