### PR TITLE
i18n(si_LK): fix 5 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -242,22 +242,22 @@
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <source>Use TrayIcon</source>
-        <translation>තේයිරීම සඳහා පොට්ලා කිරීම</translation>
+        <translation type="unfinished">පද්ධති තැටි අයිකනය භාවිත කරන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
         <source>Start minimized</source>
-        <translation>මුද්‍රණ කළේ මැතිවරන් තෙරිම</translation>
+        <translation type="unfinished">අවම කළ තත්ත්වයෙන් ආරම්භ කරන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <source>Hide on close</source>
-        <translation>වන පිටුවක් වඩා කරන්න</translation>
+        <translation type="unfinished">වසා දමන විට සඟවන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>
         <source>Always on top</source>
-        <translation>මීටරු තොප් සහිත</translation>
+        <translation type="unfinished">සෑමවිටම ඉහළින්</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="682"/>
@@ -267,7 +267,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="700"/>
         <source>Select password storage program:</source>
-        <translation>සැයුම් පදනමක් කාර්ය කරන්න:</translation>
+        <translation type="unfinished">මුරපද ගබඩා කිරීමේ වැඩසටහන තෝරන්න:</translation>
     </message>
     <message>
         <source>Nati&amp;ve git/gpg</source>


### PR DESCRIPTION
## Summary

Native-speaker review on main flagged five more Sinhala mistranslations in `configdialog.ui` (Tray section + storage-program selector). Replacements per the reviewer's suggestions, marked `type="unfinished"` so Weblate native review can finalise them.

| Source                              | Old (incorrect)              | New                                    |
| ----------------------------------- | ---------------------------- | -------------------------------------- |
| Use TrayIcon                        | තේයිරීම සඳහා පොට්ලා කිරීම    | පද්ධති තැටි අයිකනය භාවිත කරන්න         |
| Start minimized                     | මුද්‍රණ කළේ මැතිවරන් තෙරිම   | අවම කළ තත්ත්වයෙන් ආරම්භ කරන්න          |
| Hide on close                       | වන පිටුවක් වඩා කරන්න         | වසා දමන විට සඟවන්න                     |
| Always on top                       | මීටරු තොප් සහිත              | සෑමවිටම ඉහළින්                         |
| Select password storage program:    | සැයුම් පදනමක් කාර්ය කරන්න:   | මුරපද ගබඩා කිරීමේ වැඩසටහන තෝරන්න:      |

## Test plan

- [x] Verified each finding against current `localization_si_LK.ts` (all five matched).
- [x] All five marked `type="unfinished"` for Weblate native-speaker review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Improved Sinhala (Sri Lanka) translations for application configuration options and interface labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->