### PR TITLE
fix: use QLocale-aware QTranslator::load() for proper locale fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ tests/auto/gpgkeystate/tst_gpgkeystate
 tests/auto/integration/tst_integration
 tests/auto/exportpublickeydialog/tst_exportpublickeydialog
 tests/auto/importkeydialog/tst_importkeydialog
+tests/auto/locale/tst_locale
 **/*.gc*
 *.bak
 README.c*

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ tests/auto/integration/tst_integration
 tests/auto/exportpublickeydialog/tst_exportpublickeydialog
 tests/auto/importkeydialog/tst_importkeydialog
 tests/auto/locale/tst_locale
+tests/auto/locale/.qm/
+tests/auto/locale/qmake_qmake_qm_files.qrc
 **/*.gc*
 *.bak
 README.c*

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -144,11 +144,17 @@ auto main(int argc, char *argv[]) -> int {
   QCoreApplication::setApplicationName("QtPass");
   QCoreApplication::setApplicationVersion(VERSION);
 
-  // Setup and load translator for localization
+  // Setup and load translator for localization.
+  //
+  // Use the QLocale-aware load() overload so Qt walks the user's preferred
+  // language list (e.g. ar_MA -> ar, da_DK -> da) automatically. The previous
+  // single-filename form returned false on the first miss and left the app
+  // untranslated whenever the system locale carried a country suffix that
+  // didn't match any .qm file verbatim.
   QTranslator translator;
-  QString locale = QLocale::system().name();
-  if (translator.load(
-          QString(":localization/localization_%1.qm").arg(locale))) {
+  if (translator.load(QLocale::system(), QStringLiteral("localization"),
+                      QStringLiteral("_"), QStringLiteral(":/localization"),
+                      QStringLiteral(".qm"))) {
 #if SINGLE_APP
     SingleApplication::installTranslator(&translator);
     SingleApplication::setLayoutDirection(

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog locale
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/locale/locale.pro
+++ b/tests/auto/locale/locale.pro
@@ -1,0 +1,20 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_locale.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+# Pull in the embedded .qm resource that src.pro generates so the test can
+# load translations the same way the running app does.
+RESOURCES += ../../../src/qmake_qmake_qm_files.qrc
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/locale/locale.pro
+++ b/tests/auto/locale/locale.pro
@@ -10,9 +10,13 @@ OBJ_PATH += ../../../src/$(OBJECTS_DIR)
 VPATH += ../../../src
 INCLUDEPATH += ../../../src
 
-# Pull in the embedded .qm resource that src.pro generates so the test can
-# load translations the same way the running app does.
-RESOURCES += ../../../src/qmake_qmake_qm_files.qrc
+# Build and embed our own .qm files via lrelease so the test is independent
+# of src/src.pro's build state and works on every platform (the auto-generated
+# qmake_qmake_qm_files.qrc lives in src/'s build dir with absolute paths that
+# don't translate cleanly to a different build root, e.g. on Windows CI).
+TRANSLATIONS = $$files($$PWD/../../../localization/localization_*.ts)
+CONFIG += lrelease embed_translations
+QM_FILES_RESOURCE_PREFIX = /localization
 
 win32 {
     RC_FILE = ../../../windows.rc

--- a/tests/auto/locale/tst_locale.cpp
+++ b/tests/auto/locale/tst_locale.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <QCoreApplication>
+#include <QLocale>
+#include <QObject>
+#include <QString>
+#include <QTranslator>
+#include <QtTest>
+
+/**
+ * @class TestLocale
+ * @brief Exercises QtPass's translation-loading and RTL detection.
+ *
+ * The production code in main/main.cpp uses the QLocale-aware overload of
+ * QTranslator::load() so that a system locale of e.g. "ar_MA" or "da_DK"
+ * falls back to the language-only "ar" / "da" .qm file when no exact match
+ * is bundled. These tests pin that behaviour against the embedded
+ * localization resource.
+ */
+class TestLocale : public QObject {
+  Q_OBJECT
+
+private slots:
+  /**
+   * @brief Locales whose system code is shipped verbatim as a .qm file load
+   *        directly with no fallback needed.
+   */
+  void loadExactMatch_data();
+  void loadExactMatch();
+
+  /**
+   * @brief Locales whose country-suffixed name has no .qm of its own load via
+   *        Qt's locale fallback chain to the language-only .qm.
+   *
+   * This is the regression test for the renaming PRs (#1328, #1350) that
+   * dropped country suffixes from single-variant locales.
+   */
+  void loadFallback_data();
+  void loadFallback();
+
+  /**
+   * @brief A wholly unknown locale must return false (no .qm), so the app
+   *        falls back to the source-language strings rather than aborting.
+   */
+  void loadUnknownLocale();
+
+  /**
+   * @brief The "LTR"/"RTL" pivot string used by main.cpp to set layout
+   *        direction must produce "RTL" for Arabic/Persian/Urdu/Hebrew and
+   *        "LTR" (or empty fallback) for Latin-script locales.
+   */
+  void layoutDirection_data();
+  void layoutDirection();
+
+  /**
+   * @brief Loading a translator must not stick to the QObject between tests:
+   *        each load() call should clear the previous state.
+   */
+  void loadIsIdempotent();
+};
+
+void TestLocale::loadExactMatch_data() {
+  QTest::addColumn<QString>("locale");
+  // A representative spread that shipped as <lang>_<COUNTRY>.qm.
+  QTest::newRow("en_US") << "en_US";
+  QTest::newRow("en_GB") << "en_GB";
+  QTest::newRow("de_DE") << "de_DE";
+  QTest::newRow("nl_BE") << "nl_BE";
+  QTest::newRow("nl_NL") << "nl_NL";
+  QTest::newRow("zh_CN") << "zh_CN";
+  QTest::newRow("zh_Hant") << "zh_Hant";
+  QTest::newRow("pt_BR") << "pt_BR";
+  QTest::newRow("pt_PT") << "pt_PT";
+  QTest::newRow("es_MX") << "es_MX";
+  QTest::newRow("fr_FR") << "fr_FR";
+}
+
+void TestLocale::loadExactMatch() {
+  QFETCH(QString, locale);
+  QTranslator translator;
+  const bool loaded = translator.load(
+      QLocale(locale), QStringLiteral("localization"), QStringLiteral("_"),
+      QStringLiteral(":/localization"), QStringLiteral(".qm"));
+  QVERIFY2(loaded,
+           qUtf8Printable(QStringLiteral("Failed to load %1").arg(locale)));
+}
+
+void TestLocale::loadFallback_data() {
+  QTest::addColumn<QString>("locale");
+  // Locales whose country-suffixed file used to exist but was renamed in
+  // PR #1328 (ar_MA -> ar) and PR #1350 (31 single-variant locales).
+  // Qt's locale fallback should walk down to the language-only .qm.
+  QTest::newRow("ar_MA -> ar") << "ar_MA";
+  QTest::newRow("ar_SA -> ar") << "ar_SA";
+  QTest::newRow("ar_EG -> ar") << "ar_EG";
+  QTest::newRow("da_DK -> da") << "da_DK";
+  QTest::newRow("ja_JP -> ja") << "ja_JP";
+  QTest::newRow("ko_KR -> ko") << "ko_KR";
+  QTest::newRow("pl_PL -> pl") << "pl_PL";
+  QTest::newRow("ru_RU -> ru") << "ru_RU";
+  QTest::newRow("sv_SE -> sv") << "sv_SE";
+  QTest::newRow("uk_UA -> uk") << "uk_UA";
+  QTest::newRow("ja_JP_TRADITIONAL -> ja") << "ja_JP";
+  QTest::newRow("fa_IR -> fa") << "fa_IR";
+  QTest::newRow("fa_AF -> fa") << "fa_AF";
+  QTest::newRow("hi_IN -> hi") << "hi_IN";
+  QTest::newRow("vi_VN -> vi") << "vi_VN";
+  QTest::newRow("th_TH -> th") << "th_TH";
+  QTest::newRow("ur_PK -> ur") << "ur_PK";
+  QTest::newRow("bn_BD -> bn") << "bn_BD";
+  QTest::newRow("bn_IN -> bn") << "bn_IN";
+  QTest::newRow("sw_KE -> sw") << "sw_KE";
+}
+
+void TestLocale::loadFallback() {
+  QFETCH(QString, locale);
+  QTranslator translator;
+  const bool loaded = translator.load(
+      QLocale(locale), QStringLiteral("localization"), QStringLiteral("_"),
+      QStringLiteral(":/localization"), QStringLiteral(".qm"));
+  QVERIFY2(
+      loaded,
+      qUtf8Printable(
+          QStringLiteral("Failed to load %1 via locale fallback").arg(locale)));
+}
+
+void TestLocale::loadUnknownLocale() {
+  QTranslator translator;
+  // Klingon: no .qm exists, no fallback should hit.
+  const bool loaded = translator.load(
+      QLocale("tlh_KX"), QStringLiteral("localization"), QStringLiteral("_"),
+      QStringLiteral(":/localization"), QStringLiteral(".qm"));
+  QVERIFY2(!loaded, "load() should return false for an unknown locale");
+}
+
+void TestLocale::layoutDirection_data() {
+  QTest::addColumn<QString>("locale");
+  QTest::addColumn<QString>("expected");
+  QTest::newRow("ar -> RTL") << "ar" << "RTL";
+  QTest::newRow("fa -> RTL") << "fa" << "RTL";
+  QTest::newRow("ur -> RTL") << "ur" << "RTL";
+  QTest::newRow("he -> RTL") << "he" << "RTL";
+  QTest::newRow("en_US -> LTR") << "en_US" << "LTR";
+  QTest::newRow("nl_NL -> LTR") << "nl_NL" << "LTR";
+  QTest::newRow("ja -> LTR") << "ja" << "LTR";
+  QTest::newRow("zh_CN -> LTR") << "zh_CN" << "LTR";
+}
+
+void TestLocale::layoutDirection() {
+  QFETCH(QString, locale);
+  QFETCH(QString, expected);
+  QTranslator translator;
+  QVERIFY(translator.load(QLocale(locale), QStringLiteral("localization"),
+                          QStringLiteral("_"), QStringLiteral(":/localization"),
+                          QStringLiteral(".qm")));
+  QCoreApplication::installTranslator(&translator);
+  // main.cpp does: tr("LTR") == "RTL" ? RightToLeft : LeftToRight.
+  // Each .ts file ships an "LTR" source string whose translation is "RTL"
+  // for right-to-left scripts.
+  const QString got = QObject::tr("LTR");
+  QCoreApplication::removeTranslator(&translator);
+  QCOMPARE(got, expected);
+}
+
+void TestLocale::loadIsIdempotent() {
+  QTranslator translator;
+  // Loading multiple locales in sequence on the same translator should
+  // not leak state — Qt's contract is that each load() resets it.
+  QVERIFY(translator.load(QLocale("ar_MA"), QStringLiteral("localization"),
+                          QStringLiteral("_"), QStringLiteral(":/localization"),
+                          QStringLiteral(".qm")));
+  QVERIFY(translator.load(QLocale("nl_NL"), QStringLiteral("localization"),
+                          QStringLiteral("_"), QStringLiteral(":/localization"),
+                          QStringLiteral(".qm")));
+  QVERIFY(translator.load(QLocale("en_US"), QStringLiteral("localization"),
+                          QStringLiteral("_"), QStringLiteral(":/localization"),
+                          QStringLiteral(".qm")));
+}
+
+QTEST_MAIN(TestLocale)
+#include "tst_locale.moc"

--- a/tests/auto/locale/tst_locale.cpp
+++ b/tests/auto/locale/tst_locale.cpp
@@ -3,6 +3,7 @@
 #include <QCoreApplication>
 #include <QLocale>
 #include <QObject>
+#include <QScopeGuard>
 #include <QString>
 #include <QTranslator>
 #include <QtTest>
@@ -100,7 +101,7 @@ void TestLocale::loadFallback_data() {
   QTest::newRow("ru_RU -> ru") << "ru_RU";
   QTest::newRow("sv_SE -> sv") << "sv_SE";
   QTest::newRow("uk_UA -> uk") << "uk_UA";
-  QTest::newRow("ja_JP_TRADITIONAL -> ja") << "ja_JP";
+  QTest::newRow("ja_JP_TRADITIONAL -> ja") << "ja_JP_TRADITIONAL";
   QTest::newRow("fa_IR -> fa") << "fa_IR";
   QTest::newRow("fa_AF -> fa") << "fa_AF";
   QTest::newRow("hi_IN -> hi") << "hi_IN";
@@ -162,27 +163,42 @@ void TestLocale::layoutDirection() {
                           QStringLiteral("_"), QStringLiteral(":/localization"),
                           QStringLiteral(".qm")));
   QCoreApplication::installTranslator(&translator);
+  // RAII guard: ensure the translator is uninstalled even if the assertion
+  // below short-circuits the function — otherwise we'd leak it into the next
+  // data row and pollute QObject::tr() globally.
+  auto cleanup = qScopeGuard(
+      [&translator] { QCoreApplication::removeTranslator(&translator); });
   // main.cpp does: tr("LTR") == "RTL" ? RightToLeft : LeftToRight.
   // Each .ts file ships an "LTR" source string whose translation is "RTL"
   // for right-to-left scripts.
-  const QString got = QObject::tr("LTR");
-  QCoreApplication::removeTranslator(&translator);
-  QCOMPARE(got, expected);
+  QCOMPARE(QObject::tr("LTR"), expected);
 }
 
 void TestLocale::loadIsIdempotent() {
   QTranslator translator;
   // Loading multiple locales in sequence on the same translator should
-  // not leak state — Qt's contract is that each load() resets it.
-  QVERIFY(translator.load(QLocale("ar_MA"), QStringLiteral("localization"),
-                          QStringLiteral("_"), QStringLiteral(":/localization"),
-                          QStringLiteral(".qm")));
-  QVERIFY(translator.load(QLocale("nl_NL"), QStringLiteral("localization"),
-                          QStringLiteral("_"), QStringLiteral(":/localization"),
-                          QStringLiteral(".qm")));
-  QVERIFY(translator.load(QLocale("en_US"), QStringLiteral("localization"),
-                          QStringLiteral("_"), QStringLiteral(":/localization"),
-                          QStringLiteral(".qm")));
+  // not leak state — Qt's contract is that each load() resets it. Each step
+  // not only verifies load() succeeded but also confirms the translator
+  // returns text from the just-loaded locale (and not the previous one) by
+  // probing the LTR/RTL pivot string from main.cpp.
+  const auto loadAndCheck = [&translator](const QString &locale,
+                                          const QString &expectedLTR) {
+    const bool loaded = translator.load(
+        QLocale(locale), QStringLiteral("localization"), QStringLiteral("_"),
+        QStringLiteral(":/localization"), QStringLiteral(".qm"));
+    QVERIFY2(loaded,
+             qUtf8Printable(QStringLiteral("load(%1) failed").arg(locale)));
+    const QString got = translator.translate("QObject", "LTR");
+    QVERIFY2(got == expectedLTR,
+             qUtf8Printable(QStringLiteral("after load(%1): tr(\"LTR\") "
+                                           "expected %2 but got %3")
+                                .arg(locale, expectedLTR, got)));
+  };
+
+  loadAndCheck("ar_MA", "RTL"); // falls back to ar (RTL)
+  loadAndCheck("nl_NL", "LTR"); // exact Dutch (LTR)
+  loadAndCheck("en_US", "LTR"); // exact English (LTR)
+  loadAndCheck("fa_IR", "RTL"); // falls back to fa (RTL)
 }
 
 QTEST_MAIN(TestLocale)

--- a/tests/auto/locale/tst_locale.cpp
+++ b/tests/auto/locale/tst_locale.cpp
@@ -136,14 +136,22 @@ void TestLocale::loadUnknownLocale() {
 void TestLocale::layoutDirection_data() {
   QTest::addColumn<QString>("locale");
   QTest::addColumn<QString>("expected");
-  QTest::newRow("ar -> RTL") << "ar" << "RTL";
-  QTest::newRow("fa -> RTL") << "fa" << "RTL";
-  QTest::newRow("ur -> RTL") << "ur" << "RTL";
-  QTest::newRow("he -> RTL") << "he" << "RTL";
-  QTest::newRow("en_US -> LTR") << "en_US" << "LTR";
-  QTest::newRow("nl_NL -> LTR") << "nl_NL" << "LTR";
-  QTest::newRow("ja -> LTR") << "ja" << "LTR";
-  QTest::newRow("zh_CN -> LTR") << "zh_CN" << "LTR";
+  QTest::newRow("ar -> RTL") << "ar"
+                             << "RTL";
+  QTest::newRow("fa -> RTL") << "fa"
+                             << "RTL";
+  QTest::newRow("ur -> RTL") << "ur"
+                             << "RTL";
+  QTest::newRow("he -> RTL") << "he"
+                             << "RTL";
+  QTest::newRow("en_US -> LTR") << "en_US"
+                                << "LTR";
+  QTest::newRow("nl_NL -> LTR") << "nl_NL"
+                                << "LTR";
+  QTest::newRow("ja -> LTR") << "ja"
+                             << "LTR";
+  QTest::newRow("zh_CN -> LTR") << "zh_CN"
+                                << "LTR";
 }
 
 void TestLocale::layoutDirection() {


### PR DESCRIPTION
## Summary

Switch from the single-filename `QTranslator::load()` overload to the **`QLocale`-aware** overload so Qt walks the user's preferred-language list automatically (`uiLanguages()`): `ar_MA → ar`, `da_DK → da`, `ja_JP → ja`, etc.

```diff
-  QString locale = QLocale::system().name();
-  if (translator.load(
-          QString(":localization/localization_%1.qm").arg(locale))) {
+  if (translator.load(QLocale::system(), QStringLiteral("localization"),
+                      QStringLiteral("_"),
+                      QStringLiteral(":/localization"),
+                      QStringLiteral(".qm"))) {
```

## Why this matters

`QLocale::system().name()` always returns the fully-qualified `language_country` form (e.g. `"ar_MA"`), even when `LANG` is set to just `"ar"` or the system has only the language configured. The old code fed that string straight into the filename-form `load()` which returns `false` on the first miss — so any user whose system reported `"ar_MA"` / `"da_DK"` / `"pl_PL"` / etc. saw the app in English after the locale-rename PRs (#1328, #1350) removed the country-suffixed `.qm` files.

The `QLocale` overload is the canonical Qt way to do localized resource loading. It walks `QLocale::uiLanguages()` from most-specific to least-specific (`ar_MA → ar`, plus any user-preferred fallbacks) and picks the first matching file — handling the language-only-vs-region split for free.

## Test plan

Wrote a small standalone smoke test exercising 9 representative locales:

```
ar_MA -> loaded=YES expected=YES OK   (fallback ar_MA -> ar)
da_DK -> loaded=YES expected=YES OK   (fallback da_DK -> da)
ja_JP -> loaded=YES expected=YES OK   (fallback ja_JP -> ja)
pl_PL -> loaded=YES expected=YES OK   (fallback pl_PL -> pl)
de_DE -> loaded=YES expected=YES OK   (exact match)
en_US -> loaded=YES expected=YES OK   (exact match)
nl_BE -> loaded=YES expected=YES OK   (exact match)
fa_IR -> loaded=YES expected=YES OK   (fallback fa_IR -> fa)
xx_YY -> loaded=NO  expected=NO  OK   (unknown locale, returns false)
Result: PASS
```

- [x] `make check`: all 19+ suites pass, no failures.
- [x] Behaviour unchanged for locales with an exact `.qm` match.
- [x] Behaviour fixed for locales whose `_YY` suffix was dropped in #1328 / #1350.
- [x] LTR/RTL detection (`tr("LTR") == "RTL"`) still works since the translator is installed before that check runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Localization now uses Qt's locale-aware fallback loading so regional/variant locales resolve to available translations.

* **Tests**
  * New automated locale test suite validates exact match, fallback behavior, unknown locales, layout direction, and idempotent translator loading.
  * Test build now includes the locale test project and embeds translation files for runtime verification.

* **Chores**
  * Ignore rules updated to exclude generated locale test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->