### PR TITLE
i18n(ta): finalize 5 reviewer-signed-off translations (round 6)

### DIFF
--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -910,7 +910,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/keygendialog.ui" line="246"/>
         <source>Template contents will be set based on GPG version.</source>
-        <translation type="unfinished">GPG பதிப்பின் அடிப்படையில் வார்ப்புரு உள்ளடக்கங்கள் அமைக்கப்படும்.</translation>
+        <translation>GPG பதிப்பின் அடிப்படையில் வார்ப்புரு உள்ளடக்கங்கள் அமைக்கப்படும்.</translation>
     </message>
     <message>
         <source>#           QtPass GPG key generator
@@ -1446,12 +1446,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="668"/>
         <source>OTP code copied to clipboard</source>
-        <translation type="unfinished">OTP குறியீடு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</translation>
+        <translation>OTP குறியீடு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="670"/>
         <source>No OTP code found in this password entry</source>
-        <translation type="unfinished">இந்த கடவுச்சொல் பதிவில் OTP குறியீடு எதுவும் கிடைக்கவில்லை</translation>
+        <translation>இந்த கடவுச்சொல் பதிவில் OTP குறியீடு எதுவும் கிடைக்கவில்லை</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="834"/>
@@ -1565,7 +1565,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1479"/>
         <source>Failed to create folder: %1</source>
-        <translation type="unfinished">%1 கோப்பகத்தை உருவாக்க முடியவில்லை</translation>
+        <translation>%1 கோப்பகத்தை உருவாக்க முடியவில்லை</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
@@ -1596,7 +1596,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1702"/>
         <source>Re-encrypt passwords</source>
-        <translation type="unfinished">கடவுச்சொற்களை மீண்டும் குறியாக்கம் செய்</translation>
+        <translation>கடவுச்சொற்களை மீண்டும் குறியாக்கம் செய்</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1703"/>


### PR DESCRIPTION
## Summary

Pure finalisation — drop `type="unfinished"` on five entries from #1388 that CodeRabbit re-reviewed and signed off on. Two-pass agreement is sufficient.

| Source | Translation |
|---|---|
| `Template contents will be set based on GPG version.` | `GPG பதிப்பின் அடிப்படையில் வார்ப்புரு உள்ளடக்கங்கள் அமைக்கப்படும்.` |
| `OTP code copied to clipboard` | `OTP குறியீடு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது` |
| `No OTP code found in this password entry` | `இந்த கடவுச்சொல் பதிவில் OTP குறியீடு எதுவும் கிடைக்கவில்லை` |
| `Failed to create folder: %1` | `%1 கோப்பகத்தை உருவாக்க முடியவில்லை` |
| `Re-encrypt passwords` | `கடவுச்சொற்களை மீண்டும் குறியாக்கம் செய்` |

**ta now at 304 finished / 0 unfinished / 0 empty — fully complete again.**

## Test plan

- [x] All 5 verified `[UT]` on current main before finalising.
- [x] `lrelease6` → 304 finished, 0 unfinished, 0 ignored.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Tamil language translations for interface elements including OTP status messages, folder creation error notifications, password encryption action labels, and dialog template contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->