### PR TITLE
i18n(pa_IN): fix 5 reviewer-flagged mistranslations (round 7)

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -142,7 +142,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation>ਗੁੱਝ ਯਾਦ ਰੱਖਣ ਵਾਲੇ ਪਰ ਘੱਟ ਸੁਰੱਖਿਅਤ ਪੈਸਵਰਡ ਪੈਨ ਕਰੋ</translation>
+        <translation type="unfinished">ਗੁੱਝ ਯਾਦ ਰੱਖਣ ਵਾਲੇ ਪਰ ਘੱਟ ਸੁਰੱਖਿਅਤ ਪੈਸਵਰਡ ਪੈਦਾ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
@@ -281,7 +281,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="799"/>
         <source>PWGen</source>
-        <translation type="unfinished">ਪੀਵਾਈਜੈਨੇਰੇਟ</translation>
+        <translation type="unfinished">PWGen</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="816"/>
@@ -405,7 +405,7 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="100"/>
         <source>qrencode needs to be installed</source>
-        <translation>ਕੁਆਰੋਡੀਨੇ ਦੀ ਇੰਸਟਾਲ ਕਰਨੀ ਜ਼ਰੂਰੀ ਹੈ</translation>
+        <translation type="unfinished">ਕਿਊਆਰਐਨਕੋਡ ਦੀ ਇੰਸਟਾਲ ਕਰਨੀ ਜ਼ਰੂਰੀ ਹੈ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="125"/>
@@ -431,7 +431,7 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="720"/>
         <source>Create profile directory?</source>
-        <translation>ਪ੍ਰੋਫਾਈਲ ਦਿਰੈਸ਼ੋਰੀ ਬਣਾਉਣ ਦਾ ਇਲੈਕਟ੍ਰਨ?</translation>
+        <translation type="unfinished">ਕੀ ਪ੍ਰੋਫਾਈਲ ਡਾਇਰੈਕਟਰੀ ਬਣਾਈ ਜਾਵੇ?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="721"/>
@@ -472,7 +472,7 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
         <source>GnuPG not found</source>
-        <translation>ਗਨੂਪੀ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ</translation>
+        <translation type="unfinished">ਜੀਨੂਪੀਜੀ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="914"/>


### PR DESCRIPTION
## Summary

Round 7 of reviewer findings on `localization/localization_pa_IN.ts`. All five verified, applied with `type="unfinished"` so Weblate native review can finalize.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Generate easy to memorize but less secure passwords` | ends with `ਪੈਨ ਕਰੋ` | "do **pen**" — "Generate" became "pen" | `…ਪੈਦਾ ਕਰੋ` |
| 2 | `PWGen` | `ਪੀਵਾਈਜੈਨੇਰੇਟ` (from #1387) | inconsistent with #1389's verbatim `PWGen` | `PWGen` (verbatim) |
| 3 | `qrencode needs to be installed` | starts with `ਕੁਆਰੋਡੀਨੇ` | "**Quaroden**" — invented word, neither tool name nor Punjabi | `ਕਿਊਆਰਐਨਕੋਡ` (proper transliteration) |
| 4 | `Create profile directory?` | `…ਬਣਾਉਣ ਦਾ ਇਲੈਕਟ੍ਰਨ?` | "**electron**?" — the question particle got hallucinated into a subatomic physics term | `ਕੀ ਪ੍ਰੋਫਾਈਲ ਡਾਇਰੈਕਟਰੀ ਬਣਾਈ ਜਾਵੇ?` |
| 5 | `GnuPG not found` | `ਗਨੂਪੀ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ` | "**Gnoopi**" — trailing G stripped from GnuPG; same acronym-mangling family as the "C N Gop" goof from #1389 | `ਜੀਨੂਪੀਜੀ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ` |

## Test plan

- [x] All 5 verified on current main before applying.
- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6` → 270 finished + 34 unfinished (29 earlier-round + 5 just fixed).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Punjabi language translations for configuration dialog strings.
  * Several translations marked as incomplete and will be finalized in upcoming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->