### PR TITLE
i18n(ta): apply round-3 reviewer findings

### DIFF
--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -61,7 +61,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <source>Use a monospace font</source>
-        <translation>ஒரு மோனோச்பேச் எழுத்துருவைப் பயன்படுத்தவும்</translation>
+        <translation type="unfinished">ஒரு மோனோஸ்பேஸ் எழுத்துருவைப் பயன்படுத்தவும்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
@@ -721,12 +721,12 @@ You will not be able to decrypt any newly added passwords!</source>
         <location filename="../src/imitatepass.cpp" line="662"/>
         <location filename="../src/imitatepass.cpp" line="769"/>
         <source>Re-encryption failed</source>
-        <translation type="unfinished">மீள் குறியாக்கம் தோல்வியடைந்தது</translation>
+        <translation>மீள் குறியாக்கம் தோல்வியடைந்தது</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="663"/>
         <source>Failed to replace %1. Original has been restored.</source>
-        <translation type="unfinished">%1-ஐ மாற்ற முடியவில்லை. அசல் நிலை மீட்டமைக்கப்பட்டது.</translation>
+        <translation>%1-ஐ மாற்ற முடியவில்லை. அசல் நிலை மீட்டமைக்கப்பட்டது.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="692"/>
@@ -1446,12 +1446,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="668"/>
         <source>OTP code copied to clipboard</source>
-        <translation>OTP சொல்லுக்கு பதிவு தரவச்சு நகரப்பட்டது</translation>
+        <translation type="unfinished">OTP குறியீடு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
         <source>No OTP code found in this password entry</source>
-        <translation>இந்த உருவான கடவுச்சொல்லில் OTP சொல்லுக்கு இயல்பாக அமைவது விடவில்லை</translation>
+        <translation type="unfinished">இந்த கடவுச்சொல் பதிவில் OTP குறியீடு எதுவும் கிடைக்கவில்லை</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>


### PR DESCRIPTION
## Summary

Mixed batch — three different action types in five findings:

**Substantive corrections** (FIN → `type="unfinished"`, new content):

| Source | Old translation | Issue | Fix |
|---|---|---|---|
| `OTP code copied to clipboard` | `OTP சொல்லுக்கு பதிவு தரவச்சு நகரப்பட்டது` | uses `சொல்` (= "word") for "code"; incoherent | `OTP குறியீடு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது` |
| `No OTP code found in this password entry` | `இந்த உருவான கடவுச்சொல்லில் OTP சொல்லுக்கு இயல்பாக அமைவது விடவில்லை` | calque-broken; ≈ "doesn't leave to be set as default" | `இந்த கடவுச்சொல் பதிவில் OTP குறியீடு எதுவும் கிடைக்கவில்லை` |

**Spelling fix** (FIN → `type="unfinished"`, transliteration corrected):

| Source | Old | Fix |
|---|---|---|
| `Use a monospace font` | `மோனோச்பேச்` | `மோனோஸ்பேஸ்` (correct Tamil spelling of "monospace"; ச்/ஸ் confusion is a common transliteration issue) |

**Finalised** (drop `type="unfinished"` — two-pass reviewer sign-off on translations from #1382):

- `Re-encryption failed` → `மீள் குறியாக்கம் தோல்வியடைந்தது`
- `Failed to replace %1. Original has been restored.` → `%1-ஐ மாற்ற முடியவில்லை. அசல் நிலை மீட்டமைக்கப்பட்டது.`

## Test plan

- [x] All 5 verified against current main before applying.
- [x] `lrelease6` → 298 finished + 6 unfinished (3 just-corrected + 3 from earlier rounds awaiting Weblate sign-off).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Tamil language translations throughout the application, including refinements to authentication-related text, error messages, and status notifications. These adjustments enhance translation accuracy and consistency for Tamil-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->