### PR TITLE
test(locale): improve diagnostics + cover failed-load state-clearing

### DIFF
--- a/tests/auto/locale/tst_locale.cpp
+++ b/tests/auto/locale/tst_locale.cpp
@@ -159,9 +159,13 @@ void TestLocale::layoutDirection() {
   QFETCH(QString, locale);
   QFETCH(QString, expected);
   QTranslator translator;
-  QVERIFY(translator.load(QLocale(locale), QStringLiteral("localization"),
-                          QStringLiteral("_"), QStringLiteral(":/localization"),
-                          QStringLiteral(".qm")));
+  QVERIFY2(
+      translator.load(QLocale(locale), QStringLiteral("localization"),
+                      QStringLiteral("_"), QStringLiteral(":/localization"),
+                      QStringLiteral(".qm")),
+      qUtf8Printable(QStringLiteral("Failed to load %1 for layoutDirection "
+                                    "test")
+                         .arg(locale)));
   QCoreApplication::installTranslator(&translator);
   // RAII guard: ensure the translator is uninstalled even if the assertion
   // below short-circuits the function — otherwise we'd leak it into the next
@@ -195,10 +199,31 @@ void TestLocale::loadIsIdempotent() {
                                 .arg(locale, expectedLTR, got)));
   };
 
-  loadAndCheck("ar_MA", "RTL"); // falls back to ar (RTL)
-  loadAndCheck("nl_NL", "LTR"); // exact Dutch (LTR)
-  loadAndCheck("en_US", "LTR"); // exact English (LTR)
-  loadAndCheck("fa_IR", "RTL"); // falls back to fa (RTL)
+  // Negative case: per QTranslator's contract ("The previous translation is
+  // cleared regardless of whether the new translation was successfully
+  // loaded") a failed load() must wipe whatever the translator was holding.
+  // Probe with an unknown locale and verify the prior LTR/RTL value is gone.
+  const auto loadUnknownAndCheckCleared =
+      [&translator](const QString &locale, const QString &staleLTR) {
+        const bool loaded = translator.load(
+            QLocale(locale), QStringLiteral("localization"),
+            QStringLiteral("_"), QStringLiteral(":/localization"),
+            QStringLiteral(".qm"));
+        QVERIFY2(!loaded, qUtf8Printable(QStringLiteral("load(%1) unexpectedly "
+                                                        "succeeded")
+                                             .arg(locale)));
+        const QString got = translator.translate("QObject", "LTR");
+        QVERIFY2(got != staleLTR,
+                 qUtf8Printable(QStringLiteral("after failed load(%1): stale "
+                                               "translation %2 remained active")
+                                    .arg(locale, staleLTR)));
+      };
+
+  loadAndCheck("ar_MA", "RTL");                // falls back to ar (RTL)
+  loadUnknownAndCheckCleared("tlh_KX", "RTL"); // failed load must clear state
+  loadAndCheck("nl_NL", "LTR");                // exact Dutch (LTR)
+  loadAndCheck("en_US", "LTR");                // exact English (LTR)
+  loadAndCheck("fa_IR", "RTL");                // falls back to fa (RTL)
 }
 
 QTEST_MAIN(TestLocale)


### PR DESCRIPTION
## Summary

Two reviewer findings on the just-merged locale test (#1362):

### 1. `layoutDirection()` — bare `QVERIFY` → `QVERIFY2`

The `translator.load()` precondition was checked with a plain `QVERIFY`, so a failure didn't say which locale was at fault. Switched to `QVERIFY2` with the locale id in the message, matching the pattern already used by `loadExactMatch` / `loadFallback`.

### 2. `loadIsIdempotent()` — add a failed-load case

The test only exercised the happy path. Added `loadUnknownAndCheckCleared` which loads an unknown locale (`tlh_KX`) and asserts:

- `load()` returns false
- the previously-cached LTR/RTL value is **gone** — `translator.translate()` must not return the stale value.

Pins the documented `QTranslator` contract:

> The previous translation is cleared (regardless of whether the new translation was successfully loaded).

Inserted between the `ar_MA` and `nl_NL` loads so an actual `"RTL"` value is in flight when the failed load should clear it.

## Test plan

- [x] `make check` for the locale suite: 43/43 pass.
- [x] `clang-format` 17.0.6 (super-linter `v7.1.0`) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions with enhanced error messages for better failure diagnostics.
  * Extended test coverage to include negative scenarios for translator load operations, ensuring proper state handling on failed loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->