### PR TITLE
i18n(pa_IN): fix 5 reviewer-flagged mistranslations (round 5)

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="20"/>
         <source>Configuration</source>
-        <translation type="unfinished">ਸੈੱਟਿੰਗਜ਼</translation>
+        <translation type="unfinished">ਸੰਰਚਨਾ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="46"/>
@@ -127,7 +127,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
         <source>Use PWGen</source>
-        <translation>ਵੀ ਪੈਸਵਰਡ ਨੂੰ ਤਿਆਰ ਕਰੋ</translation>
+        <translation type="unfinished">PWGen ਵਰਤੋਂ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
@@ -271,7 +271,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="779"/>
         <source>Generate GPG key pair</source>
-        <translation>ਸੀ ਐਨ ਗੋਪ ਕੀ ਜੋੜ ਦੇ ਤੌਰ ਤੇ</translation>
+        <translation type="unfinished">GPG ਕੁੰਜੀ ਜੋੜੀ ਬਣਾਓ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="786"/>
@@ -415,12 +415,12 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="126"/>
         <source>Always copy to clipboard</source>
-        <translation>ਸਦਾ ਕੱਪੀਬੋਰਡ ਵਿੱਚ ਕੁਲੈਂਟ ਕਰੋ</translation>
+        <translation type="unfinished">ਸਦਾ ਕਲਿਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="127"/>
         <source>On-demand copy to clipboard</source>
-        <translation>ਮੰਗ ਅਨੁਸਾਰ ਕੱਪੀਬੋਰਡ ਵਿੱਚ ਕੁਲੈਂਟ ਕਰੋ</translation>
+        <translation type="unfinished">ਮੰਗ ਅਨੁਸਾਰ ਕਲਿਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="210"/>
@@ -442,7 +442,7 @@ URL
         <location filename="../src/configdialog.cpp" line="728"/>
         <location filename="../src/configdialog.cpp" line="985"/>
         <source>Error</source>
-        <translation>ਘਟਨਾ ਦੀ ਗੱਲ ਹੈ</translation>
+        <translation type="unfinished">ਗਲਤੀ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="729"/>
@@ -1050,7 +1050,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
         <source>Configuration</source>
-        <translation>ਸੈੱਟਿੰਗਜ਼</translation>
+        <translation type="unfinished">ਸੰਰਚਨਾ</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="293"/>
@@ -1246,7 +1246,7 @@ You will not be able to change the user list!</source>
         <location filename="../src/mainwindow.cpp" line="1487"/>
         <location filename="../src/mainwindow.cpp" line="1696"/>
         <source>Error</source>
-        <translation>ਖ਼ਰਾਬੀ</translation>
+        <translation type="unfinished">ਗਲਤੀ</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>


### PR DESCRIPTION
## Summary

Round 5 of reviewer findings on `localization/localization_pa_IN.ts`. All five verified, applied with `type="unfinished"` so Weblate native review can finalize. Total of 8 string edits since `Configuration` and `Error` each appear twice in the file.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Configuration` (×2) | `ਸੈੱਟਿੰਗਜ਼` | matched adjacent "Settings" in #1385 — reviewer wants distinct term | `ਸੰਰਚਨਾ` |
| 2 | `Use PWGen` | `ਵੀ ਪੈਸਵਰਡ ਨੂੰ ਤਿਆਰ ਕਰੋ` | "**Also create password**" — completely lost the PWGen reference | `PWGen ਵਰਤੋਂ ਕਰੋ` *(see note)* |
| 3 | `Generate GPG key pair` | `ਸੀ ਐਨ ਗੋਪ ਕੀ ਜੋੜ ਦੇ ਤੌਰ ਤੇ` | "as a **C N Gop** key pair" — GPG transliterated as 3 separate Latin letters into "C N Gop" | `GPG ਕੁੰਜੀ ਜੋੜੀ ਬਣਾਓ` |
| 4a | `Always copy to clipboard` | `ਸਦਾ ਕੱਪੀਬੋਰਡ ਵਿੱਚ **ਕੁਲੈਂਟ** ਕਰੋ` | `ਕੁਲੈਂਟ` ≈ "**coolant**"! | `ਸਦਾ ਕਲਿਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕਰੋ` |
| 4b | `On-demand copy to clipboard` | same `ਕੁਲੈਂਟ` goof | | `ਮੰਗ ਅਨੁਸਾਰ ਕਲਿਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕਰੋ` |
| 5 | `Error` (×2) | `ਘਟਨਾ ਦੀ ਗੱਲ ਹੈ` | "**it is a matter of event/incident**" — single word UI label became a sentence | `ਗਲਤੀ` |

**Note on #2:** the bare "PWGen" entry from #1387 used a transliterated form `ਪੀਵਾਈਜੈਨੇਰੇਟ`. Reviewer here suggested verbatim `PWGen` for "Use PWGen" — went with that since it's a tool name. Weblate may iterate on cross-string consistency.

## Test plan

- [x] All 5 verified on current main before applying.
- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6` → 277 finished + 27 unfinished (19 earlier-round + 8 just fixed).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Refreshed Punjabi (pa_IN) language support with updated translations for Configuration options, clipboard management, error messages, and key generation features. Translation entries have been revised across multiple application interface sections. Several translations remain incomplete and are pending final completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->