### PR TITLE
i18n(si_LK): fix 5 more mistranslations (Clipboard/panel/file display/line wrap/Show output)

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -76,7 +76,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="245"/>
         <source>Show process output</source>
-        <translation>විශේෂෙන කොටසේ අභාගවල පිළිබඳ මූල්‍ය සාර්ථකතාව විශේෂණ කරන්න</translation>
+        <translation>ක්‍රියාවලි ප්‍රතිදානය පෙන්වන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="277"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -66,7 +66,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
         <source>Display the files content as-is</source>
-        <translation>මුලින්ම කොටසේ අභාගවල තහවුරු කරන්න</translation>
+        <translation>ගොනු අන්තර්ගතය මුල් අයුරින් ම පෙන්වන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="238"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -16,7 +16,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="72"/>
         <source>Clipboard behaviour:</source>
-        <translation>කොපියා ප්‍රකාශනය:</translation>
+        <translation>පිටපත් පුවරුව හැසිරීම:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -71,7 +71,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="238"/>
         <source>No line wrapping</source>
-        <translation>පිළිබඳ පත්‍ර තම්පුකරණය අසලේ</translation>
+        <translation>පේළි එතීම අක්‍රිය</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="245"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -56,7 +56,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation>පැටෙන් සඳහා අතුසා කිරීම:</translation>
+        <translation>පැනලය ස්වයංක්‍රීයව මකා දැමීම:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Updated Sinhala language translations for configuration dialog settings, including clipboard behavior, autoclear panel timing, file content display, line wrapping, and process output options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->