### PR TITLE
i18n(pa_IN): fix 5 reviewer-flagged mistranslations (round 3)

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="20"/>
         <source>Configuration</source>
-        <translation>ਸੈਟਿੰਗਜ਼</translation>
+        <translation type="unfinished">ਸੈੱਟਿੰਗਜ਼</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="46"/>
@@ -132,7 +132,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <source>Exclude capital letters</source>
-        <translation>ਹੇਠਾਂ ਦੇ ਬੱਡੀ ਲੇਖਾਂ ਦੇ ਮੁੱਢਲੇ ਅੱਖਰਾਂ ਨੂੰ ਛੱਡੋ</translation>
+        <translation type="unfinished">ਵੱਡੇ ਅੱਖਰ ਸ਼ਾਮਲ ਨਾ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
@@ -157,7 +157,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="505"/>
         <source>Use Git</source>
-        <translation>ਜੀਟਲ ਨੂੰ ਉਪਯੋਗ ਕਰੋ</translation>
+        <translation type="unfinished">ਗਿਟ ਨੂੰ ਉਪਯੋਗ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="519"/>
@@ -237,7 +237,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="709"/>
         <source>Nati&amp;ve Git/GPG</source>
-        <translation>(&amp;v) ਅਸਲੀ ਗਿਟ/ਜੀਪੀਐਚ</translation>
+        <translation type="unfinished">(&amp;v) ਅਸਲੀ ਗਿਟ/ਜੀਪੀਜੀ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="716"/>
@@ -356,7 +356,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1028"/>
         <source>Template</source>
-        <translation>ਟੈਬਲਿਟ</translation>
+        <translation type="unfinished">ਟੈਂਪਲੇਟ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1049"/>


### PR DESCRIPTION
## Summary

Round 3 of reviewer findings on `localization/localization_pa_IN.ts`. All five verified as finalized on current main despite containing real MT errors. Applied each correction with `type="unfinished"` so Weblate native review can finalize.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Configuration` | `ਸੈਟਿੰਗਜ਼` | missing addak diacritic; mismatches adjacent "Settings" → `ਸੈੱਟਿੰਗਜ਼` | `ਸੈੱਟਿੰਗਜ਼` |
| 2 | `Exclude capital letters` | `ਹੇਠਾਂ ਦੇ ਬੱਡੀ ਲੇਖਾਂ ਦੇ ਮੁੱਢਲੇ ਅੱਖਰਾਂ ਨੂੰ ਛੱਡੋ` | ≈ "skip first letters of bigger texts below" — garbled | `ਵੱਡੇ ਅੱਖਰ ਸ਼ਾਮਲ ਨਾ ਕਰੋ` |
| 3 | `Use Git` | `ਜੀਟਲ ਨੂੰ ਉਪਯੋਗ ਕਰੋ` | "use **Gitel**" — same invented-name goof as `Git:` had pre-#1383 | `ਗਿਟ ਨੂੰ ਉਪਯੋਗ ਕਰੋ` *(see note)* |
| 4 | `Nati&ve Git/GPG` | `(&v) ਅਸਲੀ ਗਿਟ/ਜੀਪੀਐਚ` | `ਜੀਪੀਐਚ` = "GPH" not "GPG" — letter swap | `(&v) ਅਸਲੀ ਗਿਟ/ਜੀਪੀਜੀ` |
| 5 | `Template` | `ਟੈਬਲਿਟ` | "**tablet**" — UI templates briefly became iPads | `ਟੈਂਪਲੇਟ` |

**Note on #3:** reviewer suggested `ਜ਼ਿਟ` (= "Zit") but #1383 just landed `ਗਿਟ` for the bare `Git:` label. Using `ਗਿਟ` here too keeps the file internally consistent.

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] `lrelease6` → 289 finished + 15 unfinished (10 from earlier rounds awaiting Weblate sign-off + 5 just fixed).
- [ ] CI green.
- [ ] Weblate native reviewer finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization Updates**
  * Revised Punjabi translations for configuration dialog strings (Configuration, Exclude capital letters, Use Git, Native Git/GPG, Template) with updated spellings and wording. Selected translations marked as in-progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->