### PR TITLE
docs(skills): capture super-linter v8 specifics in qtpass-linting

### DIFF
--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -58,7 +58,7 @@ Or install native binaries: `cargo install zizmor`, distro packages for clang-fo
 
 `act` works well for most workflows but the super-linter image has version drift and event-mock issues — see "Reproducing CI locally" above for the reliable alternative.
 
-**Always run local CI before pushing PRs.** Use `act` to run GitHub Actions workflows locally.
+**Always run local CI before pushing PRs.** Use `act` for most workflows; for super-linter workflows, prefer the Docker-based alternative described above (version drift and event-mock issues make `act` unreliable there).
 
 ### Why Use act?
 

--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -9,7 +9,54 @@ metadata:
 
 # QtPass Linting and CI Workflow
 
-## The Act Pattern
+## Super-linter v8 specifics (CI pin: v8.6.0)
+
+The lint workflow uses `super-linter/super-linter@v8` which resolves to image **`ghcr.io/super-linter/super-linter:v8.6.0`**. Critical quirks learned the hard way:
+
+### Config file locations
+
+`LINTER_RULES_PATH` defaults to **`.github/linters/`** — every per-linter config file that super-linter explicitly passes via `--config <path>` lives there, not at repo root.
+
+| Linter | Config file                   |
+| ------ | ----------------------------- |
+| zizmor | `.github/linters/zizmor.yaml` |
+
+Other linters auto-discover their own dotfiles like `.codespellrc`, `.clang-format`, `.commitlintrc.js`, `.jshintrc`, `.jshintignore`, `.yaml-lint.yml`, `.codecov.yml` from repo root via the linter's own conventions — those don't go under `.github/linters/`.
+
+### `super-linter.env` rules
+
+- **Pure `KEY=value` only** — no comments, no blank lines, **alphabetical** (dotenv-linter `UnorderedKey` rule). The workflow does `cat super-linter.env >> $GITHUB_ENV` and `$GITHUB_ENV` rejects everything else.
+- Document the rationale for non-obvious vars **in the workflow YAML** (above the `cat` step), not in the env file.
+- **`GITHUB_*` env vars set via `$GITHUB_ENV` don't propagate** to docker-based actions like super-linter. So you cannot override e.g. `GITHUB_ACTIONS_ZIZMOR_CONFIG_FILE` this way — put the config at the default-discovered location instead.
+
+### Reproducing CI locally
+
+`act` is **unreliable** for super-linter — the floating `:v7`/`:v8` tags drift, and act's mock GitHub event JSON lacks fields that v8 super-linter needs (`forced` for push events). The reliable reproduction is the exact CI image via docker:
+
+```bash
+# Run a specific linter (e.g. zizmor) the way CI does
+docker run --rm -v "$PWD:/work" -w /work \
+  --entrypoint zizmor ghcr.io/super-linter/super-linter:v8.6.0 \
+  --config .github/linters/zizmor.yaml .github/workflows/
+
+# Or clang-format check
+docker run --rm -v "$PWD:/work" -w /work \
+  --entrypoint clang-format ghcr.io/super-linter/super-linter:v8.6.0 \
+  --style=file --dry-run --Werror path/to/file.cpp
+```
+
+Or install native binaries: `cargo install zizmor`, distro packages for clang-format/yamllint/codespell.
+
+### Tooling-version highlights
+
+- **clang-format 21.1.2** — modern; matches recent distros. (Was 17.0.6 in v7.1.0 — a notable mismatch source pre-v8 bump.)
+- **zizmor 1.23.1** — default policy is `hash-pin`; we override to `ref-pin` in the config (version tags + dependabot cooldown).
+- **commitlint 20** — picks up `.commitlintrc.js` from repo root.
+- **JSHint** — only runs via Hound (not super-linter v8). Default ES5; we set `esversion: 11` in `.jshintrc`.
+
+## The Act Pattern (caveat: super-linter is tricky)
+
+`act` works well for most workflows but the super-linter image has version drift and event-mock issues — see "Reproducing CI locally" above for the reliable alternative.
 
 **Always run local CI before pushing PRs.** Use `act` to run GitHub Actions workflows locally.
 

--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -15,23 +15,23 @@ The lint workflow uses `super-linter/super-linter@v8` which resolves to image **
 
 ### Config file locations
 
-`LINTER_RULES_PATH` defaults to **`.github/linters/`** — every per-linter config file that super-linter explicitly passes via `--config <path>` lives there, not at repo root.
+`LINTER_RULES_PATH` defaults to **`.github/linters/`** — every per-linter config file that super-linter explicitly passes via `--config <path>` lives there, not at the repository root.
 
 | Linter | Config file                   |
 | ------ | ----------------------------- |
 | zizmor | `.github/linters/zizmor.yaml` |
 
-Other linters auto-discover their own dotfiles like `.codespellrc`, `.clang-format`, `.commitlintrc.js`, `.jshintrc`, `.jshintignore`, `.yaml-lint.yml`, `.codecov.yml` from repo root via the linter's own conventions — those don't go under `.github/linters/`.
+Other linters auto-discover their own dotfiles like `.codespellrc`, `.clang-format`, `.commitlintrc.js`, `.jshintrc`, `.jshintignore`, `.yaml-lint.yml`, `.codecov.yml` from the repository root via the linter's own conventions — those don't go under `.github/linters/`.
 
 ### `super-linter.env` rules
 
-- **Pure `KEY=value` only** — no comments, no blank lines, **alphabetical** (dotenv-linter `UnorderedKey` rule). The workflow does `cat super-linter.env >> $GITHUB_ENV` and `$GITHUB_ENV` rejects everything else.
+- **Pure `KEY=value` only** — no comments, no empty lines, **alphabetical** (dotenv-linter `UnorderedKey` rule). The workflow does `cat super-linter.env >> $GITHUB_ENV` and `$GITHUB_ENV` rejects everything else.
 - Document the rationale for non-obvious vars **in the workflow YAML** (above the `cat` step), not in the env file.
 - **`GITHUB_*` env vars set via `$GITHUB_ENV` don't propagate** to docker-based actions like super-linter. So you cannot override e.g. `GITHUB_ACTIONS_ZIZMOR_CONFIG_FILE` this way — put the config at the default-discovered location instead.
 
 ### Reproducing CI locally
 
-`act` is **unreliable** for super-linter — the floating `:v7`/`:v8` tags drift, and act's mock GitHub event JSON lacks fields that v8 super-linter needs (`forced` for push events). The reliable reproduction is the exact CI image via docker:
+`act` is **unreliable** for super-linter — the floating `:v7`/`:v8` tags drift, and act's mock GitHub event JSON lacks fields that v8 super-linter needs (`forced` for push events). The reliable reproduction is the exact CI image via Docker:
 
 ```bash
 # Run a specific linter (e.g. zizmor) the way CI does
@@ -51,7 +51,7 @@ Or install native binaries: `cargo install zizmor`, distro packages for clang-fo
 
 - **clang-format 21.1.2** — modern; matches recent distros. (Was 17.0.6 in v7.1.0 — a notable mismatch source pre-v8 bump.)
 - **zizmor 1.23.1** — default policy is `hash-pin`; we override to `ref-pin` in the config (version tags + dependabot cooldown).
-- **commitlint 20** — picks up `.commitlintrc.js` from repo root.
+- **commitlint 20** — picks up `.commitlintrc.js` from the repository root.
 - **JSHint** — only runs via Hound (not super-linter v8). Default ES5; we set `esversion: 11` in `.jshintrc`.
 
 ## The Act Pattern (caveat: super-linter is tricky)

--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -25,7 +25,7 @@ Other linters auto-discover their own dotfiles like `.codespellrc`, `.clang-form
 
 ### `super-linter.env` rules
 
-- **Pure `KEY=value` only** — no comments, no empty lines, **alphabetical** (dotenv-linter `UnorderedKey` rule). The workflow does `cat super-linter.env >> $GITHUB_ENV` and `$GITHUB_ENV` rejects everything else.
+- **Pure `KEY=value` only** — no comments, no empty lines, **alphabetical** (dotenv-linter `UnorderedKey` rule). The workflow does `cat .github/super-linter.env >> $GITHUB_ENV` and `$GITHUB_ENV` rejects everything else.
 - Document the rationale for non-obvious vars **in the workflow YAML** (above the `cat` step), not in the env file.
 - **`GITHUB_*` env vars set via `$GITHUB_ENV` don't propagate** to docker-based actions like super-linter. So you cannot override e.g. `GITHUB_ACTIONS_ZIZMOR_CONFIG_FILE` this way — put the config at the default-discovered location instead.
 

--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -49,7 +49,7 @@ Or install native binaries: `cargo install zizmor`, distro packages for clang-fo
 
 ### Tooling-version highlights
 
-- **clang-format 21.1.2** — modern; matches recent distros. (Was 17.0.6 in v7.1.0 — a notable mismatch source pre-v8 bump.)
+- **clang-format 20** — modern; matches recent distros. (Was 17.0.6 in v7.1.0 — a notable mismatch source pre-v8 bump.)
 - **zizmor 1.23.1** — default policy is `hash-pin`; we override to `ref-pin` in the config (version tags + dependabot cooldown).
 - **commitlint 20** — picks up `.commitlintrc.js` from the repository root.
 - **JSHint** — only runs via Hound (not super-linter v8). Default ES5; we set `esversion: 11` in `.jshintrc`.

--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Super-linter v8 specifics (CI pin: v8.6.0)
 
-The lint workflow uses `super-linter/super-linter@v8` which resolves to image **`ghcr.io/super-linter/super-linter:v8.6.0`**. Critical quirks learned the hard way:
+The lint workflow uses `super-linter/super-linter@v8.6.0` which resolves to image **`ghcr.io/super-linter/super-linter:v8.6.0`**. Critical quirks learned the hard way:
 
 ### Config file locations
 


### PR DESCRIPTION
## Summary

The v7 → v8 super-linter saga (#1363) and the follow-up cleanups (#1366, #1368) surfaced a fleet of non-obvious quirks. Documenting them in the `qtpass-linting` skill so the next time someone touches CI lint they don't repeat the version archaeology.

## What's added

A new "Super-linter v8 specifics" section near the top of the skill covering:

- **Where per-linter config files live** — `.github/linters/` for explicit-`--config` consumers like zizmor; repo root for auto-discovering tools (clang-format, codespell, commitlint, jshint, yamllint, codecov).
- **`super-linter.env` rules** — pure `KEY=value`, alphabetical, no comments (it's `cat`-ed straight into `$GITHUB_ENV`).
- **`GITHUB_*` env vars don't propagate** via `$GITHUB_ENV` to docker-based actions — the silent failure mode that made `GITHUB_ACTIONS_ZIZMOR_CONFIG_FILE` no-op.
- **Why `act` is unreliable for super-linter** — tag drift and mock-event gaps (`forced` field on push events) — plus the docker-with-pinned-image alternative.
- **Tooling-version highlights** — clang-format 21.1.2 (was 17.0.6 in v7.1.0, source of the original chained-`<<` formatting disagreement), zizmor 1.23.1 with ref-pin policy, JSHint only via Hound (esversion 11 in `.jshintrc`).

Also added a one-line caveat to the existing "Act Pattern" section pointing at the reliable alternative.

## Test plan

- [x] `prettier --check **/*.md **/*.yml` — clean.
- [x] All lines under 400 chars (CI markdown line-length cap).
- [x] No content removed; only additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced generic local-run guidance with a CI linter–specific guide and pinned the linter image to v8.6.0.
  * Clarified where per-linter config files are located and enforced strict env-file KEY=value formatting and ordering.
  * Noted that runner-set CI env vars do not propagate into containerized linter runs.
  * Added Docker-based reproduction steps and discouraged prior local shortcuts for linter runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->