### PR TITLE
i18n(lv_LV): finalize 3 + fill 2 long paragraphs (final round)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -969,7 +969,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
         <location filename="../src/mainwindow.ui" line="382"/>
         <location filename="../src/mainwindow.cpp" line="1373"/>
         <source>Add password</source>
-        <translation type="unfinished">Pievienot paroli</translation>
+        <translation>Pievienot paroli</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="385"/>
@@ -1296,7 +1296,13 @@ This will re-encrypt ALL password files in this folder using the current recipie
 This may rewrite many files and cannot be undone easily.
 
 Continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Pāratšifrēt visas paroles mapē %1?
+
+Tādējādi tiks pāratšifrēti VISI paroļu faili šajā mapē, izmantojot pašreizējos saņēmējus, kas definēti failā .gpg-id.
+
+Tas var pārrakstīt daudzus failus, un šo darbību nevar viegli atsaukt.
+
+Turpināt?</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1747"/>
@@ -1331,7 +1337,7 @@ Continue?</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="1798"/>
         <source>&lt;h3&gt;Sharing Passwords with GPG&lt;/h3&gt;&lt;p&gt;To share passwords with other users:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;&lt;b&gt;Export your public key&lt;/b&gt; and send it to teammates&lt;/li&gt;&lt;li&gt;&lt;b&gt;Import teammates&apos; public keys&lt;/b&gt; into your GPG keyring&lt;/li&gt;&lt;li&gt;&lt;b&gt;Re-encrypt passwords&lt;/b&gt; so all recipients can decrypt them&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Only people who have a matching secret key can decrypt the passwords.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Tip:&lt;/b&gt; Use the same GPG key for all shared folders.&lt;/p&gt;&lt;p&gt;See the FAQ for more details.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h3&gt;Paroļu kopīgošana ar GPG&lt;/h3&gt;&lt;p&gt;Lai kopīgotu paroles ar citiem lietotājiem:&lt;/p&gt;&lt;ol&gt;&lt;li&gt;&lt;b&gt;Eksportējiet savu publisko atslēgu&lt;/b&gt; un nosūtiet to komandas biedriem&lt;/li&gt;&lt;li&gt;&lt;b&gt;Importējiet komandas biedru publiskās atslēgas&lt;/b&gt; savā GPG atslēgu saišķī&lt;/li&gt;&lt;li&gt;&lt;b&gt;Pāršifrējiet paroles&lt;/b&gt;, lai visi saņēmēji varētu tās atšifrēt&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Paroles var atšifrēt tikai tie, kuriem ir atbilstoša slepenā atslēga.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Padoms:&lt;/b&gt; Izmantojiet vienu un to pašu GPG atslēgu visām koplietotajām mapēm.&lt;/p&gt;&lt;p&gt;Plašāku informāciju skatiet BUJ.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -1543,7 +1549,7 @@ Continue?</source>
     <message>
         <location filename="../src/storemodel.cpp" line="412"/>
         <source>overwrite %1 with %2?</source>
-        <translation type="unfinished">pārrakstīt %1 ar %2?</translation>
+        <translation>pārrakstīt %1 ar %2?</translation>
     </message>
 </context>
 <context>
@@ -1622,7 +1628,7 @@ Sarkanie ieraksti nav derīgi; jūs nevarēsiet tos šifrēt.</translation>
     <message>
         <location filename="../src/usersdialog.cpp" line="76"/>
         <source>Keylist missing</source>
-        <translation type="unfinished">Atslēgu saraksts trūkst</translation>
+        <translation>Atslēgu saraksts trūkst</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="77"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`lv_LV\`. Verified each on fresh main, applied all five.

### Finalized (\`type="unfinished"\` removed — text was already correct)

| Source | Translation |
|---|---|
| Add password | \`Pievienot paroli\` |
| overwrite %1 with %2? | \`pārrakstīt %1 ar %2?\` |
| Keylist missing | \`Atslēgu saraksts trūkst\` |

### Filled (reviewer-supplied long-paragraph translations)

**Re-encrypt confirmation prompt** (\`Re-encrypt all passwords in %1?\\n\\nThis will…cannot be undone easily.\\n\\nContinue?\`):

Full Latvian translation, multi-paragraph structure preserved (\`Pāratšifrēt visas paroles mapē %1?…Turpināt?\`).

**Sharing-passwords-with-GPG help block** (\`<h3>Sharing Passwords with GPG</h3>...<p>See the FAQ for more details.</p>\`):

Full Latvian. All HTML tags (\`<h3>\`/\`<p>\`/\`<ol>\`/\`<li>\`/\`<b>\`) preserved exactly.

### Verification

- \`lrelease6\` clean
- 0 placeholder issues, 0 HTML tag imbalances
- lv_LV: 297 → **300 finished + 4 unfinished** out of 304 sources

## Test plan

- [ ] CI lint passes
- [ ] Native lv_LV review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed Latvian language localization by finalizing previously unfinished translations across the application. Updated UI strings now provide complete Latvian text for password re-encryption confirmations with detailed messages, password sharing help documentation with proper formatting, and standard action labels for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->