### PR TITLE
i18n(zh_Hant): fix 儲存擋 → 儲存庫 typo in password-store creation prompt

### DIFF
--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -453,7 +453,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>請問您想新增密碼儲存擋在 %1?</translation>
+        <translation>請問您想新增密碼儲存庫在 %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="728"/>


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Traditional Chinese translation for the password store creation dialog prompt, improving clarity and accuracy for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->