### PR TITLE
i18n(pa_IN): fix 5 reviewer-flagged mistranslations (round 2)

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -107,12 +107,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
         <source>Alphabetical</source>
-        <translation>ਅੰਕੜਿਆਂ ਦੇ ਅੰਕੜੇ</translation>
+        <translation type="unfinished">ਵਰਨਮਾਲਾ ਅਧਾਰਿਤ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="383"/>
         <source>Alphanumerical</source>
-        <translation>ਅੰਕੜਿਆਂ ਅਤੇ ਸੰਖਿਆਵਾਂ ਦੇ ਅੰਕੜੇ</translation>
+        <translation type="unfinished">ਅੱਖਰਾਂ ਅਤੇ ਅੰਕਾਂ ਵਾਲਾ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="388"/>
@@ -152,7 +152,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="493"/>
         <source>Git:</source>
-        <translation>ਜੀਟਲ ਦੇ ਪ੍ਰੋਜੈਕਟ ਵਿੱਚ ਜਾਣੋ:</translation>
+        <translation type="unfinished">ਗਿਟ:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="505"/>
@@ -162,7 +162,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="519"/>
         <source>Automatically add .gpg-id files</source>
-        <translation>ਅਤੇਵਿਆਂ ਗੈਸਟੀਡੀ-ਐਡੀ ਫਾਈਲਾਂ ਨੂੰ ਜ਼ਮੀਨੀ ਕਰੋ</translation>
+        <translation type="unfinished">.gpg-id ਫਾਈਲਾਂ ਨੂੰ ਆਪਣੇ ਆਪ ਸ਼ਾਮਲ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="526"/>
@@ -207,7 +207,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <source>Use TrayIcon</source>
-        <translation>ਵਾਇਰੀ ਐਕਸ਼ਨ ਪਿਕਚਰ</translation>
+        <translation type="unfinished">ਸਿਸਟਮ ਟਰੇ ਆਈਕਨ ਵਰਤੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>


### PR DESCRIPTION
## Summary

Round 2 of reviewer findings on `localization/localization_pa_IN.ts`. All five verified as finalized on current main despite containing real MT errors. Applied each correction with `type="unfinished"` so Weblate native review can finalize.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Alphabetical` | `ਅੰਕੜਿਆਂ ਦੇ ਅੰਕੜੇ` | "**numbers of numbers**" — letters became numbers | `ਵਰਨਮਾਲਾ ਅਧਾਰਿਤ` |
| 2 | `Alphanumerical` | `ਅੰਕੜਿਆਂ ਅਤੇ ਸੰਖਿਆਵਾਂ ਦੇ ਅੰਕੜੇ` | "numbers and numbers of numbers" — MT couldn't find a word for "alphabet" | `ਅੱਖਰਾਂ ਅਤੇ ਅੰਕਾਂ ਵਾਲਾ` |
| 3 | `Git:` | `ਜੀਟਲ ਦੇ ਪ੍ਰੋਜੈਕਟ ਵਿੱਚ ਜਾਣੋ:` | "go to **Gitel's project**:" — MT invented a person | `ਗਿਟ:` |
| 4 | `Automatically add .gpg-id files` | `ਅਤੇਵਿਆਂ ਗੈਸਟੀਡੀ-ਐਡੀ ਫਾਈਲਾਂ ਨੂੰ ਜ਼ਮੀਨੀ ਕਰੋ` | `ਅਤੇਵਿਆਂ` not a word; `ਗੈਸਟੀਡੀ-ਐਡੀ` mangles `.gpg-id` (same security-relevant filename-loss pattern as Tamil's `.சிபிசி-ஐடி`); `ਜ਼ਮੀਨੀ ਕਰੋ` = "make ground/landed" | `.gpg-id ਫਾਈਲਾਂ ਨੂੰ ਆਪਣੇ ਆਪ ਸ਼ਾਮਲ ਕਰੋ` |
| 5 | `Use TrayIcon` | `ਵਾਇਰੀ ਐਕਸ਼ਨ ਪਿਕਚਰ` | "**wiry action picture**" | `ਸਿਸਟਮ ਟਰੇ ਆਈਕਨ ਵਰਤੋ` |

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] `lrelease6` → 294 finished + 10 unfinished (5 from #1381 still awaiting Weblate + 5 just fixed).
- [ ] CI green.
- [ ] Weblate native reviewer finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Punjabi language translations for the configuration dialog interface, including entries for alphabetical sorting, alphanumerical sorting, Git-related settings, automatic .gpg-id file addition, and TrayIcon functionality. Several translations have been revised and marked as incomplete, pending finalization to ensure quality localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->