### PR TITLE
i18n(pa_IN): fix 3 reviewer-flagged mistranslations (round 6)

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -545,7 +545,7 @@ URL
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="52"/>
         <source>Copy to Clipboard</source>
-        <translation>ਕਾਪੀ ਕਰੋ ਟੈਬਲੈਟ</translation>
+        <translation type="unfinished">ਕਾਪੀ ਕਰੋ ਕਲਿੱਪਬੋਰਡ</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="59"/>
@@ -757,7 +757,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/importkeydialog.ui" line="93"/>
         <source>Import</source>
-        <translation>ਆਈਨਫੋਰਮ</translation>
+        <translation type="unfinished">ਇੰਪੋਰਟ</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
@@ -767,7 +767,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/importkeydialog.cpp" line="43"/>
         <source>All Files</source>
-        <translation>ਸਾਰੇ ਡਾਇਰੈਕਟਰੀ</translation>
+        <translation type="unfinished">ਸਾਰੀਆਂ ਫਾਈਲਾਂ</translation>
     </message>
     <message>
         <location filename="../src/importkeydialog.cpp" line="51"/>


### PR DESCRIPTION
## Summary

Round 6 of reviewer findings on `localization/localization_pa_IN.ts`. All three verified as finalized on current main despite containing real MT errors. Applied with `type="unfinished"` so Weblate native review can finalize.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Copy to Clipboard` | `ਕਾਪੀ ਕਰੋ ਟੈਬਲੈਟ` | "copy to **tablet**" — clipboard became an iPad. Second "tablet" sighting in this file after #1385's `Template` → `ਟੈਬਲਿਟ` | `ਕਾਪੀ ਕਰੋ ਕਲਿੱਪਬੋਰਡ` |
| 2 | `Import` | `ਆਈਨਫੋਰਮ` | "**Inform**" — single-word UI button changed verb entirely | `ਇੰਪੋਰਟ` |
| 3 | `All Files` | `ਸਾਰੇ ਡਾਇਰੈਕਟਰੀ` | "All **directory**" — files → directories, plus singular-for-plural grammar | `ਸਾਰੀਆਂ ਫਾਈਲਾਂ` |

## Test plan

- [x] All 3 verified `[FIN]` on current main before applying.
- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6` → 274 finished + 30 unfinished (27 earlier-round + 3 just fixed).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Punjabi translations for clipboard operations, file importing, and file browsing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->