### PR TITLE
i18n(lv_LV): rename krātuve→glabātuve for password-store (5 occurrences)

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -512,7 +512,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Mape %1 nešķiet paroles krātuve vai arī tā vēl nav inicializēta.</translation>
+        <translation>Mape %1 nešķiet paroles glabātuve vai arī tā vēl nav inicializēta.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
@@ -698,7 +698,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
         <location filename="../src/imitatepass.cpp" line="732"/>
         <location filename="../src/imitatepass.cpp" line="787"/>
         <source>Updating password-store</source>
-        <translation>Paroļu krātuves atjaunināšana</translation>
+        <translation>Paroļu glabātuves atjaunināšana</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="757"/>
@@ -1076,7 +1076,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
         <location filename="../src/mainwindow.cpp" line="501"/>
         <location filename="../src/mainwindow.cpp" line="514"/>
         <source>Updating password-store</source>
-        <translation>Paroles pārvaldīšanas atjauninājums</translation>
+        <translation>Paroļu glabātuves atjaunināšana</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="625"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -507,7 +507,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation>Paroļu krātuve nav inicializēta</translation>
+        <translation>Paroļu glabātuve nav inicializēta</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -497,7 +497,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>Vai vēlaties izveidot paroļu krātuvi vietā %1?</translation>
+        <translation>Vai vēlaties izveidot paroļu glabātuvi vietā %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -502,7 +502,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>
         <source>Failed to create password-store at: %1</source>
-        <translation>Neizdevās izveidot paroļu krātuvi vietā: %1</translation>
+        <translation>Neizdevās izveidot paroļu glabātuvi vietā: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -436,7 +436,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="721"/>
         <source>Would you like to create a password store at %1?</source>
-        <translation>Vai vēlaties izveidot paroļu krātuvi vietā %1?</translation>
+        <translation>Vai vēlaties izveidot paroļu glabātuvi vietā %1?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="728"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -492,7 +492,7 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="979"/>
         <source>Create password-store?</source>
-        <translation>Izveidot paroļu krātuvi?</translation>
+        <translation>Izveidot paroļu glabātuvi?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Latvian translations to use consistent terminology "paroļu glabātuve/glabātuvi" for password storage UI.
  * Applied wording changes across creation prompts, error/failure messages, initialization notices, folder messages, and update status text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->