### PR TITLE
i18n(sq_AL): terminology consistency + &Use pass mnemonic spacing

### DIFF
--- a/localization/localization_sq_AL.ts
+++ b/localization/localization_sq_AL.ts
@@ -493,7 +493,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Vendas Git/GPG</translation>
+        <translation>&amp;Vendas Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_sq_AL.ts
+++ b/localization/localization_sq_AL.ts
@@ -226,7 +226,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>&amp; Përdorni kalimin(pass)</translation>
+        <translation>&amp;Përdorni kalimin(pass)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
@@ -341,7 +341,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
         <source>Pass OTP extension needs to be installed</source>
-        <translation>Pass OTP extension duhet të instalohet</translation>
+        <translation>Zgjatimi Pass OTP duhet të instalohet</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="100"/>
@@ -488,12 +488,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
         <source>Use pass-otp extension</source>
-        <translation>Përdorni extension pass-otp</translation>
+        <translation>Përdorni zgjatimin pass-otp</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Natyral Git/GPG</translation>
+        <translation>Vendas Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -814,12 +814,12 @@ Ju nuk do të jeni në gjendje të deshifroni ndonjë fjalëkalim të shtuar ris
     <message>
         <location filename="../src/keygendialog.ui" line="14"/>
         <source>Generate GnuPG keypair</source>
-        <translation>Gjeneroni GnuPG kyçet çift</translation>
+        <translation>Gjeneroni çiftin e çelësave GnuPG</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
         <source>Generate a new key pair</source>
-        <translation>Gjeneroni një palë të re kyçe</translation>
+        <translation>Gjeneroni një palë të re çelësash</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="91"/>
@@ -1503,7 +1503,7 @@ Të vazhdohet?</translation>
     <message>
         <location filename="../src/qtpass.cpp" line="160"/>
         <source>Generating GPG key pair</source>
-        <translation>Duke gjeneruar çiftin e kyçave të GPG-së</translation>
+        <translation>Duke gjeneruar çiftin e çelësave të GPG-së</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="223"/>


### PR DESCRIPTION
## Summary

Four reviewer findings on \`localization_sq_AL.ts\`. Verified each against current code and applied with small adjustments to keep the file internally consistent.

| # | Source | Was | Now | Notes |
|---|---|---|---|---|
| 1 | &Use pass | \`&amp; Përdorni kalimin(pass)\` | \`&amp;Përdorni kalimin(pass)\` | Stray space after \`&\` would have broken Qt's mnemonic — would render "& U" instead of underlining "U" |
| 2 | Pass OTP extension needs to be installed | \`Pass OTP extension duhet të instalohet\` | \`Zgjatimi Pass OTP duhet të instalohet\` | Used \`zgjatim\` to match existing "Extensions: Zgjatime" at line 179, not reviewer's \`zgjerim\` (would introduce a third term) |
| 2.5 | Use pass-otp extension | \`Përdorni extension pass-otp\` | \`Përdorni zgjatimin pass-otp\` | Same fix applied to the sibling string the reviewer didn't flag |
| 3 | Nati&ve Git/GPG | \`Natyral Git/GPG\` | \`Vendas Git/GPG\` | Standalone "Native" was already \`Vendase\` — standardised on the masculine \`Vendas\` to agree with Git/GPG |
| 4 | Generating GPG key pair | …e **kyçave** të GPG-së | …e **çelësave** të GPG-së | The file used \`çelës\` ~10× and \`kyç\` 3× — converted the outliers |
| 4b | Generate GnuPG keypair | \`Gjeneroni GnuPG kyçet çift\` | \`Gjeneroni çiftin e çelësave GnuPG\` | Sibling string with the same issue, also got broken word order matching line 244 |
| 4c | Generate a new key pair | \`Gjeneroni një palë të re kyçe\` | \`Gjeneroni një palë të re çelësash\` | Sibling string |

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

## Test plan

- [x] CI lint passes
- [ ] Native Albanian speaker review (Vendas/Vendase choice in particular — file now mixes the two on purpose: feminine \`Vendase\` standalone, masculine \`Vendas\` before Git/GPG)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mnemonic/accelerator formatting in Albanian UI strings so keyboard shortcuts display correctly.
* **Chores**
  * Standardized Albanian terminology across pass extension labels, Git/GPG source labels, keypair generation dialogs, and status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->