### PR TITLE
i18n(lv_LV): fix Copy to Clipboard, "invalid" verb, status labels

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -545,7 +545,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="52"/>
         <source>Copy to Clipboard</source>
-        <translation>Iekopyēt īpašuma leņķī</translation>
+        <translation>Kopēt starpliktuvē</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="59"/>
@@ -599,7 +599,7 @@ e-pasts</translation>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
         <source>Signature for %1 is invalid.</source>
-        <translation>Segnojums par %1 ir neierast.</translation>
+        <translation>Paraksts par %1 ir nederīgs.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="149"/>
@@ -611,7 +611,7 @@ e-pasts</translation>
         <location filename="../src/imitatepass.cpp" line="150"/>
         <location filename="../src/imitatepass.cpp" line="599"/>
         <source>Could not read encryption key to use, .gpg-id file missing or invalid.</source>
-        <translation>Nepieciešama šifrēšanas koda atsauces faila piekļuve nav iespējama, .gpg-id faila trūkums vai neierast.</translation>
+        <translation>Nepieciešama šifrēšanas koda atsauces faila piekļuve nav iespējama, .gpg-id fails trūkst vai ir nederīgs.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
@@ -1648,12 +1648,12 @@ Sarkanie ieraksti nav derīgi; jūs nevarēsiet tos šifrēt.</translation>
     <message>
         <location filename="../src/usersdialog.cpp" line="336"/>
         <source>[EXPIRED] </source>
-        <translation>[IETRUŠTS] </translation>
+        <translation>[BEIDZIES] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="340"/>
         <source>[PARTIAL] </source>
-        <translation>[PĀRZĪMĒTS] </translation>
+        <translation>[DAĻĒJS] </translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`lv_LV\`. Verified each against current main, applied all five.

| # | Source | Was | Now |
|---|---|---|---|
| 1 | Copy to Clipboard | \`Iekopyēt īpašuma leņķī\` *(non-word "y" + ≈"owner's angle")* | \`Kopēt starpliktuvē\` |
| 2 | Signature for %1 is invalid. | \`Segnojums par %1 ir **neierast**.\` *("Segnojums" not Latvian; "neierast" ≈ "to not get used to")* | \`Paraksts par %1 ir **nederīgs**.\` |
| 3 | Could not read encryption key… missing or invalid. | …faila trūkums vai **neierast**. | …fails trūkst vai ir **nederīgs**. |
| 4 | [EXPIRED] | \`[IETRUŠTS]\` *(non-word)* | \`[BEIDZIES]\` *(ended/expired)* |
| 5 | [PARTIAL] | \`[PĀRZĪMĒTS]\` *(≈"redrawn")* | \`[DAĻĒJS]\` *(partial)* |

Trailing space on bracket labels preserved to match source format.

\`lrelease6\`: 272/272 finished, no warnings. Audit: 0 placeholder mismatches.

## Test plan

- [x] CI lint passes
- [ ] Native Latvian speaker review through Weblate (the bracket-label word choices in particular — "BEIDZIES" vs "BEIDZIS" / "DAĻĒJS" vs alternatives)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Latvian language translations across the interface, including button labels, error messages for signature validation and configuration issues, and user status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->