### PR TITLE
i18n(ta): fix 5 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -26,7 +26,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="98"/>
         <source>Autoclear after:</source>
-        <translation>தன்னியக்க கற்றல் பிறகு:</translation>
+        <translation type="unfinished">தன்னியக்க அழிப்பு பிறகு:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="115"/>
@@ -56,7 +56,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation>தன்னியக்க குழு: பிறகு:</translation>
+        <translation type="unfinished">தன்னியக்க குழுவை அழி:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>Abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
@@ -464,7 +464,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>
         <source>Failed to create password-store at: %1</source>
-        <translation>தரவு அளவுக்கான உணவு வடிவம் உருவாக்குவதில் தோல்வி: %1</translation>
+        <translation type="unfinished">கடவுச்சொல் களஞ்சியத்தை இங்கு உருவாக்க முடியவில்லை: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1017"/>
@@ -703,7 +703,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation>எழுதத் தவறிவிட்டது .சிபிசி-ஐடி எழுதுவதற்கு.</translation>
+        <translation type="unfinished">எழுதுவதற்கு .gpg-id ஐ திறக்க முடியவில்லை.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="274"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on `localization/localization_ta.ts`. All five verified against current `main`; all were marked as **finalized** (no `type="unfinished"`) despite containing real errors. Applied each fix with `type="unfinished"` so Weblate native review can confirm.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Autoclear after:` | `தன்னியக்க கற்றல் பிறகு:` | "automatic **learning** after:" — wrong word (clear → learn) | `தன்னியக்க அழிப்பு பிறகு:` |
| 2 | `Autoclear panel after:` | `தன்னியக்க குழு: பிறகு:` | extra colon mid-string breaks readability | `தன்னியக்க குழுவை அழி:` |
| 3 | `ABCDE…xyz0123456789` | `Abcdef…xyz0123456789` | only first letter capitalized, rest lowercase | restored source verbatim |
| 4 | `Failed to create password-store at: %1` | `தரவு அளவுக்கான உணவு வடிவம் உருவாக்குவதில் தோல்வி: %1` | ≈ "data size **food** format creation failure" (உணவு = food) | `கடவுச்சொல் களஞ்சியத்தை இங்கு உருவாக்க முடியவில்லை: %1` |
| 5 | `Failed to open .gpg-id for writing.` | `எழுதத் தவறிவிட்டது .சிபிசி-ஐடி எழுதுவதற்கு.` | `.gpg-id` transliterated as `.சிபிசி-ஐடி` (`.sipisi-idi`) — user sees a non-existent filename; also redundant எழுத/எழுது | `எழுதுவதற்கு .gpg-id ஐ திறக்க முடியவில்லை.` |

**#3 is security-relevant** — per the `qtpass-localization-audit` skill, the alphabet character-set source must not be translated; altering it breaks password generation.

**#5 is also security-adjacent** — error messages referring to `.சிபிசி-ஐடி` instead of `.gpg-id` make troubleshooting impossible.

## Test plan

- [x] All five verified against current main before applying.
- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6 localization/localization_ta.ts` → 299 finished + 5 unfinished (the five just fixed).
- [ ] CI green.
- [ ] Weblate native reviewer finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tamil language translations for user interface labels and error messages. Strings related to autoclear timers, character sets, and password operations were revised. Some incomplete translations may temporarily display English fallback text until further updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->