### PR TITLE
i18n(si_LK): fix 5 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -359,7 +359,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1065"/>
         <source>Show all lines beginning with a word followed by a colon as fields in password fields, not only the listed ones</source>
-        <translation>ගැටළුවක් දී කිරීමේ පසුව සංකීර්ණයක් මත තෝල ලේන් මූලික පාත්වය කිරීමට අවසන් කරන්න, සහ පැති දෙකක් මත තෝල ලේන් නොකිරීමට</translation>
+        <translation type="unfinished">ලැයිස්තුගත කර ඇති ඒවා පමණක් නොව, වචනයකින් ආරම්භ වී එයට පසු කොලනයක් (:) ඇති සියලු පේළි මුරපද ක්ෂේත්‍ර ලෙස පෙන්වන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1068"/>
@@ -377,12 +377,12 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="1095"/>
         <source>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; version </source>
-        <translation>&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; වැසුනු ම්වොරූන්: </translation>
+        <translation type="unfinished">&lt;a href=&quot;https://QtPass.org/&quot;&gt;QtPass&lt;/a&gt; අනුවාදය </translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="125"/>
         <source>No Clipboard</source>
-        <translation>කොපියා මුරවල</translation>
+        <translation type="unfinished">පසුරු පුවරුවක් නැත</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>
@@ -403,12 +403,12 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="720"/>
         <source>Create profile directory?</source>
-        <translation>පුර්ගන් සිටින පොලීස් හැකිදෙන විද්‍යාත්මක කණ්ඩායම කරන්න?</translation>
+        <translation type="unfinished">පැතිකඩ නාමාවලිය සෑදීමට අවශ්‍යද?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="721"/>
         <source>Would you like to create a password store at %1?</source>
-        <translation>මුරපද පහත මූලකයේ නව කළමනා භාවිතා කිරීමට එක් කෙරිණි %1?</translation>
+        <translation type="unfinished">ඔබට %1 හි මුරපද ගබඩාවක් සාදීමට අවශ්‍යද?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>


### PR DESCRIPTION
## Summary

Native-speaker review on main flagged five more Sinhala mistranslations. Replacements per the reviewer's suggestions, marked `type="unfinished"` so Weblate native review can finalise them.

| Source                                              | Old (incorrect)                            | New                                                   |
| --------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
| Show all lines beginning with a word…               | (garbled paragraph)                        | coherent translation conveying the field-detection rule |
| `<a>QtPass</a> version `                            | වැසුනු ම්වොරූන්: (made-up word)            | අනුවාදය (HTML preserved)                              |
| No Clipboard                                        | කොපියා මුරවල (non-standard)                | පසුරු පුවරුවක් නැත                                    |
| Create profile directory?                           | …පොලීස්… (contains "police"!)              | පැතිකඩ නාමාවලිය සෑදීමට අවශ්‍යද?                       |
| Would you like to create a password store at %1?    | (garbled, %1 preserved)                    | ඔබට %1 හි මුරපද ගබඩාවක් සාදීමට අවශ්‍යද?               |

## Test plan

- [x] Verified each finding against current `localization_si_LK.ts` (all five matched).
- [x] HTML markup (`<a href="https://QtPass.org/">QtPass</a>`) preserved in version string.
- [x] `%1` placeholder preserved in password-store prompt.
- [x] All five marked `type="unfinished"` for Weblate native-speaker review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sinhala language localization entries, marking five UI strings and confirmation dialogs as requiring completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->