### PR TITLE
i18n(lv_LV): fix 5 more mistranslations (5th batch)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -316,7 +316,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="952"/>
         <source>Profile name, used to identify this configuration profile</source>
-        <translation>Profila vārds, izmantots identificēt šo konfigurācijas profiļu</translation>
+        <translation>Profila vārds, izmantots šī konfigurācijas profila identificēšanai</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
@@ -512,7 +512,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Krājuma pārvaldības katalogs %1 nav parast, vai tā darbība vēl nav ieviesta.</translation>
+        <translation>Mape %1 nešķiet paroles krātuve vai arī tā vēl nav inicializēta.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
@@ -632,8 +632,8 @@ e-pasts</translation>
         <location filename="../src/imitatepass.cpp" line="275"/>
         <source>None of the selected keys have a secret key available.
 You will not be able to decrypt any newly added passwords!</source>
-        <translation>Nav pieejami jebkura salīdzinoši tālu atslēgas.
-Jūs nevarat dekriptēt jebkuru jauno ierosināto paroli!</translation>
+        <translation>Nevienai no izvēlētajām atslēgām nav pieejama slepenā atslēga.
+Jūs nevarēsiet atšifrēt nevienu no jaunpievienotajām parolēm!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="314"/>
@@ -671,7 +671,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
         <source>Creating backup commit</source>
-        <translation>Izveidojam atvērtu kopkopu</translation>
+        <translation>Izveidojam dublējuma kommitu</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="698"/>
@@ -682,7 +682,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="699"/>
         <source>Could not inspect git status. Re-encryption was aborted.</source>
-        <translation>Nevarēja pārbaudīt Git stāvokli. Pārencēšana tika atcelta.</translation>
+        <translation>Nevarēja pārbaudīt Git stāvokli. Pārešifrēšana tika atcelta.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="707"/>


### PR DESCRIPTION
## Summary

Fifth batch of reviewer findings on \`lv_LV\`. Verified each on fresh main, applied all five.

| Source | Was | Now |
|---|---|---|
| Profile name, used to identify this configuration profile | \`Profila vārds, izmantots **identificēt** šo konfigurācijas **profiļu**\` *(wrong case ending)* | \`Profila vārds, izmantots šī konfigurācijas profila identificēšanai\` |
| The folder %1 doesn't seem to be a password store or is not yet initialised. | \`Krājuma pārvaldības katalogs %1 nav **parast**, vai tā darbība vēl nav ieviesta.\` *(parast = incomplete word)* | \`Mape %1 nešķiet paroles krātuve vai arī tā vēl nav inicializēta.\` |
| None of the selected keys have a secret key available… | …**salīdzinoši tālu atslēgas**… *(≈ "comparatively distant keys")* | …**slepenā atslēga**… *(secret key)* + cleaner full sentence |
| Creating backup commit | Izveidojam **atvērtu kopkopu** *(≈ "open duplicate-duplicate")* | Izveidojam dublējuma kommitu |
| Could not inspect git status. Re-encryption was aborted. | …**Pārencēšana** tika atcelta. *(made-up word)* | …Pārešifrēšana tika atcelta. |

\`lrelease6\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Latvian UI translations: clarified configuration profile label, rephrased password-store initialization error, updated "no selected secret keys" warning wording, and refined re-encryption progress/error messages and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->