### PR TITLE
chore(ci): silence the yamllint warning fleet (21 → 0)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
+---
 version: "{build}"
 
 image: Visual Studio 2022

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 updates:

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,3 +1,4 @@
+---
 # zizmor configuration — see https://docs.zizmor.sh/configuration/
 #
 # We pin every `uses:` to a specific version tag (v8.6.0, v6.0.2, ...) and

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,3 +1,4 @@
+---
 name: Coverity Scan
 
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,4 @@
+---
 name: Documentation and public code coverage
 
 on:

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -1,3 +1,4 @@
+---
 name: publiccode.yml validation
 
 on:

--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -1,3 +1,4 @@
+---
 name: Release Build
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,3 +1,4 @@
+---
 # SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs
 opencode.json
 .opencode/package-lock.json
 .opencode/*.local.json
+.opencode/scheduled_tasks.lock

--- a/.transifex.yml
+++ b/.transifex.yml
@@ -1,3 +1,4 @@
+---
 git:
   filters:
     - filter_type: dir

--- a/.yaml-lint.yml
+++ b/.yaml-lint.yml
@@ -2,7 +2,15 @@
 extends: default
 
 rules:
-  # 80 chars should be enough, but don't fail if a line is longer
+  # 160 chars to comfortably accommodate long shell one-liners and URLs in
+  # workflows (yamllint default of 80 is conservative for the wide-screen era).
   line-length:
-    max: 120
+    max: 160
+    level: warning
+
+  # GitHub Actions workflows use `on:` as a key, which yamllint's truthy rule
+  # would otherwise flag as ambiguous boolean ("on" being a YAML 1.1 truthy
+  # alias). check-keys: false scopes the rule to *values* only.
+  truthy:
+    check-keys: false
     level: warning

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,3 +1,4 @@
+---
 publiccodeYmlVersion: "0.5.0"
 
 name: QtPass


### PR DESCRIPTION
## Summary

`yamllint` was emitting **21 warnings** on every CI run. None failed the build but they cluttered the lint log. Three categories, all addressed:

| Category | Count | Fix |
| --- | --- | --- |
| `document-start` (missing `---`) | 10 files | Prepend `---` |
| `line-length` (>120 chars) | 2 lines | Bump max in config 120 → 160 |
| `truthy` (`on:` key in workflows) | 8 files | `truthy: { check-keys: false }` in config |

Net: **21 → 0**. yaml-prettier stays clean.

## Why each choice

### `---` document-start

YAML 1.1 spec recommends it, yamllint warns when missing. Just prepend. The `reuse.yml` file has an SPDX header on top, so the `---` slots above the comment block.

### Line-length 120 → 160

Two flagged lines:

- `.appveyor.yml:68` — 148 chars, a Windows path-conditional `copy` chain.
- `release-installers.yml:188` — 128 chars, an awk one-liner extracting the version from `qtpass.pri`.

Both are single-purpose shell expressions where breaking would hurt readability more than help. 160 is a comfortable modern cap.

### `truthy` `check-keys: false`

YAML 1.1 treats `on`/`off`/`yes`/`no` as booleans. GitHub Actions uses `on:` as the canonical event-trigger key — it's not something we can rename. Scoping the check to *values* only handles the GHA case while still catching genuine truthy ambiguity in scalar values elsewhere.

## Verification

```
docker run ghcr.io/super-linter/super-linter:v8.6.0 yamllint -c .yaml-lint.yml -f parsable .
```

→ zero output, exit 0.

```
npx prettier --check "**/*.yml" "**/*.yaml"
```

→ "All matched files use Prettier code style!"

## Drive-by

`.opencode/scheduled_tasks.lock` (local session lock — not for git) added to `.gitignore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized YAML configuration file formatting across the repository.
  * Updated linting rules to adjust line-length limits and improve validation behavior.
  * Refreshed build system and workflow configurations.
  * Updated build artifact exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->