### PR TITLE
i18n(fr_LU): fix monospaced→monospacée typo

### DIFF
--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -51,7 +51,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <source>Use a monospace font</source>
-        <translation>Utiliser une police monospaced</translation>
+        <translation>Utiliser une police monospacée</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>


### PR DESCRIPTION
## Summary

Reviewer flagged five issues on \`fr_LU\`. Verified each — applying one (clear typo), rejecting four (regional French variation, faithful source translation).

### Applied

| Source | Was | Now |
|---|---|---|
| Use a monospace font | \`Utiliser une police **monospaced**\` | \`Utiliser une police **monospacée**\` *(English word leaked into French; fr_FR already has the correct form)* |

### Rejected

The other four findings either ask to homogenise fr_LU with fr_FR/fr_BE (erasing legitimate regional variation between Metropolitan, Belgian, and Luxembourgish French) or misread distinct source strings as inconsistency:

| # | Finding | Why rejected |
|---|---|---|
| 2 | \`tels quels\` → \`tel quel\` | Both grammatically valid. \`tels quels\` agrees with plural masculine \`fichiers\`; \`tel quel\` is invariable. fr_FR uses \`tel quel\`, fr_BE uses \`tels qu'ils sont\`, fr_LU uses \`tels quels\` — three valid regional choices. |
| 3 | \`Pas de passage à la ligne\` → \`Pas de retour à la ligne\` | fr_FR uses \`Aucune rupture\`, fr_BE uses \`Pas de retour\`, fr_LU uses \`Pas de passage\`. Three valid expressions, three regions. \`Pas de passage à la ligne\` isn't wrong. |
| 4 | \`grands magasins\` → \`grands dépôts\` | fr_FR, fr_BE, **and** fr_LU all use \`magasins\` here. Changing only fr_LU would *diverge* from the other French locales, not improve consistency. Cross-locale terminology question for separate PR. |
| 5 | \`clés GPG\` → \`clés GnuPG\` | Source string is literally \"Generate **GPG** key pair\" (line 877's source is \"Generate **GnuPG** keypair\" — a *different* string). Translation faithfully preserves the GPG/GnuPG distinction. fr_FR and fr_BE make the same distinction. |

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected French (Luxembourgish) translation for the monospace font label with proper spelling and accents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->