### PR TITLE
[REJECT] i18n: edits .ts source string instead of UI — would break translation lookup

### DIFF
--- a/localization/localization_lv_LV.ts
+++ b/localization/localization_lv_LV.ts
@@ -36,7 +36,7 @@
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
-        <source>Content panel behaviour:</source>
+        <source>Content panel behavior:</source>
         <translation>Satura paneļa uzvedība:</translation>
     </message>
     <message>


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._