### PR TITLE
i18n(si_LK): Potential fixes for 5 code quality findings

### DIFF
--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -398,7 +398,7 @@ email</translation>
         <location filename="../src/configdialog.cpp" line="210"/>
         <location filename="../src/configdialog.cpp" line="226"/>
         <source>This field is required</source>
-        <translation>මෙම තූක්කය අවශ්‍ය</translation>
+        <translation>මෙම ක්ෂේත්‍රය අවශ්‍ය</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="720"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -469,7 +469,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation>මුරපද කළමනාව සංකේතනය කර නැත</translation>
+        <translation>මුරපද ගබඩාව සංකේතනය කර නැත</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -474,7 +474,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>%1 දිග මුරපද කළමනාවක් සංකේතනය කර නැත හෝ ඇසුරක්ෂිත නොහැක.</translation>
+        <translation>%1 ෆෝල්ඩරය මුරපද ගබඩාවක් ලෙස නොපෙනේ හෝ තවම ආරම්භ කර නොමැත.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -484,7 +484,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1267"/>
         <source>Profile: %1 at %2</source>
-        <translation>ප්‍රායෝගිකතා: %1 පවුල්ලේ %2</translation>
+        <translation>පැතිකඩ: %1 හි %2</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1272"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -469,7 +469,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
         <source>Password store not initialised</source>
-        <translation>මුරපද ගබඩාව සංකේතනය කර නැත</translation>
+        <translation>මුරපද ගබඩාව ආරම්භ වී නැත</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
@@ -484,7 +484,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1267"/>
         <source>Profile: %1 at %2</source>
-        <translation>පැතිකඩ: %1 හි %2</translation>
+        <translation>පැතිකඩ: %2 හි %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1272"/>

--- a/localization/localization_si_LK.ts
+++ b/localization/localization_si_LK.ts
@@ -479,7 +479,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
         <source>New profile: %1 at %2</source>
-        <translation>%2 වෙලාවේ %1 අගය පළමු කළ ඇත</translation>
+        <translation>%2 හි %1 නව පැතිකඩ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1267"/>


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Sinhala UI text for clearer required-field messaging.
  * Reworded the phrase for "password store" to a more natural term.
  * Clarified folder initialization/error message when a folder is not a password store or not yet initialized.
  * Adjusted wording and placeholder order for profile creation/display messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->