### PR TITLE
i18n(lv_LV, lt_LT): fill remaining translation gaps + Latvian quality fixes

### DIFF
--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -840,7 +840,7 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="210"/>
         <source>Repeat pass</source>
-        <translation type="unfinished">Pakartoti slaptažodį</translation>
+        <translation type="unfinished">Pakartoti slaptafrazę</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="227"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -296,7 +296,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="846"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="877"/>
@@ -390,12 +390,12 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.ui" line="1095"/>
         <source>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; version </source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; version </translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="68"/>
         <source>System tray is not available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sistemos dėklas nepasiekiamas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
@@ -815,7 +815,7 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
         <source>Generate a new key pair</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sukurti naują raktų porą</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="91"/>
@@ -830,7 +830,7 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="155"/>
         <source>Passphrase</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Slaptafrazė</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="200"/>
@@ -840,7 +840,7 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="210"/>
         <source>Repeat pass</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pakartoti slaptažodį</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="227"/>
@@ -1095,7 +1095,7 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="668"/>
         <source>OTP code copied to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">OTP kodas nukopijuotas į iškarpinę</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
@@ -1105,12 +1105,12 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="704"/>
         <source>Password and Content hidden</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Slaptažodis ir turinys paslėpti</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="784"/>
         <source>Looking for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Ieškoma: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>
@@ -1206,7 +1206,7 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1390"/>
         <source>Rename password</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pervadinti slaptažodį</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1400"/>
@@ -1216,17 +1216,17 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1412"/>
         <source>Re-encrypt all passwords</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Iš naujo užšifruoti visus slaptažodžius</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1417"/>
         <source>Export my public key...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Eksportuoti mano viešąjį raktą...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1423"/>
         <source>Add recipient...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pridėti gavėją...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1428"/>
@@ -1261,17 +1261,17 @@ Jūs negalėsite pakeisti naudotojų sąrašo!</translation>
         <location filename="../src/mainwindow.cpp" line="1510"/>
         <location filename="../src/mainwindow.cpp" line="1546"/>
         <source>Rename file</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pervadinti failą</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>
         <source>Rename Folder To: </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pervadinti aplanką į: </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1546"/>
         <source>Rename File To: </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pervadinti failą į: </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1697"/>
@@ -1310,7 +1310,9 @@ Continue?</source>
         <source>Could not export public key for %1.
 
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nepavyko eksportuoti viešojo rakto %1.
+
+%2</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1770"/>
@@ -1612,12 +1614,12 @@ Red entries are not valid, you will not be able to encrypt to these.</source>
     <message>
         <location filename="../src/usersdialog.cpp" line="76"/>
         <source>Keylist missing</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Trūksta raktų sąrašo</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="77"/>
         <source>Could not fetch list of available GPG keys</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nepavyko gauti pasiekiamų GPG raktų sąrašo</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="153"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -296,7 +296,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="846"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="877"/>
@@ -390,12 +390,12 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.ui" line="1095"/>
         <source>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; version </source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; version </translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="68"/>
         <source>System tray is not available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sistēmas paplāte nav pieejama</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
@@ -472,7 +472,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
         <source>GnuPG not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">GnuPG nav atrasts</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="914"/>
@@ -643,7 +643,7 @@ Jūs nevarat dekriptēt jebkuru jauno ierosināto paroli!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="315"/>
         <source>Failed to sign %1.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Neizdevās parakstīt %1.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="382"/>
@@ -666,7 +666,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
         <source>Failed to replace %1. Original has been restored.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Neizdevās aizstāt %1. Oriģināls ir atjaunots.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
@@ -860,17 +860,17 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/keygendialog.cpp" line="168"/>
         <source>Invalid name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nederīgs nosaukums</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nosaukumam jābūt vismaz 5 rakstzīmes garam.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>
         <source>Invalid email</source>
-        <translation>Nevalids e-pasta adrese</translation>
+        <translation>Nederīga e-pasta adrese</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="181"/>
@@ -940,7 +940,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.ui" line="155"/>
         <source>Toggle case-insensitive content search</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pārslēgt no reģistra neatkarīgu satura meklēšanu</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="211"/>
@@ -950,7 +950,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.ui" line="263"/>
         <source>Welcome to QtPass</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Laipni lūdzam QtPass</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="322"/>
@@ -965,7 +965,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
         <location filename="../src/mainwindow.ui" line="382"/>
         <location filename="../src/mainwindow.cpp" line="1373"/>
         <source>Add password</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pievienot paroli</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="385"/>
@@ -1250,12 +1250,12 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
         <source>Failed to create folder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Neizdevās izveidot mapi: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
         <source>Failed to create .gpg-id file in: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Neizdevās izveidot .gpg-id failu: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>
@@ -1335,7 +1335,7 @@ Continue?</source>
     <message>
         <location filename="../src/pass.cpp" line="158"/>
         <source>Invalid password length</source>
-        <translation>Neplatība paroles garuma dēļ</translation>
+        <translation>Nederīgs paroles garums</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="159"/>
@@ -1432,7 +1432,7 @@ Continue?</source>
         <location filename="../main/main.cpp" line="155"/>
         <location filename="../main/main.cpp" line="159"/>
         <source>LTR</source>
-        <translation type="unfinished"></translation>
+        <translation>LTR</translation>
     </message>
 </context>
 <context>
@@ -1539,7 +1539,7 @@ Continue?</source>
     <message>
         <location filename="../src/storemodel.cpp" line="412"/>
         <source>overwrite %1 with %2?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">pārrakstīt %1 ar %2?</translation>
     </message>
 </context>
 <context>
@@ -1618,32 +1618,32 @@ Sarkanie ieraksti nav derīgi; jūs nevarēsiet tos šifrēt.</translation>
     <message>
         <location filename="../src/usersdialog.cpp" line="76"/>
         <source>Keylist missing</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Atslēgu saraksts trūkst</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="77"/>
         <source>Could not fetch list of available GPG keys</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nevarēja iegūt pieejamo GPG atslēgu sarakstu</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="153"/>
         <source>Key not found in keyring</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Atslēga nav atrasta atslēgu saišķī</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="306"/>
         <source>created</source>
-        <translation type="unfinished"></translation>
+        <translation>izveidots</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="310"/>
         <source>expires</source>
-        <translation type="unfinished"></translation>
+        <translation>beidzas</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="333"/>
         <source>[INVALID] </source>
-        <translation type="unfinished"></translation>
+        <translation>[NEDERĪGS] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="336"/>


### PR DESCRIPTION
## Summary

Fill the remaining translation gaps in Latvian and Lithuanian, plus two quality fixes on Latvian.

| Locale | Before | After |
|---|---|---|
| lv_LV | 272 finished, 32 empty gaps | 278 finished, 15 unfinished-with-text, 11 empty (long paragraphs) |
| lt_LT | 262 finished, 42 empty gaps | 278 finished, 16 unfinished-with-text, 9 empty (long paragraphs) |

### Confident fixes (finalized)

**Latvian quality fixes** — same \`nederīgs\` family the reviewer flagged for PR #1247:
- "Invalid email": \`Nevalids e-pasta adrese\` → \`Nederīga e-pasta adrese\`
- "Invalid password length": \`Neplatība paroles garuma dēļ\` → \`Nederīgs paroles garums\`

**Source-verbatim / trivial** (both locales):
- HTML link blocks → source verbatim (the visible link text is a URL, not a phrase to localise)
- LTR token (lv_LV) → \`LTR\`

**Bracket labels** (lv_LV only — matches the convention from PR #1247):
- \`[INVALID]\` → \`[NEDERĪGS]\`
- \`created\` → \`izveidots\`
- \`expires\` → \`beidzas\`

### Best-effort short labels (kept \`type="unfinished"\` for Weblate review)

~30 strings across both locales — things like "System tray is not available", "Failed to sign %1", "OTP code copied to clipboard", "Rename password", "Could not fetch list of available GPG keys".

These are machine-quality starting points. They reach users (Qt's lrelease writes unfinished strings to .qm) but are flagged for Weblate reviewers to refine.

### Left for native review (~10/locale)

Long paragraph translations not touched here:
- The 3 GnuPG-install hint variants
- The passphrase-length advisory (\`<html>...There is no limit on the length...\`)
- \`<h3>Sharing Passwords with GPG</h3>...\` help block (lv_LV)
- \`<h3>Export Your Public Key</h3>...\` help block (lt_LT)
- "Select which users should be able to decrypt..." recipient-selector explanation (lt_LT)
- "QtPass is a GUI for..." about block
- "Re-encrypt all passwords in %1?..." full confirmation prompt
- A few others

Translating GnuPG-domain prose without a native speaker is high-risk — leaving for Weblate native reviewers.

### Verification

- \`lrelease6\` clean for both files
- Audit reports 0 placeholder mismatches, 0 missing mnemonics, 0 HTML imbalances

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV / lt_LT review through Weblate (all unfinished entries are flagged for that purpose)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added complete Lithuanian translations for UI strings in configuration, key generation, main window, export/errors, and user dialogs
  * Updated and completed Latvian translations for configuration links, system/GnuPG status, validation and error messages, main window actions, prompts, and users dialog metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->