### PR TITLE
i18n(fr_BE/fr_FR/fr_LU): shared French typos and grammar fixes

### DIFF
--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -104,7 +104,7 @@
     </message>
     <message>
         <source>Include special symbols </source>
-        <translation type="vanished">Utiliser des symbôles spéciaux </translation>
+        <translation type="vanished">Utiliser des symboles spéciaux </translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
@@ -349,7 +349,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
         <source>GnuPG not found</source>
-        <translation>GnuPG n&apos;as pas été trouvé</translation>
+        <translation>GnuPG n&apos;a pas été trouvé</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
@@ -385,7 +385,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Le dossier %1 ne semble pas être un magasin de mots de passe ou n&apos;as pas encore été initialisé.</translation>
+        <translation>Le dossier %1 ne semble pas être un magasin de mots de passe ou n&apos;a pas encore été initialisé.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
@@ -1493,7 +1493,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
         <source>Failed to create folder: %1</source>
-        <translation>Failed pour créer le dossier&#xa0;: %1</translation>
+        <translation>Échec de la création du dossier&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
@@ -1519,7 +1519,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="1697"/>
         <source>Directory does not exist: %1</source>
-        <translation>Annuaire n&apos;existe pas&#xa0;: %1</translation>
+        <translation>Le répertoire n&apos;existe pas&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1702"/>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -123,7 +123,7 @@
     </message>
     <message>
         <source>Include special symbols </source>
-        <translation type="vanished">Utiliser des symbôles spéciaux </translation>
+        <translation type="vanished">Utiliser des symboles spéciaux </translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
@@ -396,7 +396,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
         <source>GnuPG not found</source>
-        <translation>GnuPG n&apos;as pas été trouvé</translation>
+        <translation>GnuPG n&apos;a pas été trouvé</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
@@ -432,7 +432,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Le dossier %1 ne semble pas être un magasin de mots de passe ou n&apos;as pas encore été initialisé.</translation>
+        <translation>Le dossier %1 ne semble pas être un magasin de mots de passe ou n&apos;a pas encore été initialisé.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -104,7 +104,7 @@
     </message>
     <message>
         <source>Include special symbols </source>
-        <translation type="vanished">Utiliser des symbôles spéciaux </translation>
+        <translation type="vanished">Utiliser des symboles spéciaux </translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
@@ -349,7 +349,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
         <source>GnuPG not found</source>
-        <translation>GnuPG n&apos;as pas été trouvé</translation>
+        <translation>GnuPG n&apos;a pas été trouvé</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
@@ -385,7 +385,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Le dossier %1 ne semble pas être un magasin de mots de passe ou n&apos;as pas encore été initialisé.</translation>
+        <translation>Le dossier %1 ne semble pas être un magasin de mots de passe ou n&apos;a pas encore été initialisé.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
@@ -1519,7 +1519,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="1697"/>
         <source>Directory does not exist: %1</source>
-        <translation>Répertoire n&apos;existe pas&#xa0;: %1</translation>
+        <translation>Le répertoire n&apos;existe pas&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1702"/>


### PR DESCRIPTION
## Summary

Reviewer flagged five issues on \`fr_BE\`. Verified each against the current code, applied all five, and propagated the three issues that \`fr_FR\` and \`fr_LU\` share with it — those are pre-existing typos that copy across all three French locales.

### fr_BE only

| Source | Was | Now |
|---|---|---|
| Failed to create folder: %1 | \`**Failed** pour créer le dossier: %1\` *(verb left untranslated)* | \`Échec de la création du dossier: %1\` *(matches fr_FR / fr_LU)* |
| Directory does not exist: %1 | \`**Annuaire** n'existe pas: %1\` *(annuaire = phone directory)* | \`Le répertoire n'existe pas: %1\` |

### fr_LU only

| Source | Was | Now |
|---|---|---|
| Directory does not exist: %1 | \`Répertoire n'existe pas: %1\` *(missing definite article)* | \`Le répertoire n'existe pas: %1\` *(matches fr_FR)* |

### All three locales (fr_BE + fr_FR + fr_LU)

| Source | Was | Now |
|---|---|---|
| Include special symbols *(vanished entry)* | \`Utiliser des **symbôles** spéciaux\` *(stray circumflex)* | \`Utiliser des **symboles** spéciaux\` |
| GnuPG not found | \`GnuPG **n'as** pas été trouvé\` | \`GnuPG **n'a** pas été trouvé\` *(third-person singular: il/elle a, not tu as)* |
| The folder %1 doesn't seem to be a password store… | \`…ou **n'as** pas encore été initialisé\` | \`…ou **n'a** pas encore été initialisé\` *(same conjugation error)* |

The "n'as" → "n'a" fix is the highest-impact one — it's in both a "GnuPG not found" error and the password-store initialisation message, so it's user-visible during setup.

\`lrelease6\`: all three files clean (304/304 finished, no warnings).

## Test plan

- [ ] CI lint passes
- [ ] Native French speaker review (the typos and grammar fixes are unambiguous; the "Annuaire" → "répertoire" change is a clear improvement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected French translations across multiple regional variants (Belgium, France, Luxembourg), including spelling fixes and grammar adjustments for improved translation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->