### PR TITLE
i18n(lv_LV): fix atstupts→atcelts typo + 'run in terminal' phrasing

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -687,7 +687,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="707"/>
         <source>Re-encryption was aborted because a git backup could not be created.</source>
-        <translation>Atjauninājums tika atstupts, jo neizdevās izveidot Git rezervēto kopiju.</translation>
+        <translation>Atjauninājums tika atcelts, jo neizdevās izveidot Git rezervēto kopiju.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="729"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -1313,7 +1313,7 @@ Turpināt?</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1748"/>
         <source>&lt;h3&gt;Export Your Public Key&lt;/h3&gt;&lt;p&gt;No signing key is configured. Set one in QtPass Settings &amp;gt; GPG keys, or run this in a terminal:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;your-key-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Then send the file to your teammates.&lt;/p&gt;</source>
-        <translation>&lt;h3&gt;Eksportējiet Jūsu Publisku Klīnu&lt;/h3&gt;&lt;p&gt;Nepieciešama klīna nav iestatīta. Iestatiet vienu QtPass Configurācijā &amp;gt; GPG klīnē vai veiciniet šo uz termināla:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;jūsu-klīna-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Tad nosūtiet failu savai komandai.&lt;/p&gt;</translation>
+        <translation>&lt;h3&gt;Eksportējiet Jūsu Publisku Klīnu&lt;/h3&gt;&lt;p&gt;Nepieciešama klīna nav iestatīta. Iestatiet vienu QtPass Configurācijā &amp;gt; GPG klīnē vai izpildiet šo terminālī:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;jūsu-klīna-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Tad nosūtiet failu savai komandai.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1768"/>


### PR DESCRIPTION
_This PR applies 2/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings). 3 suggestions were skipped to avoid creating conflicts._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Latvian UI translations with clearer error messaging and refined terminal command execution instructions for improved user clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->