### PR TITLE
docs(skills): clarify fresh-skeleton vs patch-existing localization

### DIFF
--- a/.opencode/skills/qtpass-localization/SKILL.md
+++ b/.opencode/skills/qtpass-localization/SKILL.md
@@ -159,9 +159,11 @@ Use the `xx_YY` form only when the translation is genuinely region-specific (Bra
    # -> Updating 'localization/localization_<lang>.ts'...
    ```
 
-4. After confirming the file is populated with `type="unfinished"` entries, translators must fill each entry with a best-effort translation (keeping `type="unfinished"`) before opening a PR. This applies to files registered via `TRANSLATIONS +=` in `src/src.pro`. Entries must not be left empty so the repository localization rule ("Fill empty translation entries with best-effort translations marked `type=\"unfinished\"`") is enforced.
+4. The skeleton ships as-is once the file is populated by `lupdate`: all entries `type="unfinished"`, ready for Weblate translators to fill. A bootstrap PR does **not** need pre-filled best-effort translations — empty `<translation type="unfinished">` is the deliverable.
 
-5. Translate strings via Qt Linguist or hand-edit the `.ts` XML, then push for Weblate to track.
+   The "fill empty entries with best-effort, mark `type="unfinished"`" guidance applies only when **patching an existing locale** flagged by reviewers — not to fresh-skeleton bootstrap PRs.
+
+5. Optionally hand-edit a few high-value strings (window title, About box) via Qt Linguist before pushing, then let Weblate handle the rest.
 
 ### Worked example
 


### PR DESCRIPTION
## Summary

CodeRabbit auto-fix `fecccfc4e` added a 437-char step 4 to `qtpass-localization/SKILL.md` that:

- Violated the project's 400-char markdown line-length rule (CI lint failure waiting to happen).
- Mandated pre-filling translations before opening a bootstrap PR.
- Contradicted how #1335 (fa skeleton) actually shipped, and Weblate's standard convention that empty `type="unfinished"` is how new locales are introduced.

Replaced with a shorter, accurate version that distinguishes the two flows:

- **Fresh-skeleton PRs** (e.g. #1335 adding `fa`) — empty `type="unfinished"` is the deliverable; Weblate translators fill them later.
- **Patch-existing PRs** (reviewer-flagged mistranslation fixes) — best-effort translations marked `type="unfinished"` are appropriate.

## Test plan

- [x] `awk 'length > 400'` reports zero violations.
- [x] `prettier --check` clean across all `.md`/`.yml`.
- [x] Guidance now matches the merged PRs (#1330, #1334, #1335).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated localization workflow documentation for new locale bootstrap pull requests, removing the prior requirement to pre-fill best-effort translations during initial submissions. The revised process now focuses editor effort solely on high-value strings, with automated translation management handling remaining entries. Reviewer-requested patches retain conditional guidance as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->