### PR TITLE
i18n(zh_Hant): homogenise CJK mnemonics to (&L)-at-start convention

### DIFF
--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -276,7 +276,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>&amp;使用pass</translation>
+        <translation>(&amp;U) 使用pass</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
@@ -1787,27 +1787,27 @@ Continue?</source>
     <message>
         <location filename="../src/trayicon.cpp" line="69"/>
         <source>&amp;Hide</source>
-        <translation>&amp;隱藏</translation>
+        <translation>(&amp;H) 隱藏</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation>最小化(&amp;N)</translation>
+        <translation>(&amp;N) 最小化</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation>最大化(&amp;X)</translation>
+        <translation>(&amp;X) 最大化</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation>&amp;恢復</translation>
+        <translation>(&amp;R) 恢復</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>
         <source>&amp;Quit</source>
-        <translation>&amp;退出</translation>
+        <translation>(&amp;Q) 退出</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Summary

The project's Qt mnemonic guideline §2 specifies that for CJK locales, mnemonics should be added as a Latin letter in parentheses at the start of the translation, not via the native script. \`zh_Hant\` had a mix of three styles across the 8 mnemonic-bearing entries:

| Style | Examples | Status |
|---|---|---|
| Parens-at-start `(&L) 文字` | Nati&ve Git/GPG, &Show | ✓ already correct |
| Parens-at-end `文字(&L)` | Mi&nimize, Ma&ximize | needs reorder |
| In-word native `&文字` | &Use pass, &Hide, &Restore, &Quit | needs conversion |

Standardised all 8 to the canonical form:

| Source | Was | Now |
|---|---|---|
| &Use pass | `&使用pass` | `(&U) 使用pass` |
| &Hide | `&隱藏` | `(&H) 隱藏` |
| &Restore | `&恢復` | `(&R) 恢復` |
| &Quit | `&退出` | `(&Q) 退出` |
| Mi&nimize | `最小化(&N)` | `(&N) 最小化` |
| Ma&ximize | `最大化(&X)` | `(&X) 最大化` |

Source mnemonic letters preserved (U/H/R/Q/N/X) so users with muscle memory for the English keyboard shortcuts keep them working.

\`lrelease6\`: 304 finished / 0 unfinished, no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Traditional Chinese localization with standardized keyboard shortcut mnemonic markers. Menu items and dialog options now display consistent mnemonic formatting, making keyboard navigation more discoverable and accessible. Changes include updated formatting for application menu actions and configuration dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->