### PR TITLE
i18n(lv_LV): finalize 3 + fill 2 (About block, delete warning)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -951,7 +951,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.ui" line="263"/>
         <source>Welcome to QtPass</source>
-        <translation type="unfinished">Laipni lūdzam QtPass</translation>
+        <translation>Laipni lūdzam QtPass</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="322"/>
@@ -959,7 +959,10 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
 &lt;p&gt;Please report any &lt;a href=&quot;https://github.com/IJHack/qtpass/issues&quot;&gt;issues&lt;/a&gt; you might have with this software.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&quot;https://qtpass.org/&quot;&gt;Documentation&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;&lt;a href=&quot;https://github.com/IJHack/qtpass&quot;&gt;SourceCode&lt;/a&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;QtPass ir grafiskā saskarne priekš &lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;pass&lt;/a&gt;, standarta Unix paroļu pārvaldnieka.&lt;/p&gt;
+&lt;p&gt;Lūdzu, ziņojiet par jebkādām &lt;a href=&quot;https://github.com/IJHack/qtpass/issues&quot;&gt;problēmām&lt;/a&gt;, ar kurām saskaraties, lietojot šo programmatūru.&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://qtpass.org/&quot;&gt;Dokumentācija&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://github.com/IJHack/qtpass&quot;&gt;Pirmkods&lt;/a&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="379"/>
@@ -1167,7 +1170,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1084"/>
         <source> and the whole content? &lt;br&gt;&lt;strong&gt;Attention: there are unexpected files in the given folder, check them before continue.&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation> un visu saturu? &lt;br&gt;&lt;strong&gt;Uzmanību: norādītajā mapē ir neparedzēti faili, pārbaudiet tos pirms turpināt.&lt;/strong&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1093"/>
@@ -1251,12 +1254,12 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
         <source>Failed to create folder: %1</source>
-        <translation type="unfinished">Neizdevās izveidot mapi: %1</translation>
+        <translation>Neizdevās izveidot mapi: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
         <source>Failed to create .gpg-id file in: %1</source>
-        <translation type="unfinished">Neizdevās izveidot .gpg-id failu: %1</translation>
+        <translation>Neizdevās izveidot .gpg-id failu: %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`lv_LV\`. Verified each on fresh main, applied all five.

### Finalized (\`type="unfinished"\` removed — text was already correct)

| Source | Translation |
|---|---|
| Welcome to QtPass | \`Laipni lūdzam QtPass\` |
| Failed to create folder: %1 | \`Neizdevās izveidot mapi: %1\` |
| Failed to create .gpg-id file in: %1 | \`Neizdevās izveidot .gpg-id failu: %1\` |

### Filled (reviewer-supplied long-paragraph translations)

**About block** (\`<p>QtPass is a GUI for…</p>...<p>SourceCode</p>\`): full Latvian translation provided. All \`<p>\`/\`<a href>\` tags preserved.

**Delete-confirmation extension** (\` and the whole content? <br><strong>Attention: there are unexpected files in the given folder, check them before continue.</strong>\`):

\`un visu saturu? <br><strong>Uzmanību: norādītajā mapē ir neparedzēti faili, pārbaudiet tos pirms turpināt.</strong>\`

### Verification

- \`lrelease6\` clean
- 0 placeholder issues, 0 HTML tag imbalances
- lv_LV: 292 → **295 finished + 5 unfinished** out of 304

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Latvian language translations for multiple user-facing messages, including the application welcome message, main description, file validation warnings, and error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->