### PR TITLE
i18n(sl_SI): fix 5 mistranslations (mostly grammar/cross-language)

### DIFF
--- a/localization/localization_sl_SI.ts
+++ b/localization/localization_sl_SI.ts
@@ -197,7 +197,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="602"/>
         <source>Allow searching inside password file contents. Requires decrypting every file and can be slow on large stores.</source>
-        <translation type="unfinished">Dovolite pretrago v sadržju geselske datoteke. Zahteva dešifriranje vsake datoteke in lahko na velikih bazi podatkov je težko.</translation>
+        <translation type="unfinished">Dovoli iskanje po vsebini datotek z gesli. Zahteva dešifriranje vsake datoteke in je lahko počasno pri velikih bazah podatkov.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="624"/>
@@ -271,7 +271,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
         <source>Generate GPG key pair</source>
-        <translation type="unfinished">Generiraj GPG ključno paro</translation>
+        <translation type="unfinished">Ustvari GPG ključno paro</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="786"/>
@@ -316,7 +316,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="952"/>
         <source>Profile name, used to identify this configuration profile</source>
-        <translation type="unfinished">Profilno ime, uporabljan za identifikacijo ta konfiguracijski profil</translation>
+        <translation type="unfinished">Profilno ime, uporabljeno za identifikacijo tega konfiguracijskega profila</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
@@ -326,12 +326,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
         <source>Path to the password store directory</source>
-        <translation type="unfinished">Pot do zbiralne datoteke gesel</translation>
+        <translation type="unfinished">Pot do mape shrambe gesel</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="965"/>
         <source>Signing Key</source>
-        <translation type="unfinished">Podpisna ključ</translation>
+        <translation type="unfinished">Podpisni ključ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="968"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on \`sl_SI\`. Verified each on fresh main, applied all five.

| Source | Was | Now |
|---|---|---|
| Allow searching inside password file contents… | …v **sadržju** geselske datoteke… na velikih bazi podatkov **je težko**. *(Croatian/Serbian "sadržju" + ungrammatical case)* | …po **vsebini** datotek z gesli… pri velikih bazah podatkov **je počasno**. |
| Generate GPG key pair | **Generiraj** GPG ključno paro | **Ustvari** GPG ključno paro *(consistency)* |
| Profile name, used to identify this configuration profile | …**uporabljan** za identifikacijo **ta konfiguracijski profil** *(wrong gender + nominative instead of genitive)* | …**uporabljeno** za identifikacijo **tega konfiguracijskega profila** |
| Path to the password store directory | Pot do **zbiralne datoteke** gesel *(≈ "collection files")* | Pot do **mape shrambe** gesel |
| Signing Key | **Podpisna** ključ *(feminine adjective on masculine noun)* | **Podpisni** ključ |

\`lrelease6\` clean.

## Test plan

- [ ] CI lint passes
- [ ] Native sl_SI review through Weblate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Slovenian (sl_SI) translations with refined phrasing, improved terminology, and grammatical adjustments in the configuration dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->