### PR TITLE
i18n: fix placeholder format + wrong-string mappings (5 locales)

### DIFF
--- a/localization/localization_bg_BG.ts
+++ b/localization/localization_bg_BG.ts
@@ -474,7 +474,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Изглежда, че папката% 1 не е хранилище за пароли или все още не е инициализирана.</translation>
+        <translation>Изглежда, че папката %1 не е хранилище за пароли или все още не е инициализирана.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
@@ -752,7 +752,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="729"/>
         <source>Re-encrypting from folder %1</source>
-        <translation>Повторно криптиране от папка% 1</translation>
+        <translation>Повторно криптиране от папка %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="732"/>
@@ -1156,7 +1156,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="293"/>
         <source>Welcome to QtPass %1</source>
-        <translation>Добре дошли в QtPass% 1</translation>
+        <translation>Добре дошли в QtPass %1</translation>
     </message>
     <message>
         <source>Add Password</source>
@@ -1267,7 +1267,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="784"/>
         <source>Looking for: %1</source>
-        <translation>Търси се:% 1</translation>
+        <translation>Търси се: %1</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="934"/>
@@ -1342,7 +1342,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1242"/>
         <source>Profile changed to %1</source>
-        <translation>Профилът е променен на% 1</translation>
+        <translation>Профилът е променен на %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1371"/>
@@ -1368,7 +1368,7 @@ p, li { white-space: pre-wrap; }
         <source>New Folder: 
 (Will be placed in %1 )</source>
         <translation>Нова папка: 
-(Ще бъде поставен в% 1 )</translation>
+(Ще бъде поставен в %1 )</translation>
     </message>
     <message>
         <source>Copied to clipboard</source>
@@ -1776,7 +1776,7 @@ Continue?</source>
     <message>
         <location filename="../src/storemodel.cpp" line="412"/>
         <source>overwrite %1 with %2?</source>
-        <translation>да се презапише ли% 1 с% 2?</translation>
+        <translation>да се презапише ли %1 с %2?</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_hu_HU.ts
+++ b/localization/localization_hu_HU.ts
@@ -754,7 +754,7 @@ Nem fogja tudni megfejteni az újonnan hozzáadott jelszavakat!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="729"/>
         <source>Re-encrypting from folder %1</source>
-        <translation>Új titkosítás a (z)% 1 mappából</translation>
+        <translation>Új titkosítás a (z) %1 mappából</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="757"/>

--- a/localization/localization_pt_BR.ts
+++ b/localization/localization_pt_BR.ts
@@ -393,7 +393,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="810"/>
         <source>No profile selected</source>
-        <translation>Falha ao criar repositório de senhas em: %1</translation>
+        <translation>Nenhum perfil selecionado</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>

--- a/localization/localization_pt_PT.ts
+++ b/localization/localization_pt_PT.ts
@@ -393,7 +393,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="810"/>
         <source>No profile selected</source>
-        <translation>Falha ao criar o armazenamento de palavras-passe em: %1</translation>
+        <translation>Nenhum perfil selecionado</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>

--- a/localization/localization_ta_IN.ts
+++ b/localization/localization_ta_IN.ts
@@ -1570,7 +1570,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
         <source>Failed to create .gpg-id file in: %1</source>
-        <translation>%1 உள்ள முனையில் .gpg-id கடவுச்சொல் பயாக வர வேண்டியது: %1</translation>
+        <translation>.gpg-id கோப்பை உருவாக்க முடியவில்லை: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>


### PR DESCRIPTION
## Summary

Five locales had user-visible translation bugs that an automated audit caught. All ship-blocking quality issues — Qt placeholder substitution would have rendered literal \`% 1\` in the UI, and two Portuguese strings had completely wrong content.

### Misplaced-space placeholders (\`% 1\` → \`%1\`)

| Locale | Strings affected |
|---|---|
| **bg_BG** (8) | folder %1 ("doesn't seem to be"), Re-encrypting from folder %1, Welcome to QtPass %1, Looking for: %1, Profile changed to %1, New Folder placement, "overwrite %1 with %2" (both placeholders broken) |
| **hu_HU** (1) | Re-encrypting from folder %1 |

The space was *inside* the placeholder ("WORD% 1") instead of before it; moved the space to before the \`%\` so the placeholder is well-formed.

### Wrong-string mappings (copy-paste errors)

\`<source>No profile selected</source>\` had been mapped to a translation of an entirely different message:

| Locale | Was | Now |
|---|---|---|
| **pt_BR** | "Falha ao criar repositório de senhas em: %1" *(failed to create repo at: %1)* | "Nenhum perfil selecionado" |
| **pt_PT** | "Falha ao criar o armazenamento de palavras-passe em: %1" | "Nenhum perfil selecionado" |

Matches the convention already used by the neighbouring "No profile selected to delete" strings.

### Duplicate placeholder

| Locale | Source | Was (%1 ×2) | Now |
|---|---|---|---|
| **ta_IN** | Failed to create .gpg-id file in: %1 | %1 உள்ள முனையில் .gpg-id கடவுச்சொல் பயாக வர வேண்டியது: %1 *(garbled, %1 appears twice)* | .gpg-id கோப்பை உருவாக்க முடியவில்லை: %1 *(matches the L416 "...உருவாக்க முடியவில்லை: %1" pattern)* |

The original Tamil string was non-grammatical regardless of the placeholder issue, so I rewrote it to follow the existing convention from "Could not create profile directory: %1" rather than just dedupe.

### Verification

\`lrelease6\`: all 5 files clean (304 finished / 0 unfinished, no warnings).
Audit script confirms 0 placeholder mismatches in any of the 5 files after the fix.

## Test plan

- [x] CI lint passes
- [ ] Native bg / hu / pt / ta speaker review (especially Tamil rewrite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected translations across Bulgarian, Hungarian, Portuguese (Brazil and Portugal), and Tamil to fix spacing inconsistencies and enhance message clarity in configuration dialogs, status updates, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->