### PR TITLE
i18n(lv_LV): finalize 2, fill 2, add translator-comment on 1

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -666,7 +666,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
         <source>Failed to replace %1. Original has been restored.</source>
-        <translation type="unfinished">Neizdevās aizstāt %1. Oriģināls ir atjaunots.</translation>
+        <translation>Neizdevās aizstāt %1. Oriģināls ir atjaunots.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
@@ -835,6 +835,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="200"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;There is no limit on the length of a passphrase, and it should be carefully chosen. From the perspective of security, the passphrase to unlock the private key is one of the weakest points in GnuPG (and other public-key encryption systems as well) since it is the only protection you have if another individual gets your private key. &lt;br/&gt;Ideally, the passphrase should not use words from a dictionary and should mix the case of alphabetic characters as well as use non-alphabetic characters.&lt;br/&gt;A good passphrase is crucial to the secure use of GnuPG.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translatorcomment>TODO(lv_LV): Intentionally left untranslated for now; fallback to source text until reviewed by a Latvian translator.</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -850,17 +851,17 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="246"/>
         <source>Template contents will be set based on GPG version.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veidnes saturs tiks iestatīts atbilstoši GPG versijai.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="259"/>
         <source>For expert options check out the &lt;a href=&quot;https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html&quot;&gt;GnuPG manual&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksperta opcijām skatiet &lt;a href=&quot;https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html&quot;&gt;GnuPG rokasgrāmatu&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="168"/>
         <source>Invalid name</source>
-        <translation type="unfinished">Nederīgs nosaukums</translation>
+        <translation>Nederīgs nosaukums</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`lv_LV\`. Verified each on fresh main, applied all five.

### Finalized (\`type="unfinished"\` removed — text was already correct)

| Source | Translation |
|---|---|
| Failed to replace %1. Original has been restored. | \`Neizdevās aizstāt %1. Oriģināls ir atjaunots.\` |
| Invalid name | \`Nederīgs nosaukums\` |

### Filled (reviewer provided Latvian, finalized)

| Source | Now |
|---|---|
| Template contents will be set based on GPG version. | \`Veidnes saturs tiks iestatīts atbilstoši GPG versijai.\` |
| For expert options check out the &lt;a href=…&gt;GnuPG manual&lt;/a&gt; | \`Eksperta opcijām skatiet <a href=…>GnuPG rokasgrāmatu</a>\` *(HTML preserved verbatim)* |

### Translator-comment

The long passphrase advisory block (\`<html>...There is no limit on the length of a passphrase...</html>\`) stays untranslated for now, but added a \`<translatorcomment>\` per the reviewer's suggestion explaining it's intentionally awaiting Latvian native review, not just forgotten.

\`lrelease6\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Latvian language translations across multiple user interface components and dialogs, including critical error messages for password operations, template content descriptions, expert configuration options, and passphrase guidance, while implementing smart fallback language support for translations under review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->