### PR TITLE
i18n(lt_LT): fix Clipboard term + 4 mistranslation cleanups

### DIFF
--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -535,7 +535,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="14"/>
         <source>Export Public Key</source>
-        <translation>Eksportuoti viešąjį klaidų raktą</translation>
+        <translation>Eksportuoti viešąjį raktą</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="27"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -410,7 +410,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="125"/>
         <source>No Clipboard</source>
-        <translation>Ne klaviatūros kopija</translation>
+        <translation>Nėra iškarpinės</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -462,7 +462,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="810"/>
         <source>No profile selected</source>
-        <translation>Nepraeista profilio pasirinkimas</translation>
+        <translation>Nepasirinktas profilis</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -415,7 +415,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>
         <source>Always copy to clipboard</source>
-        <translation>Visada kopijuokite į klaviatūros kopių</translation>
+        <translation>Visada kopijuoti į iškarpinę</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="127"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -420,7 +420,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="127"/>
         <source>On-demand copy to clipboard</source>
-        <translation>Atsakomybė prieigos kopijuoti</translation>
+        <translation>Kopijuoti į iškarpinę pagal poreikį</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="210"/>


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._