### PR TITLE
i18n(si_LK): fix 3 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -595,7 +595,7 @@ e-mail</translation>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="14"/>
         <source>Export Public Key</source>
-        <translation>පවුල කළමනාකරණ සිටෙන්දී</translation>
+        <translation type="unfinished">පොදු යතුර නිර්යාත කරන්න</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="27"/>
@@ -1225,7 +1225,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="666"/>
         <source>OTP Code</source>
-        <translation>OTP වඩාතුරික ප්‍රකාශය</translation>
+        <translation type="unfinished">OTP කේතය</translation>
     </message>
     <message>
         <source>Clipboard cleared</source>
@@ -1456,7 +1456,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../src/mainwindow.cpp" line="1747"/>
         <location filename="../src/mainwindow.cpp" line="1767"/>
         <source>Export Public Key</source>
-        <translation>ප්‍රාදේශ කණගමකයන් ප්‍රිසිජත්වය</translation>
+        <translation type="unfinished">පොදු යතුර නිර්යාත කරන්න</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1748"/>


### PR DESCRIPTION
## Summary

Reviewer raised 4 findings; 3 actionable, 1 no-op.

### Applied

| Source            | Context                       | Old (incorrect)                         | New                       |
| ----------------- | ----------------------------- | --------------------------------------- | ------------------------- |
| Export Public Key | exportpublickeydialog.ui:14   | පවුල කළමනාකරණ සිටෙන්දී (garbled)        | පොදු යතුර නිර්යාත කරන්න   |
| Export Public Key | (second context)              | ප්‍රාදේශ කණගමකයන් ප්‍රිසිජත්වය (garbled) | පොදු යතුර නිර්යාත කරන්න   |
| OTP Code          | mainwindow.cpp:666            | OTP වඩාතුරික ප්‍රකාශය                   | OTP කේතය (acronym kept)   |

### Reviewed but skipped

- **"Password Behaviour:"** — entry is already `type="vanished"` (source string was removed from code). Editing the historical spelling on a vanished record is a no-op.
- **"Always copy to clipboard"** — already corrected by #1333 (current value: `සෑම විටම පසුරු පුවරුවට පිටපත් කරන්න`). The reviewer's variant `සැමවිටම` (no space) is stylistic; both are valid Sinhala.

## Test plan

- [x] All three fixes marked `type="unfinished"` for Weblate native-speaker review.
- [x] OTP acronym preserved in English; only "Code" translated.
- [x] Both `Export Public Key` contexts harmonised to the same translation.