### PR TITLE
i18n(sq_AL): Pathi→Shtegu, paren spacing, HTML tag spacing, period

### DIFF
--- a/localization/localization_sq_AL.ts
+++ b/localization/localization_sq_AL.ts
@@ -132,7 +132,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
         <source>Current path</source>
-        <translation>Pathi aktual</translation>
+        <translation>Shtegu aktual</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
@@ -226,7 +226,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>&amp;Përdorni kalimin(pass)</translation>
+        <translation>&amp;Përdorni kalimin (pass)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
@@ -412,12 +412,12 @@
     <message>
         <location filename="../src/configdialog.cpp" line="914"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store to get it.&lt;br&gt;If you already did so, make sure you started it once and&lt;br&gt;click &quot;Autodetect&quot; in the next dialog.</source>
-        <translation>Ju lutemi instaloni GnuPG në sistemin tuaj. &lt;br&gt; Instaloni &lt;strong&gt; Ubuntu &lt;/strong&gt; nga Microsoft Store për ta marrë. &lt;br&gt; Nëse tashmë e keni bërë një gjë të tillë, sigurohuni që e keni filluar një herë dhe klikoni &quot;Autodetect&quot; në dialogun tjetër.</translation>
+        <translation>Ju lutemi instaloni GnuPG në sistemin tuaj.&lt;br&gt;Instaloni &lt;strong&gt;Ubuntu&lt;/strong&gt; nga Microsoft Store për ta marrë.&lt;br&gt;Nëse tashmë e keni bërë një gjë të tillë, sigurohuni që e keni filluar një herë dhe klikoni &quot;Autodetect&quot; në dialogun tjetër.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="919"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation>Ju lutemi instaloni GnuPG në sistemin tuaj. Instaloni &lt;strong&gt; Ubuntu &lt;/strong&gt; nga Microsoft Store &lt;br&gt; ose &lt;a href = &quot;https://www.gnupg.org/download/#sec-1-2 &quot;&gt; shkarkoni &lt;/a&gt; nga GnuPG.org</translation>
+        <translation>Ju lutemi instaloni GnuPG në sistemin tuaj.&lt;br&gt;Instaloni &lt;strong&gt;Ubuntu&lt;/strong&gt; nga Microsoft Store&lt;br&gt;ose &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;shkarkoni&lt;/a&gt; nga GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
@@ -911,7 +911,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="181"/>
         <source>The email address you typed is not a valid email address.</source>
-        <translation>Adresa e emailit që keni vendosur nuk është e vlefshme .</translation>
+        <translation>Adresa e emailit që keni vendosur nuk është e vlefshme.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="201"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`localization_sq_AL.ts\`. Verified each against the current code; applying four, rejecting one as a false positive (different grammatical context misread as inconsistency).

### Applied

| # | Source | Was | Now |
|---|---|---|---|
| 1 | Current path | \`**Pathi** aktual\` | \`**Shtegu** aktual\` *("Pathi" was a transliteration; \`Shtegu\` is the actual Albanian word, already used at lines 284 and 289)* |
| 2 | &Use pass | \`&Përdorni kalimin**(pass)**\` | \`&Përdorni kalimin **(pass)**\` *(missing space)* |
| 3 | "Please install GnuPG…Microsoft Store" *(both variants)* | \`…tuaj. **&lt;br&gt;** Instaloni **&lt;strong&gt; Ubuntu &lt;/strong&gt;** nga…\` | \`…tuaj.**&lt;br&gt;**Instaloni **&lt;strong&gt;Ubuntu&lt;/strong&gt;** nga…\` *(removed extra spaces around HTML tags to match source; also fixed \`href = "…"\` spacing in the second variant)* |
| 4 | The email address you typed is not a valid email address. | \`…e vlefshme **\\.**\` | \`…e vlefshme**\\.**\` *(removed space before period)* |

For finding 3, the reviewer cited line 420 as the "good example" but it has the same issue as line 415 — both stripped.

### Rejected

> "Updating password-store" — \`dyqanit\` (lines 705, 1112) inconsistent with \`dyqan\` (line 456)

Verified: this is correct Albanian grammar, not inconsistency.

- Line 456 reads \`Dosja %1 nuk duket të jetë **një dyqan** me fjalëkalime\` — \`një\` is the indefinite article, requires nominative \`dyqan\`.
- Lines 705/1112 read \`Përditësimi **i dyqanit** me fjalëkalime\` — \`Përditësimi i …\` ("the update of …") requires the genitive case \`dyqanit\`.

Changing \`dyqanit\` → \`dyqan\` after \`i\` would make those strings non-grammatical. Different cases for different syntactic contexts is correct, not inconsistent.

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Albanian language translations with improved wording and consistent formatting in dialogs and validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->