### PR TITLE
i18n(fr_BE): fix wrong-string mappings on Rename folder/password

### DIFF
--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -1412,12 +1412,12 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="1386"/>
         <source>Rename folder</source>
-        <translation>Impossible de créer le dossier : %1</translation>
+        <translation>Renommer le dossier</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1390"/>
         <source>Rename password</source>
-        <translation>Échec de la création du fichier .gpg-id dans : %1</translation>
+        <translation>Renommer le mot de passe</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>


### PR DESCRIPTION
## Summary

Same kind of copy-paste error that hit \`pt_BR\` / \`pt_PT\` on \"No profile selected\" — caught here by the same audit script.

| Source | Was | Now |
|---|---|---|
| Rename folder | \`Impossible de créer le dossier : %1\` *(Could not create folder: %1)* | \`Renommer le dossier\` |
| Rename password | \`Échec de la création du fichier .gpg-id dans : %1\` *(Failed to create .gpg-id file in: %1)* | \`Renommer le mot de passe\` |

Replacements match the translations already used by \`fr_FR\` and \`fr_LU\` for the same source strings.

\`lrelease6\`: 304 finished / 0 unfinished, no warnings. Audit confirms 0 placeholder mismatches remain in \`fr_BE\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected French (fr_BE) translations for folder and password rename actions to display proper action labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->