### PR TITLE
fix: correct .gpgid -> .gpg-id filename in user-facing error

### DIFF
--- a/localization/localization_af.ts
+++ b/localization/localization_af.ts
@@ -648,13 +648,6 @@ e-pos</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kontroleer die .gpgid-lêerhandtekening!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Jy sal nie die gebruikerslys kan verander nie!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kan nie opdateer nie</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kontroleer die .gpg-id-lêerhandtekening!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_ar.ts
+++ b/localization/localization_ar.ts
@@ -588,13 +588,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>تحقق من توقيع ملف .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -639,6 +632,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>لا أستطيع التحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>تحقق من توقيع ملف .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_bg.ts
+++ b/localization/localization_bg.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Проверете сигнатурата на .gpgid файла!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Не може да се актуализира</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Проверете сигнатурата на .gpg-id файла!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_bn.ts
+++ b/localization/localization_bn.ts
@@ -591,8 +591,8 @@ URL
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>এ .gpgid ফাইলের স্বাক্ষর যাচাই করুন!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>এ .gpg-id ফাইলের স্বাক্ষর যাচাই করুন!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>

--- a/localization/localization_ca.ts
+++ b/localization/localization_ca.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Comproveu la signatura del fitxer .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ No podràs canviar la llista d&apos;usuaris!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>No es pot actualitzar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Comproveu la signatura del fitxer .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_cs.ts
+++ b/localization/localization_cs.ts
@@ -644,13 +644,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Zkontrolujte podpis souboru .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -695,6 +688,13 @@ Seznam uživatelů nebudete moci změnit!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nelze aktualizovat</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Zkontrolujte podpis souboru .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_cy.ts
+++ b/localization/localization_cy.ts
@@ -588,13 +588,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Gwiriwch llofnod y ffeil .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -639,6 +632,13 @@ Ni fyddwch yn gallu newid y rhestr defnyddwyr!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Methu diweddaru</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Gwiriwch llofnod y ffeil .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_da.ts
+++ b/localization/localization_da.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Tjek .gpgid-filens signatur!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Du vil ikke kunne ændre brugerlisten!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Ude af stand til at opdatere</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Tjek .gpg-id-filens signatur!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -649,13 +649,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Überprüfen Sie die .gpgid Dateisignatur!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -700,6 +693,13 @@ Sie können die Benutzerliste nicht ändern!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Update nicht möglich</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Überprüfen Sie die .gpg-id Dateisignatur!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Prüfe die Signatur der .gpgid-Dateien!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Sie können die Benutzerverzeichnis nicht ändern!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Update nicht möglich</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Prüfe die Signatur der .gpg-id-Dateien!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_el.ts
+++ b/localization/localization_el.ts
@@ -592,13 +592,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Ελέγξτε την υπογραφή αρχείου .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -643,6 +636,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Δεν είναι δυνατή η ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Ελέγξτε την υπογραφή αρχείου .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_en_GB.ts
+++ b/localization/localization_en_GB.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Check .gpgid file signature!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Cannot update</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Check .gpg-id file signature!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Check .gpgid file signature!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Cannot update</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Check .gpg-id file signature!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_es_AR.ts
+++ b/localization/localization_es_AR.ts
@@ -620,13 +620,6 @@ dirección de correo</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>¡Comprobá la firma del archivo .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -671,6 +664,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>No se puede actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>¡Comprobá la firma del archivo .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_es_EC.ts
+++ b/localization/localization_es_EC.ts
@@ -620,13 +620,6 @@ dirección de correo</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>¡Comprueba la firma del archivo .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -671,6 +664,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>No se puede actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>¡Comprueba la firma del archivo .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_es_ES.ts
+++ b/localization/localization_es_ES.ts
@@ -620,13 +620,6 @@ dirección de correo</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>¡Comprueba la firma del fichero .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -671,6 +664,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>No se puede actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>¡Comprueba la firma del fichero .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_es_MX.ts
+++ b/localization/localization_es_MX.ts
@@ -620,13 +620,6 @@ dirección de correo</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>¡Comprueba la firma del archivo .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -671,6 +664,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>No se puede actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>¡Comprueba la firma del archivo .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_es_UY.ts
+++ b/localization/localization_es_UY.ts
@@ -620,13 +620,6 @@ dirección de correo</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>¡Comprobá la firma del archivo .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -671,6 +664,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>No se puede actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>¡Comprobá la firma del archivo .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_et.ts
+++ b/localization/localization_et.ts
@@ -648,13 +648,6 @@ e-posti aadress</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kontrolli .gpgid faili allkirja!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Sa ei saa kasutajate loendit muuta!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Uuendamine ei õnnestunud</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kontrolli .gpg-id faili allkirja!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_fa.ts
+++ b/localization/localization_fa.ts
@@ -1152,15 +1152,17 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
-        <source>New password file: 
+        <source>New password file:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">فایل رمز عبور جدید:
+(در %1 قرار خواهد گرفت)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
-        <source>New Folder: 
+        <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">پوشه جدید:
+(در %1 قرار خواهد گرفت)</translation>
     </message>
     <message>
         <source>New password file:

--- a/localization/localization_fa.ts
+++ b/localization/localization_fa.ts
@@ -591,7 +591,7 @@ URL
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
+        <source>Check .gpg-id file signature!</source>
         <translation>امضای فایل .gpg-id را بررسی کنید!</translation>
     </message>
     <message>
@@ -1152,9 +1152,20 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
+        <source>New password file: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1468"/>
+        <source>New Folder: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>New password file:
 (Will be placed in %1 )</source>
-        <translation>فایل رمز عبور جدید:
+        <translation type="vanished">فایل رمز عبور جدید:
 (در %1 قرار خواهد گرفت)</translation>
     </message>
     <message>
@@ -1233,10 +1244,9 @@ You will not be able to change the user list!</source>
         <translation>این چیست؟</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation>پوشه جدید:
+        <translation type="vanished">پوشه جدید:
 (در %1 قرار خواهد گرفت)</translation>
     </message>
     <message>

--- a/localization/localization_fi.ts
+++ b/localization/localization_fi.ts
@@ -648,13 +648,6 @@ sähköposti</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Tarkista .gpgid-tiedoston allekirjoitus!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Et voi muuttaa käyttäjäluetteloa!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Ei päivitettävissä</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Tarkista .gpg-id-tiedoston allekirjoitus!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -652,13 +652,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Vérifiez la signature de fichier .gpgid&#x202f;!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -703,6 +696,13 @@ Vous ne pourrez pas modifier la liste des utilisateurs&#x202f;!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Impossible de mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Vérifiez la signature de fichier .gpg-id&#x202f;!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -652,13 +652,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Vérifiez la signature de fichier .gpgid&#x202f;!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -703,6 +696,13 @@ Vous ne pourrez pas modifier la liste des utilisateurs&#x202f;!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Impossible de mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Vérifiez la signature de fichier .gpg-id&#x202f;!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -652,13 +652,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Vérifiez la signature de fichier .gpgid&#x202f;!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -703,6 +696,13 @@ Vous ne pourrez pas modifier la liste des utilisateurs&#x202f;!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Impossible de mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Vérifiez la signature de fichier .gpg-id&#x202f;!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_fy_NL.ts
+++ b/localization/localization_fy_NL.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kontrolearje de hantekening fan it .gpgid-bestân!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Jo kinne de brûkerslist net feroarje!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kin net bywurkje</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kontrolearje de hantekening fan it .gpg-id-bestân!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_gl.ts
+++ b/localization/localization_gl.ts
@@ -671,13 +671,6 @@ e-mail</translation>
         <translation>Non se pode editar</translation>
     </message>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Comproba o ficheiro de sinatura .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -716,6 +709,13 @@ Non poderás cambiar a lista de usuarias!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Non se puido actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Comproba o ficheiro de sinatura .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_he.ts
+++ b/localization/localization_he.ts
@@ -639,7 +639,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
         <source>Check .gpg-id file signature!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">בדוק את חתימת קובץ .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_he.ts
+++ b/localization/localization_he.ts
@@ -590,13 +590,6 @@ e-mail</source>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -639,6 +632,13 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/localization/localization_hi.ts
+++ b/localization/localization_hi.ts
@@ -1154,15 +1154,17 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
-        <source>New password file: 
+        <source>New password file:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">नया पासवर्ड फ़ाइल:
+(यह %1 में रखा जाएगा)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
-        <source>New Folder: 
+        <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">नया फ़ोल्डर:
+(यह %1 में रखा जाएगा)</translation>
     </message>
     <message>
         <source>New password file:

--- a/localization/localization_hi.ts
+++ b/localization/localization_hi.ts
@@ -591,8 +591,8 @@ URL
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>.gpgid फ़ाइल हस्ताक्षर जांचें!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>.gpg-id फ़ाइल हस्ताक्षर जांचें!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -1154,9 +1154,20 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
+        <source>New password file: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1468"/>
+        <source>New Folder: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>New password file:
 (Will be placed in %1 )</source>
-        <translation>नई पासवर्ड फ़ाइल:
+        <translation type="vanished">नई पासवर्ड फ़ाइल:
 (%1 में रखी जाएगी)</translation>
     </message>
     <message>
@@ -1235,10 +1246,9 @@ You will not be able to change the user list!</source>
         <translation>यह क्या है?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation>नया फ़ोल्डर:
+        <translation type="vanished">नया फ़ोल्डर:
 (%1 में रखा जाएगा)</translation>
     </message>
     <message>

--- a/localization/localization_hr.ts
+++ b/localization/localization_hr.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Provjeri potpis .gpgid datoteke!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Nećeš moći promijeniti popis korisnika!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nije moguće aktualizirati</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Provjeri potpis .gpg-id datoteke!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_hu.ts
+++ b/localization/localization_hu.ts
@@ -656,13 +656,6 @@ e-mail</translation>
         <translation>Nem lehet szerkeszteni</translation>
     </message>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Ellenőrizd a .gpgid fájl aláírását!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -701,6 +694,13 @@ A felhasználói listát nem fogja tudni módosítani!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nem frissíthető</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Ellenőrizd a .gpg-id fájl aláírását!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_id.ts
+++ b/localization/localization_id.ts
@@ -591,8 +591,8 @@ email</translation>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Periksa tanda tangan berkas .gpgid!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Periksa tanda tangan berkas .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>

--- a/localization/localization_it.ts
+++ b/localization/localization_it.ts
@@ -649,13 +649,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Controlla la firma del file .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -700,6 +693,13 @@ Non ti sarà possibile cambiare la lista utenti!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Impossibile aggiornare</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Controlla la firma del file .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_ja.ts
+++ b/localization/localization_ja.ts
@@ -648,13 +648,6 @@ URL
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>.gpgidファイルの署名を確認してください！</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>更新できません</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>.gpg-idファイルの署名を確認してください！</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_ko.ts
+++ b/localization/localization_ko.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>.gpgid 파일 서명을 확인하세요!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>업데이트할 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>.gpg-id 파일 서명을 확인하세요!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_lb_LU.ts
+++ b/localization/localization_lb_LU.ts
@@ -592,13 +592,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kontrolléiert d&apos;Signatur vun der .gpg-id Datei!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -643,6 +636,13 @@ Dir kënnt d&apos;Benotzerlëscht net änneren!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kann net aktualiséiert ginn</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kontrolléiert d&apos;Signatur vun der .gpg-id Datei!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_lt.ts
+++ b/localization/localization_lt.ts
@@ -588,15 +588,11 @@ el. paštas</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <source>Check .gpg-id file signature!</source>
-        <translation type="vanished">Peržiūrėti .gpg-id failo parašą!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Patikrinkite .gpgid failo parašą!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Patikrinkite .gpg-id failo parašą!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>

--- a/localization/localization_lv.ts
+++ b/localization/localization_lv.ts
@@ -591,8 +591,8 @@ e-pasts</translation>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Pārbaudīt .gpgid faila parakstu!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Pārbaudīt .gpg-id faila parakstu!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>

--- a/localization/localization_nb.ts
+++ b/localization/localization_nb.ts
@@ -592,13 +592,6 @@ e-post</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Sjekk signaturen til .gpgid-filen!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -643,6 +636,13 @@ Du vil ikke kunne endre brukerlisten!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kan ikke oppdatere</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Sjekk signaturen til .gpg-id-filen!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_nl_BE.ts
+++ b/localization/localization_nl_BE.ts
@@ -652,13 +652,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Controleer de bestandsondertekening van het .gpgid-bestand!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -703,6 +696,13 @@ U kunt de gebruikerslijst niet aanpassen!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kan niet updaten</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Controleer de bestandsondertekening van het .gpg-id-bestand!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_nl_NL.ts
+++ b/localization/localization_nl_NL.ts
@@ -652,13 +652,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Controleer de bestandsondertekening van het .gpgid-bestand!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -703,6 +696,13 @@ Je kan de gebruikerslijst niet aanpassen!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kan niet bijwerken</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Controleer de bestandsondertekening van het .gpg-id-bestand!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_pl.ts
+++ b/localization/localization_pl.ts
@@ -588,13 +588,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Sprawdź podpis pliku .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -639,6 +632,13 @@ Nie będzie można zmienić listy użytkowników!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nie można było zaaktualizować</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Sprawdź podpis pliku .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_pt_BR.ts
+++ b/localization/localization_pt_BR.ts
@@ -628,13 +628,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Verifique a assinatura do arquivo .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -679,6 +672,13 @@ Você não será capaz de alterar a lista de usuários!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Não é possível atualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Verifique a assinatura do arquivo .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_pt_PT.ts
+++ b/localization/localization_pt_PT.ts
@@ -628,13 +628,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Verifique a assinatura do ficheiro .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -679,6 +672,13 @@ Não poderá alterar a lista de utilizadores!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Não foi possível atualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Verifique a assinatura do ficheiro .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_ro.ts
+++ b/localization/localization_ro.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Verificați semnătura fișierului .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Nu veți putea modifica lista de utilizatori!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>nu pot actualiza</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Verificați semnătura fișierului .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_ru.ts
+++ b/localization/localization_ru.ts
@@ -641,13 +641,6 @@ URL
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Проверить подпись файла .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -692,6 +685,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Не удалось обновить</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Проверить подпись файла .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_si.ts
+++ b/localization/localization_si.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>.gpgid ගොනු අත්සන පරීක්ෂා කරන්න!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>යාවත්කාලීන කළ නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>.gpg-id ගොනු අත්සන පරීක්ෂා කරන්න!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_sk.ts
+++ b/localization/localization_sk.ts
@@ -648,13 +648,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Skontrolujte .gpgid podpis súborov!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Nebudete môcť zmeniť zoznam užívateľov!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nie je možné aktualizovať</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Skontrolujte .gpg-id podpis súborov!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_sl.ts
+++ b/localization/localization_sl.ts
@@ -591,8 +591,8 @@ e-pošta</translation>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Preveri podpis datoteke .gpgid!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Preveri podpis datoteke .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>

--- a/localization/localization_sq.ts
+++ b/localization/localization_sq.ts
@@ -592,13 +592,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kontrolloni nënshkrimin e skedarit .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -643,6 +636,13 @@ Nuk do të jeni në gjendje të ndryshoni listën e përdoruesve!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nuk mund të modifikohet</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kontrolloni nënshkrimin e skedarit .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -648,13 +648,6 @@ URL
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Провери потпис .gpgid датотеке!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Није могуће надоградити</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Провери потпис .gpg-id датотеке!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_sr_RS.ts
+++ b/localization/localization_sr_RS.ts
@@ -648,13 +648,6 @@ e-pošta</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Proveri potpis .gpgid datoteke!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ Nećete moći da menjate listu korisnika!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Nije moguće nadograditi</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Proveri potpis .gpg-id datoteke!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_sv.ts
+++ b/localization/localization_sv.ts
@@ -620,13 +620,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kontrollera .gpgid-filsignatur!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -671,6 +664,13 @@ Du kommer inte att kunna ändra användarlista!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Kan inte uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kontrollera .gpg-id-filsignatur!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_sw.ts
+++ b/localization/localization_sw.ts
@@ -1154,15 +1154,17 @@ Hutaweza kubadilisha orodha ya watumiaji!</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
-        <source>New password file: 
+        <source>New password file:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Faili jipya la nenosiri:
+(Itawekwa katika %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
-        <source>New Folder: 
+        <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Folda Mpya:
+(Itawekwa katika %1 )</translation>
     </message>
     <message>
         <source>New password file:

--- a/localization/localization_sw.ts
+++ b/localization/localization_sw.ts
@@ -591,8 +591,8 @@ barua pepe</translation>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Angalia saini ya faili ya .gpgid!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Angalia saini ya faili ya .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -1154,9 +1154,20 @@ Hutaweza kubadilisha orodha ya watumiaji!</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
+        <source>New password file: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1468"/>
+        <source>New Folder: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>New password file:
 (Will be placed in %1 )</source>
-        <translation>Faili mpya ya nenosiri:
+        <translation type="vanished">Faili mpya ya nenosiri:
 (Itawekwa katika %1 )</translation>
     </message>
     <message>
@@ -1235,10 +1246,9 @@ Hutaweza kubadilisha orodha ya watumiaji!</translation>
         <translation>Hii ni nini?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation>Folda Mpya:
+        <translation type="vanished">Folda Mpya:
 (Itawekwa katika %1 )</translation>
     </message>
     <message>

--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -648,13 +648,6 @@ e-mail</source>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>சரிபார்க்கவும் .gpgid கோப்பு கையொப்பம்!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>புதுப்பிக்க முடியாது</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>சரிபார்க்கவும் .gpg-id கோப்பு கையொப்பம்!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_th.ts
+++ b/localization/localization_th.ts
@@ -591,8 +591,8 @@ e-mail</translation>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>ตรวจสอบลายเซ็นไฟล์ .gpgid!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>ตรวจสอบลายเซ็นไฟล์ .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -1152,9 +1152,20 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
+        <source>New password file: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1468"/>
+        <source>New Folder: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>New password file:
 (Will be placed in %1 )</source>
-        <translation>ไฟล์รหัสผ่านใหม่:
+        <translation type="vanished">ไฟล์รหัสผ่านใหม่:
 (จะถูกวางใน %1 )</translation>
     </message>
     <message>
@@ -1233,10 +1244,9 @@ You will not be able to change the user list!</source>
         <translation>นี่คืออะไร?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation>โฟลเดอร์ใหม่:
+        <translation type="vanished">โฟลเดอร์ใหม่:
 (จะถูกวางใน %1 )</translation>
     </message>
     <message>

--- a/localization/localization_th.ts
+++ b/localization/localization_th.ts
@@ -1152,15 +1152,17 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
-        <source>New password file: 
+        <source>New password file:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">ไฟล์รหัสผ่านใหม่:
+(จะถูกวางไว้ใน %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
-        <source>New Folder: 
+        <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">โฟลเดอร์ใหม่:
+(จะถูกวางไว้ใน %1 )</translation>
     </message>
     <message>
         <source>New password file:

--- a/localization/localization_tr.ts
+++ b/localization/localization_tr.ts
@@ -592,13 +592,6 @@ e-posta</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>.gpgid dosyasının imzasını gözden geçirin!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -643,6 +636,13 @@ Kullanıcı listesini değiştiremeyeceksiniz!</translation>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Güncellenemiyor</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>.gpg-id dosyasının imzasını gözden geçirin!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_uk.ts
+++ b/localization/localization_uk.ts
@@ -648,13 +648,6 @@ URL
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Перевірте підпис файлу .gpgid!</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>Не вдається оновити</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Перевірте підпис файлу .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_ur.ts
+++ b/localization/localization_ur.ts
@@ -591,8 +591,8 @@ URL
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>.gpgid فائل کے دستخط چیک کریں!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>.gpg-id فائل کے دستخط چیک کریں!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -1154,9 +1154,20 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
+        <source>New password file: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1468"/>
+        <source>New Folder: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>New password file:
 (Will be placed in %1 )</source>
-        <translation>نئی پاس ورڈ فائل:
+        <translation type="vanished">نئی پاس ورڈ فائل:
 (%1 میں رکھی جائے گی)</translation>
     </message>
     <message>
@@ -1235,10 +1246,9 @@ You will not be able to change the user list!</source>
         <translation>یہ کیا ہے؟</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation>نیا فولڈر:
+        <translation type="vanished">نیا فولڈر:
 (%1 میں رکھا جائے گا)</translation>
     </message>
     <message>

--- a/localization/localization_ur.ts
+++ b/localization/localization_ur.ts
@@ -1154,15 +1154,17 @@ You will not be able to change the user list!</source>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
-        <source>New password file: 
+        <source>New password file:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">نئی پاس ورڈ فائل:
+(یہ %1 میں رکھی جائے گی)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
-        <source>New Folder: 
+        <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">نیا فولڈر:
+(یہ %1 میں رکھا جائے گا)</translation>
     </message>
     <message>
         <source>New password file:

--- a/localization/localization_vi.ts
+++ b/localization/localization_vi.ts
@@ -1152,15 +1152,17 @@ Bạn sẽ không thể thay đổi danh sách người dùng!</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
-        <source>New password file: 
+        <source>New password file:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tệp mật khẩu mới:
+(Sẽ được đặt trong %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1468"/>
-        <source>New Folder: 
+        <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Thư mục mới:
+(Sẽ được đặt trong %1 )</translation>
     </message>
     <message>
         <source>New password file:

--- a/localization/localization_vi.ts
+++ b/localization/localization_vi.ts
@@ -591,8 +591,8 @@ e-mail</translation>
         <location filename="../src/imitatepass.cpp" line="141"/>
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>Kiểm tra chữ ký tệp .gpgid!</translation>
+        <source>Check .gpg-id file signature!</source>
+        <translation>Kiểm tra chữ ký tệp .gpg-id!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -1152,9 +1152,20 @@ Bạn sẽ không thể thay đổi danh sách người dùng!</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
+        <source>New password file: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1468"/>
+        <source>New Folder: 
+(Will be placed in %1 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>New password file:
 (Will be placed in %1 )</source>
-        <translation>Tệp mật khẩu mới:
+        <translation type="vanished">Tệp mật khẩu mới:
 (Sẽ được đặt trong %1 )</translation>
     </message>
     <message>
@@ -1233,10 +1244,9 @@ Bạn sẽ không thể thay đổi danh sách người dùng!</translation>
         <translation>Đây là gì?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1468"/>
         <source>New Folder:
 (Will be placed in %1 )</source>
-        <translation>Thư mục mới:
+        <translation type="vanished">Thư mục mới:
 (Sẽ được đặt trong %1 )</translation>
     </message>
     <message>

--- a/localization/localization_zh_CN.ts
+++ b/localization/localization_zh_CN.ts
@@ -652,13 +652,6 @@ e-mail</translation>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>检查 .gpgid 文件签名！</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -703,6 +696,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>无法更新</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>检查 .gpg-id 文件签名！</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -648,13 +648,6 @@ e-mail</source>
 <context>
     <name>ImitatePass</name>
     <message>
-        <location filename="../src/imitatepass.cpp" line="141"/>
-        <location filename="../src/imitatepass.cpp" line="319"/>
-        <location filename="../src/imitatepass.cpp" line="505"/>
-        <source>Check .gpgid file signature!</source>
-        <translation>檢查.gpgid檔案簽名！</translation>
-    </message>
-    <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
@@ -699,6 +692,13 @@ You will not be able to change the user list!</source>
         <location filename="../src/imitatepass.cpp" line="260"/>
         <source>Cannot update</source>
         <translation>無法更新</translation>
+    </message>
+    <message>
+        <location filename="../src/imitatepass.cpp" line="141"/>
+        <location filename="../src/imitatepass.cpp" line="319"/>
+        <location filename="../src/imitatepass.cpp" line="505"/>
+        <source>Check .gpg-id file signature!</source>
+        <translation>檢查.gpg-id檔案簽名！</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -138,7 +138,7 @@ void ImitatePass::Insert(QString file, QString newValue, bool overwrite) {
   file = file + ".gpg";
   QString gpgIdPath = Pass::getGpgIdPath(file);
   if (!verifyGpgIdFile(gpgIdPath)) {
-    emit critical(tr("Check .gpgid file signature!"),
+    emit critical(tr("Check .gpg-id file signature!"),
                   tr("Signature for %1 is invalid.").arg(gpgIdPath));
     return;
   }
@@ -284,7 +284,7 @@ void ImitatePass::writeGpgIdFile(const QString &gpgIdFile,
  * std::cout << result << std::endl; // Expected output: true if signing and
  * verification succeed
  *
- * @param QString &gpgIdFile - Path to the .gpgid file to be signed.
+ * @param QString &gpgIdFile - Path to the .gpg-id file to be signed.
  * @param QStringList &signingKeys - List of signing keys; only the first key is
  * used.
  * @return bool - True if the file was signed and its signature verified
@@ -316,7 +316,7 @@ auto ImitatePass::signGpgIdFile(const QString &gpgIdFile,
     return false;
   }
   if (!verifyGpgIdFile(gpgIdFile)) {
-    emit critical(tr("Check .gpgid file signature!"),
+    emit critical(tr("Check .gpg-id file signature!"),
                   tr("Signature for %1 is invalid.").arg(gpgIdFile));
     return false;
   }
@@ -502,7 +502,7 @@ auto ImitatePass::verifyGpgIdForDir(const QString &file,
     return true;
   }
   if (!verifyGpgIdFile(gpgIdPath)) {
-    emit critical(tr("Check .gpgid file signature!"),
+    emit critical(tr("Check .gpg-id file signature!"),
                   tr("Signature for %1 is invalid.").arg(gpgIdPath));
     return false;
   }


### PR DESCRIPTION
## Summary

Two-part PR:

### 1. `.gpgid` → `.gpg-id` source fix

Three `tr()` callsites in `imitatepass.cpp` (`Insert`, `signGpgIdFile`, `verifyGpgIdForDir`) emitted `Check .gpgid file signature!` — but the canonical filename is `.gpg-id` (with hyphen), as used everywhere else in this codebase, in the `password-store` standard, and even in the doc-comment of the same function. Fixed all three plus the `signGpgIdFile` doc-comment typo.

### 2. Translation refresh + audit on the new locales

- Ran `make distclean && qmake6` to refresh source references across all 57 `.ts` files.
- For the **60 locales** that had previously translated the broken form, migrated the translation onto the new (correct) entry with `.gpgid` → `.gpg-id` applied to the translation text. Most translations had hand-typed the typo verbatim (e.g. `sw`: `Angalia saini ya faili ya .gpgid!`).
- Dropped the now-redundant vanished entries.
- Marked the migrated translations finished — purely mechanical typo fix, no Weblate review needed.

### Audit on the 7 newly-added locales (fa, bn, hi, sw, th, ur, vi)

All filled by Weblate translators since their skeletons landed. Audit applied per the `qtpass-localization-audit` skill workflow:

| Check                       | Result    |
| --------------------------- | --------- |
| Placeholder mismatches      | 0         |
| Missing mnemonics           | 0         |
| HTML tag imbalance          | 0         |
| Mixed-script artifacts      | 0         |
| Verbatim-source fallbacks   | 0         |
| Alphabet character set      | preserved (no MT-translated `A-Z-...`) |
| `lrelease6` smoke test      | clean     |

The Weblate translators did good work — none of the classic MT defects from the bn-via-Qwen pass (`কopi`, `গénেরেট`, `commuter`/`exemeter` for minimize/maximize, Russian leaks) are present.

## Test plan

- [x] `grep -r '\.gpgid' .` returns nothing project-wide.
- [x] `make distclean && qmake6` succeeds; new source string lands in every locale.
- [x] `lrelease6 localization/localization_<lang>.ts` generates cleanly for each of the 7 new locales.
- [x] Audit clean across all 7 (placeholder/HTML/mnemonic/mixed-script/length/verbatim).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the signature-check message wording and propagated that fix across all supported languages so the verification prompt is consistent and clear for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->