### PR TITLE
i18n(pa_IN): fix 5 reviewer-flagged mistranslations

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -16,7 +16,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="72"/>
         <source>Clipboard behaviour:</source>
-        <translation>ਕਲਪੀ ਵਿਚਾਰਧਾਰਾ:</translation>
+        <translation type="unfinished">ਕਲਿੱਪਬੋਰਡ ਵਿਹਾਰ:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
@@ -52,22 +52,22 @@
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation>ਪੈਨਲ ਬਾਅਦ ਦੇ ਉਸ਼ੂਮ ਕਰੋ:</translation>
+        <translation type="unfinished">ਪੈਨਲ ਆਪਣੇ-ਆਪ ਸਾਫ਼ ਕਰੋ ਬਾਅਦ:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <source>Use a monospace font</source>
-        <translation>ਇੱਕ ਵਿਸਥਾਰੀ ਫੋਨਟ ਵਰਤੋ</translation>
+        <translation type="unfinished">ਮੋਨੋਸਪੇਸ ਫੌਂਟ ਵਰਤੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
         <source>Display the files content as-is</source>
-        <translation>ਅਜਿਹੇ ਪਹਿਲੂ ਦੇ ਮਾਹਿਓ ਦਿਖਾਓ</translation>
+        <translation type="unfinished">ਫਾਈਲ ਦੀ ਸਮੱਗਰੀ ਨੂੰ ਜਿਵੇਂ ਹੈ ਦਿਖਾਓ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="238"/>
         <source>No line wrapping</source>
-        <translation>ਨਾ ਲਾਈਨ ਡ੍ਰਾਪਿੰਗ</translation>
+        <translation type="unfinished">ਲਾਈਨ ਰੈਪਿੰਗ ਨਹੀਂ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="245"/>


### PR DESCRIPTION
## Summary

Five reviewer findings on `localization/localization_pa_IN.ts`. All five verified against current main as finalized (no `type="unfinished"`) despite containing real MT errors. Applied each correction with `type="unfinished"` so Weblate native review can finalize.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Clipboard behaviour:` | `ਕਲਪੀ ਵਿਚਾਰਧਾਰਾ:` | "clip **ideology/philosophy**:" — `ਵਿਚਾਰਧਾਰਾ` literally means doctrine/ideology | `ਕਲਿੱਪਬੋਰਡ ਵਿਹਾਰ:` |
| 2 | `Autoclear panel after:` | `ਪੈਨਲ ਬਾਅਦ ਦੇ ਉਸ਼ੂਮ ਕਰੋ:` | `ਉਸ਼ੂਮ` is not a standard word | `ਪੈਨਲ ਆਪਣੇ-ਆਪ ਸਾਫ਼ ਕਰੋ ਬਾਅਦ:` |
| 3 | `Use a monospace font` | `ਇੱਕ ਵਿਸਥਾਰੀ ਫੋਨਟ ਵਰਤੋ` | `ਵਿਸਥਾਰੀ` = "expanded/detailed" — wrong meaning | `ਮੋਨੋਸਪੇਸ ਫੌਂਟ ਵਰਤੋ` |
| 4 | `Display the files content as-is` | `ਅਜਿਹੇ ਪਹਿਲੂ ਦੇ ਮਾਹਿਓ ਦਿਖਾਓ` | incoherent | `ਫਾਈਲ ਦੀ ਸਮੱਗਰੀ ਨੂੰ ਜਿਵੇਂ ਹੈ ਦਿਖਾਓ` |
| 5 | `No line wrapping` | `ਨਾ ਲਾਈਨ ਡ੍ਰਾਪਿੰਗ` | `ਡ੍ਰਾਪਿੰਗ` = transliterated **dropping** — MT confused "wrap" with "drop" | `ਲਾਈਨ ਰੈਪਿੰਗ ਨਹੀਂ` |

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] `lrelease6 localization/localization_pa_IN.ts` → 299 finished + 5 unfinished, 0 ignored.
- [ ] CI green.
- [ ] Weblate native reviewer finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Punjabi translations for the configuration dialog, including clipboard behavior options, panel auto-clear settings, and display formatting preferences such as monospace font display, file formatting, and line wrapping controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->