### PR TITLE
i18n(ta): fix 5 reviewer-flagged mistranslations (round 2)

### DIFF
--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -721,12 +721,12 @@ You will not be able to decrypt any newly added passwords!</source>
         <location filename="../src/imitatepass.cpp" line="662"/>
         <location filename="../src/imitatepass.cpp" line="769"/>
         <source>Re-encryption failed</source>
-        <translation>இரண்டாம் தனிப்பட்ட உள்ளடக்கல் தவறவு</translation>
+        <translation type="unfinished">மீள் குறியாக்கம் தோல்வியடைந்தது</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
         <source>Failed to replace %1. Original has been restored.</source>
-        <translation>%1 மூலத்திற்கு மாற்றம் செய்யப்படவில்லை. முன்னோக்கி உள்ளது.</translation>
+        <translation type="unfinished">%1-ஐ மாற்ற முடியவில்லை. அசல் நிலை மீட்டமைக்கப்பட்டது.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
@@ -742,7 +742,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="699"/>
         <source>Could not inspect git status. Re-encryption was aborted.</source>
-        <translation>கிட் அட்டவணையின் சுவார்ச்சி மாற்றம் செய்யப்படவில்லை. குறியாக்கல் தனிப்ரச்சிணை எதிர்த்து முடிவுகள் இழந்தது.</translation>
+        <translation type="unfinished">கிட் நிலையை சரிபார்க்க முடியவில்லை. மீள் குறியாக்கம் நிறுத்தப்பட்டது.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="707"/>
@@ -768,7 +768,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="758"/>
         <source>Could not verify .gpg-id for directory.</source>
-        <translation>துறைக்கு .gpg-id மாற்றம் தேவையாக விளக்கப்படவில்லை.</translation>
+        <translation type="unfinished">அடைவைப் பொறுத்து .gpg-id ஐ சரிபார்க்க முடியவில்லை.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="770"/>
@@ -870,7 +870,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/keygendialog.ui" line="14"/>
         <source>Generate GnuPG keypair</source>
-        <translation>Gnenearne gnupg gnukg keypair</translation>
+        <translation type="unfinished">GnuPG விசை ஜோடியை உருவாக்கு</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>


### PR DESCRIPTION
## Summary

Round 2 of reviewer findings on `localization/localization_ta.ts`. Five entries verified against current main as finalized despite containing real MT errors. Applied each correction with `type="unfinished"` so Weblate native review can finalize.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Re-encryption failed` | `இரண்டாம் தனிப்பட்ட உள்ளடக்கல் தவறவு` | ≈ "second personal contained mistake" — calque | `மீள் குறியாக்கம் தோல்வியடைந்தது` |
| 2 | `Failed to replace %1. Original has been restored.` | `%1 மூலத்திற்கு மாற்றம் செய்யப்படவில்லை. முன்னோக்கி உள்ளது.` | ≈ "%1 source not changed. Forward exists." — meaning lost | `%1-ஐ மாற்ற முடியவில்லை. அசல் நிலை மீட்டமைக்கப்பட்டது.` |
| 3 | `Could not inspect git status. Re-encryption was aborted.` | long garbled string containing `சுவார்ச்சி மாற்றம்` / `தனிப்ரச்சிணை எதிர்த்து` (non-coherent) | | `கிட் நிலையை சரிபார்க்க முடியவில்லை. மீள் குறியாக்கம் நிறுத்தப்பட்டது.` |
| 4 | `Could not verify .gpg-id for directory.` | `துறைக்கு .gpg-id மாற்றம் தேவையாக விளக்கப்படவில்லை.` | uses `துறை` = "department" for "directory" | `அடைவைப் பொறுத்து .gpg-id ஐ சரிபார்க்க முடியவில்லை.` |
| 5 | `Generate GnuPG keypair` | `Gnenearne gnupg gnukg keypair` | pure misspelled English, not even Tamil — looks like a model hallucination / encoding glitch | `GnuPG விசை ஜோடியை உருவாக்கு` |

#5 is wild — the translation isn't broken Tamil, it's literally garbled English: `Gnenearne gnupg gnukg keypair`. Worst-of-MT material.

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] `lrelease6 localization/localization_ta.ts` → 299 finished + 5 unfinished, 0 ignored.
- [ ] CI green.
- [ ] Weblate native reviewer finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Tamil language translations for multiple system messages and interface labels, including error notifications for encryption operations, file replacement procedures, version control status checks, and system directory validation.
  * Designated certain translations as incomplete for ongoing refinement and quality review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->