### PR TITLE
i18n(si_LK): fix 5 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -176,7 +176,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
         <source>Current path</source>
-        <translation>විස්තර දීම</translation>
+        <translation type="unfinished">වත්මන් මාර්ගය</translation>
     </message>
     <message>
         <source>Use pwgen</source>
@@ -218,17 +218,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
         <source>Automatically push</source>
-        <translation>සාමාන්‍ය සඳහා එලෙකුතු කරන්න</translation>
+        <translation type="unfinished">ස්වයංක්‍රීයව තල්ලු කරන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="533"/>
         <source>Automatically pull</source>
-        <translation>සාමාන්‍ය සඳහා පිහිටීම කරන්න</translation>
+        <translation type="unfinished">ස්වයංක්‍රීයව ලබා ගන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>
         <source>Extensions:</source>
-        <translation>වැඩි මුදල්:</translation>
+        <translation type="unfinished">විස්තාරක:</translation>
     </message>
     <message>
         <source>Use pass otp extension</source>
@@ -237,7 +237,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="624"/>
         <source>System:</source>
-        <translation>ද්‍රයත්ව කණ්ඩායම:</translation>
+        <translation type="unfinished">පද්ධතිය:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="636"/>


### PR DESCRIPTION
## Summary

Native-speaker review on main flagged five Sinhala mistranslations in `configdialog.ui`. Replacements per the reviewer's suggestions, marked `type="unfinished"` so Weblate native review can finalise them.

| Source                | Old (incorrect)              | New                              |
| --------------------- | ---------------------------- | -------------------------------- |
| Current path          | විස්තර දීම (describing)      | වත්මන් මාර්ගය                    |
| Automatically push    | සාමාන්‍ය සඳහා එලෙකුතු කරන්න  | ස්වයංක්‍රීයව තල්ලු කරන්න         |
| Automatically pull    | සාමාන්‍ය සඳහා පිහිටීම කරන්න  | ස්වයංක්‍රීයව ලබා ගන්න            |
| Extensions:           | වැඩි මුදල්: (more money)     | විස්තාරක:                        |
| System:               | ද්‍රයත්ව කණ්ඩායම:            | පද්ධතිය: (standard term)         |

## Test plan

- [x] Verified each finding against current `localization_si_LK.ts` (all five matched).
- [x] Audit (placeholder/HTML balance) clean for the touched entries; only pre-existing `<numerusform>` plurals remain (not bugs).
- [x] All five marked `type="unfinished"` for Weblate review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Sinhala (Sri Lankan) translations for settings and navigation labels, including "Current path," "Automatically push," "Automatically pull," "Extensions," and "System."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->