### PR TITLE
i18n(sl_SI): fix Izrašeno→Izraženo typo in numerus forms

### DIFF
--- a/localization/localization_sl_SI.ts
+++ b/localization/localization_sl_SI.ts
@@ -1135,9 +1135,9 @@ Ne boste mogli spremeniti seznama uporabnikov!</translation>
         <source>Found %n match(es)</source>
         <translation>
             <numerusform>Izraženo %n ustreznico</numerusform>
-            <numerusform>Izrašeno %n ustreznice</numerusform>
-            <numerusform>Izrašenih %n ustreznic</numerusform>
-            <numerusform>Izrašenih %n ustreznica</numerusform>
+            <numerusform>Izraženo %n ustreznice</numerusform>
+            <numerusform>Izraženih %n ustreznic</numerusform>
+            <numerusform>Izraženih %n ustreznica</numerusform>
         </translation>
     </message>
     <message numerus="yes">


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._