### PR TITLE
i18n(lv_LV): fix kommit→komit (single-m) typo on backup commit strings

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -677,7 +677,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
         <location filename="../src/imitatepass.cpp" line="698"/>
         <location filename="../src/imitatepass.cpp" line="706"/>
         <source>Backup commit failed</source>
-        <translation>Dublējuma kommita izveide neizdevās</translation>
+        <translation>Dublējuma komita izveide neizdevās</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="699"/>

--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -671,7 +671,7 @@ Jūs nevarēsiet mainīt lietotāju sarakstu!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
         <source>Creating backup commit</source>
-        <translation>Izveidojam dublējuma kommitu</translation>
+        <translation>Izveidojam dublējuma komitu</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="698"/>


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._