### PR TITLE
docs(skills): update localization guidance + add audit skill

### DIFF
--- a/.opencode/skills/qtpass-localization-audit/SKILL.md
+++ b/.opencode/skills/qtpass-localization-audit/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: qtpass-localization-audit
+description: QtPass localization audit - structural checks on .ts files (placeholders, HTML balance, mnemonics, mixed-script artifacts)
+license: GPL-3.0-or-later
+metadata:
+  audience: developers
+  workflow: localization
+---
+
+# QtPass Localization Audit
+
+Structural audits for `.ts` translation files. Use this **before** merging large translation contributions (machine-translated batches from Qwen, GPT, Gemini, etc.) and **after** reviewer-supplied refinements that could disturb non-obvious bits like placeholder format or HTML structure.
+
+The audit catches issues that produce broken UI but read as plausible translations:
+
+- Missing or malformed Qt placeholders (`%1`, `%2`).
+- HTML tag imbalance — translation drops or adds `<br>`/`<strong>`/`<a>`/`<p>` etc.
+- Missing keyboard mnemonics where source has `&Letter`.
+- Mixed-script artifacts (Latin letters glued onto a non-Latin word mid-character).
+- Wrong-string mappings (translation block doesn't match its source — copypaste error).
+- Cross-language leaks (Slovenian text in a Sinhala file, etc.).
+
+## Quick audit (single file)
+
+The Quick audit covers **placeholders, mnemonics, HTML tag balance, and mixed-script artifacts** only.
+
+It does **not** detect wrong-string mappings (translation block paired with the wrong source) or cross-language leaks. For those, run the scripts in [Targeted patterns](#targeted-patterns) — `Find wrong-string mappings` and `Find Slovenian leaks (or any cross-locale leak)` — or the full standard cleanup workflow below.
+
+```bash
+python3 <<'EOF'
+import re, os
+LOC = 'localization/localization_lv_LV.ts'   # change as needed
+
+with open(LOC) as f:
+    content = f.read()
+
+mnemonic_sources = {
+    '&amp;Use pass', 'Nati&amp;ve Git/GPG',
+    '&amp;Show', '&amp;Hide', '&amp;Restore', '&amp;Quit',
+    'Mi&amp;nimize', 'Ma&amp;ximize',
+}
+
+# Locale-to-script map for mixed-script detection. Add ranges as needed.
+LOCALE_TO_SCRIPT_RANGES = {
+    'si': '඀-෿',           # Sinhala
+    'ta': '஀-௿',           # Tamil
+    'hi': 'ऀ-ॿ',           # Devanagari
+    'ru': 'Ѐ-ӿ', 'uk': 'Ѐ-ӿ', 'bg': 'Ѐ-ӿ', 'sr': 'Ѐ-ӿ',
+    'el': 'Ͱ-Ͽ',           # Greek
+    'zh': '一-鿿', 'ja': '぀-ゟ゠-ヿ一-鿿', 'ko': '가-힯',
+    'ar': '؀-ۿ', 'he': '֐-׿',
+}
+lang = os.path.basename(LOC).replace('localization_', '').replace('.ts', '').split('_')[0]
+script_range = LOCALE_TO_SCRIPT_RANGES.get(lang)  # None for Latin-script locales
+
+ph = mn = html = mixed = wrong = 0
+for m in re.finditer(
+    r'<message[^>]*>.*?<source>(.*?)</source>.*?<translation([^>]*)>(.*?)</translation>',
+    content, re.DOTALL
+):
+    src, attrs, trans = m.group(1), m.group(2), m.group(3)
+    if 'vanished' in attrs or not trans.strip():
+        continue
+
+    # 1. Placeholder integrity. %1, %2, ... must match exactly.
+    # %n is the Qt plural placeholder: if source uses it, the translation
+    # must use it too (once per <numerusform>), but the count is allowed
+    # to differ across plural forms.
+    s_ph = sorted(re.findall(r'%\d+', src))
+    t_ph = sorted(re.findall(r'%\d+', trans))
+    s_has_n = bool(re.search(r'%n\b', src))
+    t_has_n = bool(re.search(r'%n\b', trans))
+    if s_ph != t_ph or s_has_n != t_has_n or re.search(r'%\s+(?:\d|n)', trans):
+        ph += 1
+        print(f'  [PH]   {src[:60]}\n         -> {trans[:80]}')
+
+    # 2. Missing mnemonics on known mnemonic-bearing sources
+    if src in mnemonic_sources and not re.search(r'&amp;[^\s&;]', trans):
+        mn += 1
+        print(f'  [MN]   {src} -> {trans[:60]}')
+
+    # 3. HTML tag balance (per-tag count must match source)
+    for tag in ['html','body','p','br','strong','a','h3','pre','code','b','ol','li']:
+        s_o = len(re.findall(rf'&lt;{tag}[ /&gt;]', src))
+        s_c = len(re.findall(rf'&lt;/{tag}&gt;', src))
+        t_o = len(re.findall(rf'&lt;{tag}[ /&gt;]', trans))
+        t_c = len(re.findall(rf'&lt;/{tag}&gt;', trans))
+        if s_o != t_o or s_c != t_c:
+            html += 1
+            print(f'  [HTML] {src[:40]} | <{tag}> s={s_o}/{s_c} t={t_o}/{t_c}')
+            break
+
+    # 4. Mixed-script (Latin letter glued to a non-Latin word, or vice versa).
+    # Skipped automatically for Latin-script locales (script_range is None).
+    if script_range:
+        mixed_re = re.compile(f'[{script_range}]+[a-z]+|[a-z]+[{script_range}]+')
+        if mixed_re.search(trans):
+            mixed += 1
+            print(f'  [MIX]  {src[:40]} | {trans[:60]}')
+
+print(f'\nplaceholder={ph} mnemonic={mn} html={html} mixed-script={mixed}')
+EOF
+```
+
+## All-files sweep
+
+For a quick across-the-board check (no per-issue printing, just counts):
+
+```bash
+python3 <<'EOF'
+import re, os, glob
+mnemonic_sources = {
+    '&amp;Use pass','Nati&amp;ve Git/GPG','&amp;Show','&amp;Hide',
+    '&amp;Restore','&amp;Quit','Mi&amp;nimize','Ma&amp;ximize',
+}
+total_ph = total_mn = total_html = 0
+for f in sorted(glob.glob('localization/localization_*.ts')):
+    loc = os.path.basename(f).replace('localization_','').replace('.ts','')
+    content = open(f).read()
+    ph = mn = html = 0
+    for m in re.finditer(r'<message[^>]*>.*?<source>(.*?)</source>.*?<translation([^>]*)>(.*?)</translation>', content, re.DOTALL):
+        src,a,t = m.group(1), m.group(2), m.group(3)
+        if 'vanished' in a or not t.strip(): continue
+        s_ph = sorted(re.findall(r'%\d+', src))
+        t_ph = sorted(re.findall(r'%\d+', t))
+        s_n = bool(re.search(r'%n\b', src)); t_n = bool(re.search(r'%n\b', t))
+        if s_ph != t_ph or s_n != t_n or re.search(r'%\s+(?:\d|n)', t): ph += 1
+        if src in mnemonic_sources and not re.search(r'&amp;[^\s&;]', t): mn += 1
+        for tag in ['html','body','p','br','strong','a','h3','pre','code','b','ol','li']:
+            s_o = len(re.findall(rf'&lt;{tag}[ /&gt;]', src))
+            s_c = len(re.findall(rf'&lt;/{tag}&gt;', src))
+            t_o = len(re.findall(rf'&lt;{tag}[ /&gt;]', t))
+            t_c = len(re.findall(rf'&lt;/{tag}&gt;', t))
+            if s_o != t_o or s_c != t_c:
+                html += 1; break
+    if ph or mn or html:
+        print(f'{loc:8s}  ph={ph:3d}  mn={mn:3d}  html={html:3d}')
+    total_ph += ph; total_mn += mn; total_html += html
+print(f'---\ntotal: ph={total_ph} mn={total_mn} html={total_html}')
+EOF
+```
+
+## Common machine-translation artifact patterns
+
+The audit finds _structural_ breakage; _semantic_ problems need eye review. Patterns we've repeatedly caught from machine-translated contributions:
+
+- **Wrong-meaning calques**: `Atgriezt paroli` (= "Return password") for "Repeat password" in lv_LV; `Iekrētāja lekts` (≈ "Mr. [Non-word] sheet") for "Clipboard cleared".
+- **Placeholder corruption**: `% 1` (with space) instead of `%1` — Qt won't substitute and renders the literal.
+- **Cross-language loanwords**: Croatian `sadržju` (= "content") in a Slovenian file; Latvian `Parole` for "password" appearing in Lithuanian.
+- **Made-up verb forms**: `Pārencēšana` (made-up Latvian for "re-encryption" — should be `Pāršifrēšana`); `būtošana` (made-up from `būt` = "to be") for "status".
+- **Wrong word-association**: `පොලීසිය` (Sinhala for "police") for "search"; `මුදල්`/`මූල්‍ය` ("money"/"financial") for unrelated concepts; `හාර්ය` ("wife") for "key".
+- **Repetition glitches**: `kopkopu` ("duplicate-duplicate") in lv_LV for "backup"; same fragment repeated 3× in a single string for sl_SI.
+- **Wrong sigil for mnemonic**: `%顯示` instead of `&amp;顯示` for `&Show`.
+- **JSON delimiter leak**: translation ends with stray `},{` characters (machine-translation tooling fragment).
+- **Stray Latin words mid-script**: `&lt;b&gt;Clipboard&lt;/b&gt;` left untranslated inside an otherwise-Sinhala paragraph.
+- **Alphabet character set translated**: the password generator's `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789` source must NOT be translated. Some MT pipelines insert hyphens (`A-Z-...`) or substitute regional letters (`abcdeļš` for the middle of the alphabet) — both break password generation.
+
+## Standard cleanup workflow for MT contributions
+
+When a friend-or-bot contributes a batch of machine translations:
+
+1. **Commit the contribution as-is** (one commit, attribute properly):
+
+   ```bash
+   git checkout -b LangFromContributor upstream/main
+   git checkout -- localization/localization_<lang>.ts  # in case of unrelated working-tree noise
+   git add localization/localization_<lang>.ts
+   git commit -S -m "i18n(<lang>): translations from <Contributor>"
+   ```
+
+2. **Run the audit** (single-file form above).
+3. **For each finding, decide**:
+   - Placeholder mismatch → either fix the placeholder or revert to empty `<translation type="unfinished"></translation>` for native review.
+   - HTML imbalance on a long paragraph → revert to empty.
+   - Mixed-script artifact → revert to empty unless one obvious fix applies.
+   - Alphabet character-set mistranslation → restore source verbatim.
+   - Missing mnemonic → add per Qt mnemonic conventions (see `qtpass-localization` skill).
+4. **Commit the cleanup** as a second commit on the same branch (this keeps the contribution diff reviewable).
+5. **Re-run the audit** to confirm 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
+6. **`lrelease6` smoke test**:
+
+   ```bash
+   lrelease6 localization/localization_<lang>.ts | tail -3
+   rm -f localization/localization_<lang>.qm
+   ```
+
+7. **Push and PR**, attributing the contributor in the commit body / PR description.
+
+## Targeted patterns
+
+The patterns below cover checks the [Quick audit](#quick-audit-single-file) intentionally skips — wrong-string mappings, cross-language leaks, and verbatim-untranslated source fallback. Run them when reviewing a translation contribution or before merging a Weblate sync.
+
+### Find verbatim-untranslated entries (translation == source)
+
+Useful for scanning whether a file has actual coverage or is mostly source-fallback. Filter for proper-noun / technical-token false positives:
+
+```python
+import re, glob
+ignore = {
+    'QtPass','GPG','Git','OTP','PWGen','pass','Pass','Email','%1','%2','…','⌕',
+    'Aa','LTR','Ctrl+G','Ctrl+N','PGP','GnuPG','YubiKey','Push','Git push','Git pull',
+    'gpg','git','Git:','qrencode','pwgen',
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
+    'login\nURL\ne-mail',
+    'QProcess::FailedToStart','QProcess::Crashed','QProcess::Timedout',
+    'QProcess::ReadError','QProcess::WriteError','QProcess::UnknownError',
+}
+for f in sorted(glob.glob('localization/localization_*.ts')):
+    content = open(f).read()
+    for m in re.finditer(r'<message[^>]*>.*?<source>(.*?)</source>.*?<translation([^>]*)>(.*?)</translation>', content, re.DOTALL):
+        src,a,t = m.group(1), m.group(2), m.group(3)
+        if 'vanished' in a or not t.strip(): continue
+        if src.strip() == t.strip() and src not in ignore and 'href' not in src and len(src) > 2:
+            print(f'{f}: {src[:60]!r}')
+```
+
+### Find Slovenian leaks (or any cross-locale leak)
+
+Replace the keyword set with distinguishing words from the _unintended_ language:
+
+```python
+# Detect Slovenian leaks in non-sl_SI files
+slovenian = ['mogoče','prepričani','želite','izbrisati','odložišče','počiščeno',
+             'ključa','obesku','zagon','uspel','nepričakovano']
+import re, glob
+for f in sorted(glob.glob('localization/localization_*.ts')):
+    if 'sl_SI' in f: continue
+    content = open(f).read()
+    for m in re.finditer(r'<message[^>]*>.*?<source>(.*?)</source>.*?<translation([^>]*)>(.*?)</translation>', content, re.DOTALL):
+        src,a,t = m.group(1), m.group(2), m.group(3)
+        if 'vanished' in a or not t.strip(): continue
+        for w in slovenian:
+            if w in t.lower():
+                print(f'{f}: {src[:50]} -> {t[:60]}')
+                break
+```
+
+### Find wrong-string mappings (copypaste errors)
+
+Look for translations whose `%`-placeholder set doesn't match the source's. Already covered by the main placeholder check, but a separate scan focused on mismatched length / radically different translation can also help:
+
+```python
+import re, glob
+for f in sorted(glob.glob('localization/localization_*.ts')):
+    content = open(f).read()
+    for m in re.finditer(r'<message[^>]*>.*?<source>(.*?)</source>.*?<translation([^>]*)>(.*?)</translation>', content, re.DOTALL):
+        src,a,t = m.group(1), m.group(2), m.group(3)
+        if 'vanished' in a or not t.strip(): continue
+        # Suspicious: translation 3× longer than source, or vice versa
+        if len(src) > 10 and (len(t) > 3 * len(src) or len(t) * 3 < len(src)):
+            print(f'{f}: len-ratio {len(src)}->{len(t)}: {src[:50]!r}')
+```
+
+## When to skip the audit
+
+- Pure terminology rename PRs (e.g., `krātuve→glabātuve`) on a single locale: structure is preserved by definition.
+- Single-string typo fixes from a known reviewer.
+- Removing `type="unfinished"` (finalising) on previously-validated translations.
+
+For everything else — especially MT-source contributions — running the audit takes ~5 seconds and reliably catches issues that would otherwise need a second PR.

--- a/.opencode/skills/qtpass-localization/SKILL.md
+++ b/.opencode/skills/qtpass-localization/SKILL.md
@@ -17,11 +17,33 @@ Qt uses Qt Linguist (`.ts` files) for translations.
 
 ### Existing Languages
 
+Always re-derive the current list at the moment of work, since new locales land regularly:
+
 ```bash
-ls localization/localization_*.ts
+ls localization/localization_*.ts | sed 's|.*localization_||;s|\.ts$||'
 ```
 
-Currently includes: af_ZA, ar_MA, bg_BG, ca_ES, cs_CZ, cy_GB, da_DK, de_DE, de_LU, el_GR, en_GB, en_US, es_ES, et_EE, fi_FI, fr_BE, fr_FR, fr_LU, gl_ES, he_IL, hr_HR, hu_HU, it_IT, ja_JP, ko_KR, lb_LU, nb_NO, nl_BE, nl_NL, pl_PL, pt_PT, ro_RO, ru_RU, sk_SK, sl_SI, sq_AL, sr_RS, sv_SE, ta, tr_TR, uk_UA, zh_CN, zh_Hant
+Per-locale completion stats (finished / unfinished-with-text / empty):
+
+```bash
+python3 -c "
+import re, glob, os
+for f in sorted(glob.glob('localization/localization_*.ts')):
+    loc = os.path.basename(f).replace('localization_','').replace('.ts','')
+    content = open(f).read()
+    fin=ut=ue=0
+    for m in re.finditer(r'<translation([^>]*)>(.*?)</translation>', content, re.DOTALL):
+        a,b = m.group(1), m.group(2)
+        if 'vanished' in a: continue
+        if 'unfinished' in a:
+            if b.strip(): ut += 1
+            else: ue += 1
+        else: fin += 1
+    print(f'{loc:8s}  {fin:3d}/{fin+ut+ue}  ut={ut:3d}  empty={ue}')
+"
+```
+
+`unfinished-with-text` means a translation exists but is flagged for native-speaker review (Weblate convention).
 
 ## Updating Translations
 
@@ -240,7 +262,51 @@ git commit -m "Resolve merge conflict - use theirs for translations"
 
 ### Weblate vs Local Editing
 
-QtPass uses Weblate for translations. Don't manually edit `.ts` files for translations - let Weblate handle it. Only run `qmake6` locally to update source references.
+Translations are normally managed via [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/). However, **direct `.ts` edits are appropriate** for:
+
+- Fixing reviewer-flagged bugs (placeholder mismatches, broken HTML, made-up words, mixed-script artifacts).
+- Filling empty entries with best-effort translations marked `type="unfinished"` so Weblate native reviewers can refine them.
+- Batch corrections suggested in PR review by native speakers.
+- Standardising terminology across multiple strings (e.g., normalising `klipboard`/`klipbordas`/`Tabela e kopjimit` onto a single term).
+
+When in doubt, fix and mark `type="unfinished"` so Weblate review can iterate. Only run `qmake6` to update **source** strings (English) when code changes — that step is mechanical and affects every locale file.
+
+### Qt Mnemonic Conventions
+
+Qt UI strings use `&` (rendered as `&amp;` in `.ts` XML) before a letter to mark a keyboard accelerator (e.g., `&Quit` underlines Q so Alt+Q triggers it). Conventions per script family:
+
+- **Latin scripts** (de, fr, es, en, etc.): in-word `&Letter` — `&File`, `&Edit`, `&Quit`. Pick a non-conflicting letter; within a single menu, mnemonics must be unique.
+- **CJK scripts** (zh, ja, ko): parens-at-start `(&L) text` — `(&F) 文件`, `(&Q) 退出`. Don't rely on native characters as mnemonics.
+- **RTL scripts** (ar, he): either parens-at-start `(&L) text` (preferred for portability) or native-letter `&letter`.
+- **Cyrillic / Greek / Tamil / Sinhala**: not strictly defined; in-word native letters (`&Покажи`) work if the user's keyboard supports them, otherwise use `(&L) text` parens form.
+
+Preserve the source mnemonic letter in the translation when feasible, so the same shortcut works across locales. When this is not possible, choose a non-conflicting letter from the translated string.
+
+Audit for missing mnemonics:
+
+```bash
+python3 -c "
+import re, glob
+mnemonic_sources = {'&amp;Use pass','Nati&amp;ve Git/GPG','&amp;Show','&amp;Hide','&amp;Restore','&amp;Quit','Mi&amp;nimize','Ma&amp;ximize'}
+for f in sorted(glob.glob('localization/localization_*.ts')):
+    content = open(f).read()
+    for m in re.finditer(r'<message[^>]*>.*?<source>(.*?)</source>.*?<translation([^>]*)>(.*?)</translation>', content, re.DOTALL):
+        src,a,t = m.group(1), m.group(2), m.group(3)
+        if 'vanished' in a or src not in mnemonic_sources or not t.strip(): continue
+        if not re.search(r'&amp;[^\s&;]', t):
+            print(f'{f}: {src} -> {t}')
+"
+```
+
+## Reviewer-Iteration Workflow
+
+Translation review tends to come in batches of ~5 findings at a time (CodeRabbit, GitHub AI quality findings, native-speaker comments on PRs). Standard handling:
+
+1. **Verify each finding against current code** before fixing. Reviewer-supplied diffs may be against an older state — confirm the broken text actually exists in the latest `.ts`.
+2. **Fix only what's needed.** If a reviewer-suggested change is itself wrong (e.g., breaks Qt mnemonic conventions, reverses earlier-established terminology), reject with explanation.
+3. **Apply same-pattern fixes if found in passing.** When fixing one occurrence of a typo, search the file for sibling occurrences of the same MT-pattern. Document in commit message which were flagged vs which were proactive.
+4. **Run the audit script** (see `qtpass-localization-audit` skill) before pushing — placeholder format and HTML balance are non-obvious bugs that the reviewer's prose description may not catch.
+5. **Mark new translations `type="unfinished"`** unless a native speaker has confirmed them. Weblate finalises them on review.
 
 ## Fixing Translation Issues in PRs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,9 +345,11 @@ QtPass uses Qt Test framework. Test files are in `tests/auto/`.
 
 ## Localization
 
-QtPass uses Qt Linguist (`.ts` files) in `localization/`. Don't manually edit translations - Weblate handles that. Run `qmake6` after source changes to update translation source references.
+QtPass uses Qt Linguist (`.ts` files) in `localization/`. Translations are normally managed via [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/).
 
-See `qtpass-localization` skill for details.
+Direct `.ts` edits are appropriate for fixing reviewer-flagged bugs (placeholder mismatches, broken HTML, made-up words from MT) and for batch native-speaker corrections. Run `qmake6` after source string changes to update translation references.
+
+See `qtpass-localization` skill for the workflow and `qtpass-localization-audit` skill for structural audits of `.ts` files.
 
 ## Skills
 
@@ -355,6 +357,7 @@ See `qtpass-localization` skill for details.
 - `qtpass-testing` - Qt Test framework and test structure
 - `qtpass-linting` - CI/CD and linters
 - `qtpass-localization` - Translation workflow
+- `qtpass-localization-audit` - Structural audit of `.ts` files (placeholders, HTML balance, mnemonics, mixed-script)
 - `qtpass-github` - PRs, issues, merging
 - `qtpass-releasing` - Release process
 - `qtpass-docs` - Documentation guide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,9 +345,13 @@ QtPass uses Qt Test framework. Test files are in `tests/auto/`.
 
 ## Localization
 
-QtPass uses Qt Linguist (`.ts` files) in `localization/`. Translations are normally managed via [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/).
+QtPass uses Qt Linguist (`.ts` files) in `localization/`. Translations are normally managed via [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/), but direct `.ts` edits are appropriate for:
 
-Direct `.ts` edits are appropriate for fixing reviewer-flagged bugs (placeholder mismatches, broken HTML, made-up words from MT) and for batch native-speaker corrections. Run `qmake6` after source string changes to update translation references.
+- Fixing reviewer-flagged bugs (placeholder mismatches like `% 1` vs `%1`, broken HTML tags, made-up words from MT, mixed-script artifacts).
+- Batch corrections suggested by native-speaker reviewers on a PR.
+- Filling empty entries with best-effort translations marked `type="unfinished"` for Weblate to refine.
+
+After changing **source** strings (English in code), run `qmake6` to refresh translation source references; that step is purely mechanical and affects every locale file.
 
 See `qtpass-localization` skill for the workflow and `qtpass-localization-audit` skill for structural audits of `.ts` files.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,13 @@ Common pitfalls: unnamed parameters in declarations, orphaned doc blocks not imm
 
 ## Localization
 
-Translation files are `.ts` files in `localization/`. Do **not** edit them manually — translations are managed via Weblate. After changing source strings, run `qmake6` to update translation source references.
+Translation files are `.ts` files in `localization/`. Translations are normally managed via [Weblate](https://hosted.weblate.org/projects/qtpass/qtpass/), but direct `.ts` edits are appropriate for:
+
+- Fixing reviewer-flagged bugs (placeholder mismatches like `% 1` vs `%1`, broken HTML tags, made-up words from MT, mixed-script artifacts).
+- Batch corrections suggested by native-speaker reviewers on a PR.
+- Filling empty entries with best-effort translations marked `type="unfinished"` for Weblate to refine.
+
+After changing **source** strings (English in code), run `qmake6` to refresh translation source references; that step is purely mechanical and affects every locale file.
 
 ## Skills
 
@@ -123,6 +129,7 @@ Specialized skills are available for common workflows:
 - `qtpass-testing` — Qt Test structure and patterns
 - `qtpass-linting` — CI/CD and formatters
 - `qtpass-localization` — translation workflow
+- `qtpass-localization-audit` — structural audit of `.ts` files (placeholders, HTML balance, mnemonics, mixed-script)
 - `qtpass-github` — PRs, issues, merging
 - `qtpass-releasing` — release process
 - `qtpass-docs` — documentation guide


### PR DESCRIPTION
## Summary

Capture patterns from the recent multi-locale translation cleanup work (PRs #1247–#1321 brought lv_LV/lt_LT/sl_SI to 100% finished and si_LK from 89/354 to 286/304).

### Three changes

**1. \`CLAUDE.md\` and \`AGENTS.md\` — clarified \"Localization\" sections.** The previous text said "Do **not** edit them manually — translations are managed via Weblate." That's been contradicted by ~40 PRs of direct \`.ts\` edits to fix placeholder mismatches, broken HTML, MT artifacts, etc. New text lists when direct edits are appropriate (reviewer-flagged bugs, batch native-speaker corrections, filling empty entries with \`type=\"unfinished\"\`).

**2. \`qtpass-localization\` SKILL.md updates:**
- Replaced stale hand-maintained language list with a per-run directory listing + per-locale completion stats script.
- Rewrote "Weblate vs Local Editing" section with concrete cases when direct edits are appropriate.
- Added Qt mnemonic conventions section (Latin in-word / CJK \`(&L) text\` parens-at-start / RTL / non-Latin scripts) with audit snippet.
- Added "Reviewer-Iteration Workflow" section codifying the verify-each-finding-against-current-code methodology.

**3. New \`qtpass-localization-audit\` skill:**
- Quick single-file audit script (placeholder integrity, HTML balance, mnemonics, mixed-script).
- All-files sweep script.
- Common MT-artifact pattern collection (wrong-meaning calques, made-up verb forms, cross-language loanwords, repetition glitches, alphabet mistranslation).
- Standard cleanup workflow for MT contributions (commit as-is → audit → fix → recheck → push).
- Targeted patterns: verbatim-untranslated detection, cross-locale-leak detection, wrong-string-mapping detection.
- When to skip the audit.

## Test plan

- [ ] CI lint passes (markdown formatting via prettier)
- [ ] Audit scripts run cleanly against the current state of \`localization/*.ts\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Adds a localization audit guide with command-line checks for structural issues in Qt translation files (placeholders, plurals, mnemonics, HTML balance, mixed-script artifacts) and a recommended cleanup workflow plus smoke-test step.
  * Updates localization workflow to discover locales at runtime and produce per-locale status reports.
  * Clarifies acceptable direct .ts edits and reviewer iteration guidance; documents a new localization-audit skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->