### PR TITLE
i18n(lt_LT): fix saugykla→saugyklą accusative + Plikoje→Aplanke + pabaigą→parašą

### DIFF
--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -592,7 +592,7 @@ el. paštas</translation>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
         <source>Check .gpgid file signature!</source>
-        <translation>Peržiūrėti .gpgid failo pabaigą!</translation>
+        <translation>Peržiūrėti .gpgid failo parašą!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -497,7 +497,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>Ar norėtumėte sukurti slaptažodžių saugykla %1?</translation>
+        <translation>Ar norėtumėte sukurti slaptažodžių saugyklą %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -436,7 +436,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="721"/>
         <source>Would you like to create a password store at %1?</source>
-        <translation>Ar norite sukurti slaptažodžių saugykla %1?</translation>
+        <translation>Ar norite sukurti slaptažodžių saugyklą %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="728"/>

--- a/localization/localization_lt_LT.ts
+++ b/localization/localization_lt_LT.ts
@@ -512,7 +512,7 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Plikoje %1 nėra slaptažodžių saugykla arba ji dar nebuvo inicijuota.</translation>
+        <translation>Aplanke %1 nėra slaptažodžių saugykla arba ji dar nebuvo inicijuota.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>


### PR DESCRIPTION
_This PR applies 4/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lithuanian language translations with corrected grammar and phrasing for password store prompts, folder labels, and file signature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->