### PR TITLE
i18n(pa_IN): fill remaining 5 empty entries with best-effort Punjabi

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -261,7 +261,7 @@
         <location filename="../src/configdialog.ui" line="837"/>
         <location filename="../src/configdialog.ui" line="1015"/>
         <source>…</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">…</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="776"/>
@@ -666,7 +666,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
         <source>Failed to replace %1. Original has been restored.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1 ਨੂੰ ਬਦਲਣ ਵਿੱਚ ਅਸਫਲ। ਅਸਲ ਨੂੰ ਬਹਾਲ ਕੀਤਾ ਗਿਆ ਹੈ।</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
@@ -1430,7 +1430,7 @@ Continue?</source>
     <message>
         <location filename="../src/passworddialog.ui" line="143"/>
         <source>Length:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">ਲੰਬਾਈ:</translation>
     </message>
 </context>
 <context>
@@ -1655,12 +1655,12 @@ Red entries are not valid, you will not be able to encrypt to these.</source>
     <message>
         <location filename="../src/usersdialog.cpp" line="336"/>
         <source>[EXPIRED] </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">[ਮਿਆਦ ਪੁੱਗੀ] </translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="340"/>
         <source>[PARTIAL] </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">[ਅੰਸ਼ਕ] </translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

Brings Punjabi (Gurmukhi) to **100% coverage** (was 98% — 5 empty entries left over from the Llama 3.2 audit revert in #1372). All five filled with best-effort Punjabi and marked `type="unfinished"` so Weblate native review can finalise.

| Source | Translation |
|---|---|
| `…` | `…` (verbatim, matches all other Indic locales) |
| `Failed to replace %1. Original has been restored.` | `%1 ਨੂੰ ਬਦਲਣ ਵਿੱਚ ਅਸਫਲ। ਅਸਲ ਨੂੰ ਬਹਾਲ ਕੀਤਾ ਗਿਆ ਹੈ।` |
| `Length:` | `ਲੰਬਾਈ:` (matches Hindi `लंबाई:` and existing pa_IN "Password Length:" → "ਪਾਸਵਰਡ ਲੰਬਾਈ:") |
| `[EXPIRED] ` | `[ਮਿਆਦ ਪੁੱਗੀ] ` |
| `[PARTIAL] ` | `[ਅੰਸ਼ਕ] ` |

Cross-referenced against finalised Hindi / Marathi / Bengali translations for consistency.

## Test plan

- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6 localization/localization_pa_IN.ts` → 299 finished + 5 unfinished, 0 ignored.
- [ ] CI green.
- [ ] Weblate native reviewer finalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed Punjabi language translations for multiple dialogs, including error messages, labels, and status indicators across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->