### PR TITLE
i18n(lv_LV): fix 5 more mistranslated strings (4th batch)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -410,7 +410,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="125"/>
         <source>No Clipboard</source>
-        <translation>Nav klipbordas</translation>
+        <translation>Nav starpliktuves</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>
@@ -567,7 +567,7 @@ e-pasts</translation>
         <location filename="../src/exportpublickeydialog.cpp" line="90"/>
         <location filename="../src/exportpublickeydialog.cpp" line="100"/>
         <source>Save Public Key</source>
-        <translation>Saglabājiet publisku vārdu</translation>
+        <translation>Saglabājiet publisko atslēgu</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.cpp" line="84"/>
@@ -592,7 +592,7 @@ e-pasts</translation>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
         <source>Check .gpgid file signature!</source>
-        <translation>Pārbaudīt .gpgid faila segnojumu!</translation>
+        <translation>Pārbaudīt .gpgid faila parakstu!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -661,7 +661,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
         <location filename="../src/imitatepass.cpp" line="662"/>
         <location filename="../src/imitatepass.cpp" line="769"/>
         <source>Re-encryption failed</source>
-        <translation>Atgriezenais šifrēšana neplānojas</translation>
+        <translation>Atkārtota šifrēšana neizdevās</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
@@ -737,7 +737,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/importkeydialog.ui" line="27"/>
         <source>Import a GPG public key from file or paste it below. The key should be in ASCII-armored format.</source>
-        <translation>Ielieciet GPG publisku paroli no faila vai ievadiet to šeit. Paroles jābūt ASCII armored formāta.</translation>
+        <translation>Importējiet GPG publisko atslēgu no faila vai ielīmējiet to zemāk. Atslēgai jābūt ASCII-armored formātā.</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.ui" line="42"/>


### PR DESCRIPTION
## Summary

Fourth batch of reviewer findings on \`lv_LV\`. Verified each on fresh main, applied all five.

| Source | Was (≈ meaning) | Now |
|---|---|---|
| No Clipboard | \`Nav **klipbordas**\` *(transliteration of English)* | \`Nav starpliktuves\` *(matches established term)* |
| Save Public Key | \`Saglabājiet publisku **vārdu**\` *(= "public word/name")* | \`Saglabājiet publisko atslēgu\` |
| Check .gpgid file signature! | \`...faila **segnojumu**!\` *(non-Latvian)* | \`...faila parakstu!\` |
| Re-encryption failed | \`**Atgriezenais šifrēšana neplānojas**\` *(≈ "the returnable encryption is not planned")* | \`Atkārtota šifrēšana neizdevās\` |
| Import a GPG public key from file or paste it below… | \`**Ielieciet** GPG publisku **paroli**…\` *(= "insert GPG public password")* | \`Importējiet GPG publisko atslēgu… Atslēgai jābūt ASCII-armored formātā.\` |

\`lrelease6\` clean.

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined Latvian translations with improved accuracy and clarity across the user interface, including enhanced terminology for security operations and key management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->