### PR TITLE
i18n(lv_LV): pattern-extension fixes from prior PR learnings (10 strings)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -611,7 +611,7 @@ e-pasts</translation>
         <location filename="../src/imitatepass.cpp" line="150"/>
         <location filename="../src/imitatepass.cpp" line="599"/>
         <source>Could not read encryption key to use, .gpg-id file missing or invalid.</source>
-        <translation>Nepieciešama šifrēšanas koda atsauces faila piekļuve nav iespējama, .gpg-id fails trūkst vai ir nederīgs.</translation>
+        <translation>Nevarēja nolasīt šifrēšanas atslēgu izmantošanai, .gpg-id fails trūkst vai ir nederīgs.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
@@ -621,7 +621,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation>Nepieciešama ierobežošana, lai atvērtu .gpg-id failu uzrakstīšanai.</translation>
+        <translation>Neizdevās atvērt .gpg-id failu rakstīšanai.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="274"/>
@@ -713,7 +713,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="770"/>
         <source>Failed to re-encrypt %1</source>
-        <translation>Nepieciešama atšifrēšana %1 neplānojusies</translation>
+        <translation>Neizdevās atkārtoti šifrēt %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="776"/>
@@ -780,7 +780,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/importkeydialog.cpp" line="52"/>
         <source>Could not open file: %1</source>
-        <translation>Nepieciešama faila atvēršana: %1</translation>
+        <translation>Nevarēja atvērt failu: %1</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="67"/>
@@ -797,7 +797,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/importkeydialog.cpp" line="127"/>
         <source>Could not parse imported key id from GPG output.</source>
-        <translation>Nepieciešama ievades paraksta identifikācijas atpazīšana no GPG izvada.</translation>
+        <translation>Nevarēja parsēt importētās atslēgas id no GPG izvada.</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="172"/>
@@ -1095,7 +1095,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="668"/>
         <source>OTP code copied to clipboard</source>
-        <translation>OTP kods iekopēts uz klipbordu</translation>
+        <translation>OTP kods kopēts starpliktuvē</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
@@ -1298,7 +1298,7 @@ Continue?</source>
         <location filename="../src/mainwindow.cpp" line="1747"/>
         <location filename="../src/mainwindow.cpp" line="1767"/>
         <source>Export Public Key</source>
-        <translation>Eksportēt publisku vārdu</translation>
+        <translation>Eksportēt publisko atslēgu</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1748"/>
@@ -1310,7 +1310,7 @@ Continue?</source>
         <source>Could not export public key for %1.
 
 %2</source>
-        <translation>Nepieciešama publiska šifrēšanas funkcija, %1. 
+        <translation>Nevarēja eksportēt publisko atslēgu lietotājam %1.
 
 %2</translation>
     </message>
@@ -1446,7 +1446,7 @@ Continue?</source>
         <location filename="../src/qtpass.cpp" line="223"/>
         <source>Failed to connect WebDAV:
 </source>
-        <translation>Nepieciešama telpa WebDAV:
+        <translation>Neizdevās savienoties ar WebDAV:
 </translation>
     </message>
     <message>
@@ -1526,7 +1526,7 @@ Continue?</source>
     <message>
         <location filename="../src/qtpass.cpp" line="512"/>
         <source>Copied to clipboard</source>
-        <translation>Iekopēts uz klipbordu</translation>
+        <translation>Kopēts starpliktuvē</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Summary

Audited \`lv_LV\` for the systematic mistranslation patterns surfaced by recent reviewer findings (PRs #1247–#1253). Found **10 more strings** exhibiting the same issues.

### Pattern 1: \`Nepieciešama\` misused for \"Failed/Could not\" (7 strings)

Latvian \`Nepieciešam*\` means \"necessary/needed\" — wrong word for failure messages. The established convention from prior PRs:
- \"Failed\" → \`Neizdevās\`
- \"Could not\" → \`Nevarēja\`

| Source | Was | Now |
|---|---|---|
| Could not read encryption key… | \`Nepieciešama šifrēšanas koda atsauces faila piekļuve nav iespējama…\` | \`Nevarēja nolasīt šifrēšanas atslēgu izmantošanai…\` |
| Failed to open .gpg-id for writing. | \`Nepieciešama ierobežošana, lai atvērtu…\` *(≈ "necessary restriction")* | \`Neizdevās atvērt .gpg-id failu rakstīšanai.\` |
| Failed to re-encrypt %1 | \`Nepieciešama atšifrēšana %1 neplānojusies\` | \`Neizdevās atkārtoti šifrēt %1\` |
| Could not open file: %1 | \`Nepieciešama faila atvēršana: %1\` | \`Nevarēja atvērt failu: %1\` |
| Could not parse imported key id from GPG output. | \`Nepieciešama ievades paraksta identifikācijas atpazīšana…\` | \`Nevarēja parsēt importētās atslēgas id no GPG izvada.\` |
| Could not export public key for %1.\\n\\n%2 | \`Nepieciešama publiska šifrēšanas funkcija, %1. \\n\\n%2\` | \`Nevarēja eksportēt publisko atslēgu lietotājam %1.\\n\\n%2\` |
| Failed to connect WebDAV:\\n | \`Nepieciešama telpa WebDAV:\\n\` *(≈ "necessary room WebDAV")* | \`Neizdevās savienoties ar WebDAV:\\n\` |

### Pattern 2: \`vārdu\` (word/name) → \`atslēgu\` (key) (1 string)

Sibling of the \"Save Public Key\" fix in PR #1253:

| Source | Was | Now |
|---|---|---|
| Export Public Key | \`Eksportēt publisku **vārdu**\` *(= "export public name")* | \`Eksportēt publisko atslēgu\` |

### Pattern 3: \`klipbord*\` → \`starpliktuv*\` (2 strings)

The \`klipbords\` transliteration was already replaced with \`starpliktuv*\` in several strings (PRs #1247, #1251, #1253). These two were missed.

| Source | Was | Now |
|---|---|---|
| OTP code copied to clipboard | \`OTP kods iekopēts uz **klipbordu**\` | \`OTP kods kopēts **starpliktuvē**\` |
| Copied to clipboard | \`Iekopēts uz **klipbordu**\` | \`Kopēts **starpliktuvē**\` |

### Verification

- \`lrelease6\` clean
- 0 placeholder issues, 0 HTML imbalances

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved Latvian translations with corrected error messages for encryption, export, and import operations; refined clipboard notifications; and updated UI text for key export and WebDAV connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->