### PR TITLE
i18n: fix grammar/calque bugs surfaced by regional-variant audit (7 locales)

### DIFF
--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -579,7 +579,7 @@ email</translation>
         <location filename="../src/configdialog.ui" line="602"/>
         <location filename="../src/ui_configdialog.h" line="939"/>
         <source>Allow searching inside password file contents. Requires decrypting every file and can be slow on large stores.</source>
-        <translation>Lassen Sie die Suche innerhalb der Passwortdatei Inhalte. Erfordert die Entschlüsselung jeder Datei und kann auf großen Geschäften langsam sein.</translation>
+        <translation>Ermöglicht die Suche innerhalb der Inhalte von Passwortdateien. Erfordert das Entschlüsseln jeder Datei und kann bei großen Passwortspeichern langsam sein.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="709"/>

--- a/localization/localization_en_GB.ts
+++ b/localization/localization_en_GB.ts
@@ -1830,7 +1830,7 @@ Continue?</translation>
     <message>
         <location filename="../src/qtpass.cpp" line="512"/>
         <source>Copied to clipboard</source>
-        <translation>copied to clipboard</translation>
+        <translation>Copied to clipboard</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -787,7 +787,7 @@ Vous ne serez pas en mesure de déchiffrer les mots de passe nouvellement ajout�
     <message>
         <location filename="../src/imitatepass.cpp" line="782"/>
         <source>Re-encryption completed: %1 files re-encrypted</source>
-        <translation>Recryptage terminée&#xa0;: %1 fichiers ré-encryptés</translation>
+        <translation>Recryptage terminé&#xa0;: %1 fichiers ré-encryptés</translation>
     </message>
 </context>
 <context>
@@ -1731,12 +1731,12 @@ Continuez&#x202f;?</translation>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation>GPG clé paire génération échouée</translation>
+        <translation>Échec de la génération de la paire de clés GPG</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>
         <source>GPG key pair generated successfully</source>
-        <translation>GPG clé paire générée avec succès</translation>
+        <translation>Paire de clés GPG générée avec succès</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="465"/>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -1883,7 +1883,7 @@ Continuer&#x202f;?</translation>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation>Échec de la génération de la paire de clés GPG échouée</translation>
+        <translation>Échec de la génération de la paire de clés GPG</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -685,7 +685,7 @@ e-mail</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="315"/>
         <source>Failed to sign %1.</source>
-        <translation>L&apos;échec de signer %1.</translation>
+        <translation>Échec de la signature de %1.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="382"/>
@@ -1731,12 +1731,12 @@ Continuez&#x202f;?</translation>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation>GPG clé paire génération échouée</translation>
+        <translation>Échec de la génération de la paire de clés GPG</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>
         <source>GPG key pair generated successfully</source>
-        <translation>GPG clé paire générée avec succès</translation>
+        <translation>Paire de clés GPG générée avec succès</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="465"/>

--- a/localization/localization_nl_BE.ts
+++ b/localization/localization_nl_BE.ts
@@ -116,7 +116,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
         <source>Alphanumerical</source>
-        <translation>Alphanumeriek</translation>
+        <translation>Alfanumeriek</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="388"/>
@@ -141,7 +141,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
         <source>Allow searching inside password file contents. Requires decrypting every file and can be slow on large stores.</source>
-        <translation>Staan zoeken in wachtwoord inhoud. Verzoeken om elk dossier te ontcijferen en kunnen traag zijn op grote winkels.</translation>
+        <translation>Maakt het mogelijk om te zoeken in de inhoud van wachtwoordbestanden. Vereist het ontcijferen van elk bestand en kan traag zijn bij grote opslaglocaties.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="776"/>
@@ -1728,7 +1728,7 @@ Doorgaan?</translation>
     <message>
         <location filename="../src/passworddialog.ui" line="124"/>
         <source>Alphanumerical</source>
-        <translation>Alphanumeriek</translation>
+        <translation>Alfanumeriek</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="129"/>

--- a/localization/localization_pt_BR.ts
+++ b/localization/localization_pt_BR.ts
@@ -1300,7 +1300,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="152"/>
         <source>Case-insensitive toggle</source>
-        <translation>Caso-insensível toggle</translation>
+        <translation>Alternar diferenciação entre maiúsculas e minúsculas</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="155"/>


### PR DESCRIPTION
## Summary

Cross-comparing translations within regional language families (es*/pt*/fr*/de*/nl*/en*) surfaces real bugs where one variant has a broken translation while others have it right. **12 fixes across 7 locales** — preserving the legitimate vocabulary differences between regions, fixing only what's grammatically broken, a calque, or has a typo.

### French (fr_FR, fr_BE, fr_LU)

| Locale | Source | Was | Now |
|---|---|---|---|
| fr_BE / fr_LU | GPG key pair generated successfully | \`GPG clé paire générée avec succès\` *(English calque)* | \`Paire de clés GPG générée avec succès\` *(matches fr_FR)* |
| fr_BE / fr_LU | GPG key pair generation failed | \`GPG clé paire génération échouée\` *(calque)* | \`Échec de la génération de la paire de clés GPG\` |
| fr_FR | GPG key pair generation failed | \`Échec de la génération de la paire de clés GPG **échouée**\` *(redundant — "failure… failed")* | \`Échec de la génération de la paire de clés GPG\` |
| fr_LU | Failed to sign %1. | \`L'échec de signer %1.\` *(broken: "the failure of to sign")* | \`Échec de la signature de %1.\` *(matches fr_FR/fr_BE)* |
| fr_BE | Re-encryption completed: %1 files re-encrypted | \`Recryptage **terminée**\` *(gender mismatch)* | \`Recryptage **terminé**\` |

### German (de_DE)

| Source | Was | Now |
|---|---|---|
| Allow searching inside password file contents… | \`**Lassen Sie** die Suche innerhalb der Passwortdatei Inhalte… auf großen **Geschäften** langsam sein.\` | \`**Ermöglicht** die Suche innerhalb der Inhalte von Passwortdateien… kann bei großen **Passwortspeichern** langsam sein.\` |

Two issues: \`Lassen Sie\` is the imperative "let yourself search" instead of "allows search", and \`Geschäften\` means **department stores**, not password stores.

### Dutch (nl_BE)

| Source | Was | Now |
|---|---|---|
| Allow searching inside password file contents… | \`Staan zoeken in wachtwoord inhoud. Verzoeken om elk dossier te ontcijferen…\` *(calque-broken)* | \`Maakt het mogelijk om te zoeken in de inhoud van wachtwoordbestanden. Vereist het ontcijferen…\` *(matches nl_NL structure)* |
| Alphanumerical | \`Alp**h**anumeriek\` | \`Alfanumeriek\` *(Dutch drops the \`h\`)* |

### Portuguese (pt_BR)

| Source | Was | Now |
|---|---|---|
| Case-insensitive toggle | \`Caso-insensível **toggle**\` *(half-translated)* | \`Alternar diferenciação entre maiúsculas e minúsculas\` |

### English (en_GB)

| Source | Was | Now |
|---|---|---|
| Copied to clipboard | \`**c**opied to clipboard\` | \`**C**opied to clipboard\` *(sentence-initial)* |

### Out of scope (preserving regional variation)

The audit found ~700 differences between regional variants in these families. The 12 above are real bugs; the rest are legitimate regional vocabulary or stylistic differences:

- es_ES \`fichero\` / Latin America \`archivo\`
- pt_BR \`senha\`/\`arquivo\` / pt_PT \`palavra-passe\`/\`ficheiro\`
- de_DE \`Kennwort\` / de_LU \`Passwort\`
- nl_NL \`je\` (informal) / nl_BE \`uw\` (formal)
- fr_FR/fr_BE/fr_LU idiom variants
- zh_CN Simplified vs zh_Hant Traditional
- sr_RS Latin vs sr_Cyrl Cyrillic

Those stay as-is.

\`lrelease6\`: all 7 files clean (304/304 finished, no warnings).

## Test plan

- [ ] CI lint passes
- [ ] Native speaker review (especially the German "Allow searching…" rewrite and the Dutch one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved translations for German, English (GB), French (Belgium, France, Luxembourg), Dutch (Belgium), and Portuguese (Brazil) localization files.
  * Enhanced grammatical accuracy, sentence structure, and wording clarity across UI messages, settings descriptions, and error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->