### PR TITLE
i18n(lv_LV): fix Klīnu→Atslēgu (key) in export help + 4 other cleanups

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -1313,7 +1313,7 @@ Turpināt?</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1748"/>
         <source>&lt;h3&gt;Export Your Public Key&lt;/h3&gt;&lt;p&gt;No signing key is configured. Set one in QtPass Settings &amp;gt; GPG keys, or run this in a terminal:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;your-key-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Then send the file to your teammates.&lt;/p&gt;</source>
-        <translation>&lt;h3&gt;Eksportējiet Jūsu Publisku Klīnu&lt;/h3&gt;&lt;p&gt;Nepieciešama klīna nav iestatīta. Iestatiet vienu QtPass Configurācijā &amp;gt; GPG klīnē vai izpildiet šo terminālī:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;jūsu-klīna-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Tad nosūtiet failu savai komandai.&lt;/p&gt;</translation>
+        <translation>&lt;h3&gt;Eksportējiet Jūsu Publisko Atslēgu&lt;/h3&gt;&lt;p&gt;Nepieciešamā atslēga nav iestatīta. Iestatiet vienu QtPass Configurācijā &amp;gt; GPG atslēgās vai izpildiet šo terminālī:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;jūsu-atslēgas-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Tad nosūtiet failu savai komandai.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1768"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -376,7 +376,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1068"/>
         <source>Show all fields templated</source>
-        <translation>Parādiet visus formu laukus</translation>
+        <translation>Rādīt visus veidņu laukus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1080"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -497,7 +497,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>Vēlaties izveidot paroļu krātuvi %1?</translation>
+        <translation>Vai vēlaties izveidot paroļu krātuvi %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -1225,7 +1225,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1417"/>
         <source>Export my public key...</source>
-        <translation>Eksportējiet manu publikāciju...</translation>
+        <translation>Eksportēt manu publisko atslēgu...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1423"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -452,7 +452,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="747"/>
         <source>Select recipients for %1</source>
-        <translation>Izvēlieties saņēmējus priekš %1</translation>
+        <translation>Izvēlieties saņēmējus mapei %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="773"/>
@@ -1313,7 +1313,7 @@ Turpināt?</translation>
     <message>
         <location filename="../src/mainwindow.cpp" line="1748"/>
         <source>&lt;h3&gt;Export Your Public Key&lt;/h3&gt;&lt;p&gt;No signing key is configured. Set one in QtPass Settings &amp;gt; GPG keys, or run this in a terminal:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;your-key-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Then send the file to your teammates.&lt;/p&gt;</source>
-        <translation>&lt;h3&gt;Eksportējiet Jūsu Publisko Atslēgu&lt;/h3&gt;&lt;p&gt;Nepieciešamā atslēga nav iestatīta. Iestatiet vienu QtPass Configurācijā &amp;gt; GPG atslēgās vai izpildiet šo terminālī:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;jūsu-atslēgas-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Tad nosūtiet failu savai komandai.&lt;/p&gt;</translation>
+        <translation>&lt;h3&gt;Eksportējiet Jūsu Publisko Atslēgu&lt;/h3&gt;&lt;p&gt;Nav konfigurēta parakstīšanas atslēga. Iestatiet to QtPass iestatījumos &amp;gt; GPG atslēgas vai izpildiet šo terminālī:&lt;/p&gt;&lt;pre&gt;gpg --armor --export --output my_key.asc &amp;lt;jūsu-atslēgas-id&amp;gt;&lt;/pre&gt;&lt;p&gt;Tad nosūtiet failu savai komandai.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1768"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -452,7 +452,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="747"/>
         <source>Select recipients for %1</source>
-        <translation>Izvēlieties saņēmējus par %1</translation>
+        <translation>Izvēlieties saņēmējus priekš %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="773"/>


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Latvian UI text for configuration dialogs and main window: clearer wording and grammar for template fields, recipient selection context, password-store prompts, and public-key export instructions (including command placeholder wording) for a more natural, user-friendly experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->