### PR TITLE
i18n(lv_LV): fix 5 mistranslated config-dialog strings

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -197,7 +197,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
         <source>Allow searching inside password file contents. Requires decrypting every file and can be slow on large stores.</source>
-        <translation>Izveidot meklējumu parādījumos parādījuma faila saturā. Šajā procesā ir nepieciešama atvieglošana katras failas un var būt ātruma jautājumiem lielās datu iekšējās pārvaldībās.</translation>
+        <translation>Atļaut meklēt paroļu failu saturā. Nepieciešams atšifrēt katru failu, un lielās glabātuvēs tas var būt lēni.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="624"/>
@@ -271,7 +271,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
         <source>Generate GPG key pair</source>
-        <translation>Izveidot GPG atbilstošu pārslēgšanas paaudzi</translation>
+        <translation>Izveidot GPG atslēgu pāri</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="786"/>
@@ -301,7 +301,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="877"/>
         <source>Autodetect</source>
-        <translation>Automātiskais atdzesēšana</translation>
+        <translation>Automātiskā noteikšana</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="900"/>
@@ -326,12 +326,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
         <source>Path to the password store directory</source>
-        <translation>Pateiksmes uz paroles pārvaldes kataloga</translation>
+        <translation>Ceļš uz paroļu glabātuves katalogu</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="965"/>
         <source>Signing Key</source>
-        <translation>Saglabāšanas ciprs</translation>
+        <translation>Parakstīšanas atslēga</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="968"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`lv_LV\` config-dialog translations. Verified each on current main, applied all five.

| Source | Was (≈ meaning) | Now |
|---|---|---|
| Allow searching inside password file contents… | \`Izveidot meklējumu parādījumos parādījuma… ātruma jautājumiem lielās datu iekšējās pārvaldībās.\` *(calque-broken)* | \`Atļaut meklēt paroļu failu saturā. Nepieciešams atšifrēt katru failu, un lielās glabātuvēs tas var būt lēni.\` |
| Generate GPG key pair | \`Izveidot GPG atbilstošu pārslēgšanas paaudzi\` *(≈ "matching switching generation")* | \`Izveidot GPG atslēgu pāri\` |
| Autodetect | \`Automātiskais atdzesēšana\` *(= "automatic cooling")* | \`Automātiskā noteikšana\` |
| Path to the password store directory | \`**Pateiksmes** uz paroles pārvaldes kataloga\` *(\`Pateiksmes\` = thanksgiving)* | \`**Ceļš** uz paroļu glabātuves katalogu\` *(matches \`Ceļš\` already used elsewhere)* |
| Signing Key | \`Saglabāšanas ciprs\` *(≈ "storage cipher/digit")* | \`Parakstīšanas atslēga\` |

\`lrelease6\` clean.

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced Latvian language translations for configuration options, including improved clarity for search functionality, key generation, autodetection, storage paths, and signing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->