### PR TITLE
i18n(lv_LV): fix 5 more mistranslated strings (3rd batch)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -400,7 +400,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
         <source>Pass OTP extension needs to be installed</source>
-        <translation>Pass OTP uzstādes jāinstalē</translation>
+        <translation>Pass OTP paplašinājums jāinstalē</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="100"/>
@@ -415,12 +415,12 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>
         <source>Always copy to clipboard</source>
-        <translation>Visur kopēt uz īpašuma koplēdzinājumu</translation>
+        <translation>Vienmēr kopēt uz starpliktuvi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="127"/>
         <source>On-demand copy to clipboard</source>
-        <translation>Piemērota kopējuma uzklāšana</translation>
+        <translation>Pēc pieprasījuma kopēt uz starpliktuvi</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="210"/>
@@ -502,7 +502,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>
         <source>Failed to create password-store at: %1</source>
-        <translation>Nepieciešama krājuma izveide no %1 neplānojas</translation>
+        <translation>Neizdevās izveidot paroļu krātuvi vietā: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
@@ -555,7 +555,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="28"/>
         <source>Public key for %1</source>
-        <translation>%1 parakstīšanas vārds</translation>
+        <translation>Publiskā atslēga lietotājam %1</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="67"/>


### PR DESCRIPTION
## Summary

Third batch of reviewer findings on \`lv_LV\`. Verified each on fresh main, applied all five.

| Source | Was (≈ meaning) | Now |
|---|---|---|
| Pass OTP extension needs to be installed | \`Pass OTP **uzstādes** jāinstalē\` *(uzstādes ≈ settings)* | \`Pass OTP paplašinājums jāinstalē\` |
| Always copy to clipboard | \`**Visur** kopēt uz **īpašuma koplēdzinājumu**\` *(≈ "everywhere…property co-agreement")* | \`Vienmēr kopēt uz starpliktuvi\` *(matches \`starpliktuvi\` from PR #1247)* |
| On-demand copy to clipboard | \`**Piemērota kopējuma uzklāšana**\` *(≈ "suitable application of the total copy")* | \`Pēc pieprasījuma kopēt uz starpliktuvi\` |
| Failed to create password-store at: %1 | \`Nepieciešama krājuma izveide no %1 neplānojas\` *(≈ "necessary stock creation from %1 is not planned")* | \`Neizdevās izveidot paroļu krātuvi vietā: %1\` |
| Public key for %1 | \`%1 parakstīšanas vārds\` *(≈ "%1's signing name")* | \`Publiskā atslēga lietotājam %1\` |

\`lrelease6\` clean. Audit: 0 placeholder mismatches.

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Latvian translations for improved clarity of user-facing UI messages, including OTP notifications, clipboard behavior options, error messages, and dialog labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->