### PR TITLE
i18n(si_LK): fix 5 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -161,7 +161,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="960"/>
         <source>Path to the password store directory</source>
-        <translation>මුරපද මෙහෙයුම් පථය</translation>
+        <translation type="unfinished">මුරපද ගබඩා නාමාවලියට යන මාර්ගය</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="965"/>
@@ -276,7 +276,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
         <source>&amp;Use pass</source>
-        <translation>&amp;Pass වෙනුවී කරන්න</translation>
+        <translation type="unfinished">&amp;Pass භාවිතා කරන්න</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
@@ -307,7 +307,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="827"/>
         <source>pass</source>
-        <translation>පස්ස්</translation>
+        <translation type="unfinished">පසු</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.passwordstore.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;www.passwordstore.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -413,7 +413,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>
         <source>Could not create profile directory: %1</source>
-        <translation>පුද්ගලය පහත මූලකයේ නව කළමනා භාවිතා කිරීමට එක් කෙරිණි: %1</translation>
+        <translation type="unfinished">පැතිකඩ නාමාවලිය සෑදිය නොහැකි විය: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="747"/>
@@ -428,7 +428,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="810"/>
         <source>No profile selected</source>
-        <translation>පහත මූලකයේ නොවැල්සුන් සායනය කර ඇත</translation>
+        <translation type="unfinished">කිසිදු පැතිකඩක් තෝරා නැත</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>


### PR DESCRIPTION
## Summary

Native-speaker review on main flagged five more Sinhala mistranslations. Replacements per the reviewer's suggestions, marked `type="unfinished"` so Weblate native review can finalise them.

| Source                                          | Old (incorrect)                                   | New                                                |
| ----------------------------------------------- | ------------------------------------------------- | -------------------------------------------------- |
| Path to the password store directory            | මුරපද මෙහෙයුම් පථය (= "password operation path")  | මුරපද ගබඩා නාමාවලියට යන මාර්ගය                     |
| &Use pass                                       | &Pass වෙනුවී කරන්න (incorrect verb)               | &Pass භාවිතා කරන්න (mnemonic preserved on Latin P) |
| pass (config)                                   | පස්ස් (inconsistent with line-305 usage)          | පසු (standardised)                                 |
| Could not create profile directory: %1          | (garbled, %1 preserved)                           | පැතිකඩ නාමාවලිය සෑදිය නොහැකි විය: %1               |
| No profile selected                             | පහත මූලකයේ නොවැල්සුන් සායනය කර ඇත                 | කිසිදු පැතිකඩක් තෝරා නැත                           |

## Test plan

- [x] Verified each finding against current `localization_si_LK.ts` (all five matched).
- [x] `&P` mnemonic preserved on `&Use pass`.
- [x] `%1` placeholder preserved in directory-creation error.
- [x] `pass` translation standardised across the file.
- [x] All five marked `type="unfinished"` for Weblate native-speaker review.