### PR TITLE
chore(ci): tolerate 0.2% codecov noise on coverage.project gate

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,16 @@ coverage:
   ignore:
     - tests/*
     - src/qrc_*.cpp
+  project:
+    default:
+      # Tolerate up to 1% drop in overall coverage. Coverage on this
+      # codebase fluctuates run-to-run because integration tests hit
+      # different paths depending on runner state (GPG keyring, test
+      # fixture race conditions, async signal timing). Without a
+      # threshold, PRs that don't touch src/ at all can still trip
+      # the codecov/project gate on noise alone (~0.05% deltas on
+      # ~5k instrumented lines = 2-3 lines of variance).
+      threshold: 1%
   patch:
     default:
       target: 0%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,14 +5,14 @@ coverage:
     - src/qrc_*.cpp
   project:
     default:
-      # Tolerate up to 1% drop in overall coverage. Coverage on this
-      # codebase fluctuates run-to-run because integration tests hit
-      # different paths depending on runner state (GPG keyring, test
-      # fixture race conditions, async signal timing). Without a
-      # threshold, PRs that don't touch src/ at all can still trip
-      # the codecov/project gate on noise alone (~0.05% deltas on
-      # ~5k instrumented lines = 2-3 lines of variance).
-      threshold: 1%
+      # Coverage on this codebase fluctuates run-to-run because
+      # integration tests hit different paths depending on runner
+      # state (GPG keyring, test fixture race conditions, async
+      # signal timing). Observed delta on PRs that don't touch src/
+      # at all has been ~0.05% (2-3 lines of ~5k instrumented).
+      # 0.2% gives a 4x buffer for variance peaks while still
+      # catching real regressions of ~10+ lines.
+      threshold: 0.2%
   patch:
     default:
       target: 0%


### PR DESCRIPTION
## Summary

Add `coverage.project.default.threshold: 0.2%` to `.codecov.yml` so small run-to-run coverage fluctuations don't block PRs that didn't actually touch `src/`.

## Why

Coverage on this codebase fluctuates by ~0.05% between runs because integration tests hit different code paths depending on runner state (GPG keyring contents, fixture race conditions, async signal timing). A 0.05% delta on ~5k instrumented lines = 2–3 lines — well within normal variance.

PR #1364 hit this exact false positive: it's a test-only PR (`tests/auto/locale/` additions, no `src/` changes) and `codecov/patch` passed cleanly, but `codecov/project` failed on a -0.05% delta. With `tests/*` already excluded from coverage, the only explanation is measurement noise.

## Why 0.2% (not 1%)

First version was 1%; CodeRabbit pointed out that's too permissive — 50+ lines of regression could slip through. 0.2% gives a 4× buffer over observed noise (handles occasional variance peaks) while still catching real regressions of ~10 lines.

## Effect

- Tolerates up to 0.2% drop in project coverage. Real regressions still fail the gate.
- `codecov/patch` (line-level coverage on actually-changed lines) keeps its `target: 0%` — no change there.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.codecov.yml'))"` — valid YAML.
- [ ] Verified by next PR that doesn't touch `src/`: `codecov/project` should pass.