### PR TITLE
i18n: restore Qt mnemonics on 14 locales (24 strings)

### DIFF
--- a/localization/localization_cy_GB.ts
+++ b/localization/localization_cy_GB.ts
@@ -237,7 +237,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Brodorol Git/GPG</translation>
+        <translation>&amp;Brodorol Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="716"/>

--- a/localization/localization_da_DK.ts
+++ b/localization/localization_da_DK.ts
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Git/GPG direkte</translation>
+        <translation>Git/GPG &amp;direkte</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -585,7 +585,7 @@ email</translation>
         <location filename="../src/configdialog.ui" line="709"/>
         <location filename="../src/ui_configdialog.h" line="948"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Selbst installieres Git/GPG</translation>
+        <translation>&amp;Selbst installieres Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -519,7 +519,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Lokales Git/GPG</translation>
+        <translation>&amp;Lokales Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_et_EE.ts
+++ b/localization/localization_et_EE.ts
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Kasuta oma Git/GPG-lahendust</translation>
+        <translation>&amp;Kasuta oma Git/GPG-lahendust</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_fi_FI.ts
+++ b/localization/localization_fi_FI.ts
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Natiivi Git/GPG</translation>
+        <translation>&amp;Natiivi Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -1826,17 +1826,17 @@ Jatketaanko?</translation>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation>Pienennä</translation>
+        <translation>P&amp;ienennä</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation>Suurenna</translation>
+        <translation>&amp;Suurenna</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation>Palauta</translation>
+        <translation>P&amp;alauta</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>

--- a/localization/localization_gl_ES.ts
+++ b/localization/localization_gl_ES.ts
@@ -493,7 +493,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Git/GPG nativos</translation>
+        <translation>Git/GPG &amp;nativos</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_pt_BR.ts
+++ b/localization/localization_pt_BR.ts
@@ -258,7 +258,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>Utilizar pass</translation>
+        <translation>&amp;Utilizar pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>

--- a/localization/localization_pt_PT.ts
+++ b/localization/localization_pt_PT.ts
@@ -258,7 +258,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>Utilizar pass</translation>
+        <translation>&amp;Utilizar pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>

--- a/localization/localization_ro_RO.ts
+++ b/localization/localization_ro_RO.ts
@@ -1838,7 +1838,7 @@ Continuați?</translation>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation>restaurați</translation>
+        <translation>&amp;restaurați</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>

--- a/localization/localization_sr_RS.ts
+++ b/localization/localization_sr_RS.ts
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Nativni Git/GPG</translation>
+        <translation>&amp;Nativni Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_ta_IN.ts
+++ b/localization/localization_ta_IN.ts
@@ -276,7 +276,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>&amp; பாச் பயன்படுத்தவும்</translation>
+        <translation>(&amp;U) பாச் பயன்படுத்தவும்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>சொந்த அறிவிலி/சிபிசி</translation>
+        <translation>(&amp;V) சொந்த Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -1848,27 +1848,27 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="67"/>
         <source>&amp;Show</source>
-        <translation>&amp; காட்டு</translation>
+        <translation>(&amp;S) காட்டு</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>
         <source>&amp;Hide</source>
-        <translation>&amp; மறை</translation>
+        <translation>(&amp;H) மறை</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation>Mi &amp; Nimize</translation>
+        <translation>(&amp;N) Minimize</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation>Ma &amp; ximize</translation>
+        <translation>(&amp;X) Maximize</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation>&amp; மீட்டமை</translation>
+        <translation>(&amp;R) மீட்டமை</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>

--- a/localization/localization_uk_UA.ts
+++ b/localization/localization_uk_UA.ts
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>Вбудований Git/GPG</translation>
+        <translation>&amp;Вбудований Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -549,7 +549,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>原生 Git/GPG</translation>
+        <translation>(&amp;V) 原生 Git/GPG</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -1782,7 +1782,7 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="67"/>
         <source>&amp;Show</source>
-        <translation>%顯示</translation>
+        <translation>(&amp;S) 顯示</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>


### PR DESCRIPTION
## Summary

Audit found **24 strings across 14 locales** where the source carried a Qt mnemonic (\`&\` before a letter) but the translation either dropped it entirely, used broken markup (\`& X\` with a space — renders as literal \`&\`, not a mnemonic), or even used the wrong sigil (\`%顯示\` instead of \`&amp;顯示\`). The result: Alt+letter shortcuts didn't work for those menu items.

Applied the project's Qt mnemonic conventions:
- **Latin scripts**: in-word \`&Letter\` (using the source mnemonic letter where it appears in the translation, otherwise picking a non-conflicting letter)
- **CJK / Brahmic**: parens-at-start \`(&L) text\` with the source letter
- **Cyrillic**: in-word with native letter, matching what the file already uses elsewhere

### Latin scripts

| Locale | Source | Now |
|---|---|---|
| cy_GB | Nati&ve Git/GPG | \`&Brodorol Git/GPG\` |
| da_DK | Nati&ve Git/GPG | \`Git/GPG &direkte\` |
| de_DE | Nati&ve Git/GPG | \`&Selbst installieres Git/GPG\` |
| de_LU | Nati&ve Git/GPG | \`&Lokales Git/GPG\` |
| et_EE | Nati&ve Git/GPG | \`&Kasuta oma Git/GPG-lahendust\` |
| fi_FI | Nati&ve Git/GPG | \`&Natiivi Git/GPG\` |
| gl_ES | Nati&ve Git/GPG | \`Git/GPG &nativos\` |
| pt_BR / pt_PT | &Use pass | \`&Utilizar pass\` (matches source \`U\`) |
| ro_RO | &Restore | \`&restaurați\` (matches source \`R\`) |
| sr_RS | Nati&ve Git/GPG | \`&Nativni Git/GPG\` |

### fi_FI tray menu (collision avoidance)

The system tray menu already had \`&Näytä\`, \`&Piilota\`, \`&Lopeta\` — N, P, L taken. Picked non-conflicting letters for the three new ones:

| Source | Now | Letter |
|---|---|---|
| Mi&nimize | \`P&ienennä\` | i (source N taken) |
| Ma&ximize | \`&Suurenna\` | S (source X not in word) |
| &Restore | \`P&alauta\` | a (source R not in word; P/L taken) |

### Cyrillic

| Locale | Source | Now |
|---|---|---|
| uk_UA | Nati&ve Git/GPG | \`&Вбудований Git/GPG\` |

### Non-Latin (parens-at-start convention)

| Locale | Source | Was | Now |
|---|---|---|---|
| ta_IN | &Use pass | \`& பாச் பயன்படுத்தவும்\` *(stray space — broken)* | \`(&U) பாச் பயன்படுத்தவும்\` |
| ta_IN | Nati&ve Git/GPG | \`சொந்த அறிவிலி/சிபிசி\` *(machine-translated as "own ignorance/cibici")* | \`(&V) சொந்த Git/GPG\` *(restored Git/GPG, kept "சொந்த" = native)* |
| ta_IN | &Show | \`& காட்டு\` | \`(&S) காட்டு\` |
| ta_IN | &Hide | \`& மறை\` | \`(&H) மறை\` |
| ta_IN | Mi&nimize | \`Mi & Nimize\` *(broken English)* | \`(&N) Minimize\` *(left English; native reviewer can translate)* |
| ta_IN | Ma&ximize | \`Ma & ximize\` | \`(&X) Maximize\` |
| ta_IN | &Restore | \`& மீட்டமை\` | \`(&R) மீட்டமை\` |
| zh_Hant | Nati&ve Git/GPG | \`原生 Git/GPG\` | \`(&V) 原生 Git/GPG\` |
| zh_Hant | &Show | \`%顯示\` *(wrong sigil — \`%\` not \`&amp;\`)* | \`(&S) 顯示\` |

### Out of scope

Existing native-letter mnemonics in Cyrillic / Greek / Arabic / Sinhala / Tamil files (where \`&\` is already before a non-Latin letter) were left as-is. Those are acceptable per the RTL/non-Latin Option B convention and don't need fixing — only truly missing/broken mnemonics were touched.

### Verification

- \`lrelease6\`: all 14 files clean (304/304 finished, no warnings)
- Audit script reports 0 missing-mnemonic issues after the fix

## Test plan

- [ ] CI lint passes
- [ ] Native-speaker review on Tamil cleanups in particular (ta_IN had several broken machine translations that I cleaned up minimally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved keyboard accessibility by adding shortcut indicators across 12 language translations. Users can now use keyboard accelerators to quickly navigate menu items and access features. Supported languages include Cymraeg, Danish, German, Estonian, Finnish, Galician, Portuguese, Romanian, Serbian, Tamil, Ukrainian, and Traditional Chinese. This enhancement makes keyboard-based navigation more consistent and efficient across all localized versions of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->