### PR TITLE
i18n(ta): fix 5 reviewer-flagged mistranslations (round 6)

### DIFF
--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -1803,7 +1803,7 @@ Continue?</source>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation type="unfinished">GPG சூத்திரங்கள் உருவாக்கல் தோல்வியடைந்தது</translation>
+        <translation type="unfinished">GPG விசை ஜோடி உருவாக்கம் தோல்வியடைந்தது</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>

--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -534,7 +534,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="505"/>
         <source>Use Git</source>
-        <translation>அறிவிலி பயன்படுத்தவும்</translation>
+        <translation type="unfinished">கிட்டைப் பயன்படுத்தவும்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
@@ -554,7 +554,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
         <source>Git</source>
-        <translation>அறிவிலி</translation>
+        <translation type="unfinished">கிட்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="756"/>
@@ -1082,12 +1082,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>
         <source>Git push</source>
-        <translation>அறிவிலி புச்</translation>
+        <translation type="unfinished">கிட் புஷ்</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="436"/>
         <source>Git pull</source>
-        <translation>அறிவிலி இழுத்தல்</translation>
+        <translation type="unfinished">கிட் இழுத்தல்</translation>
     </message>
     <message>
         <source>git pull</source>
@@ -1803,7 +1803,7 @@ Continue?</source>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation>GPG சூத்திரங்கள் உருவாக்கல் வேற்றுமடங்கு</translation>
+        <translation type="unfinished">GPG சூத்திரங்கள் உருவாக்கல் தோல்வியடைந்தது</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>


### PR DESCRIPTION
## Summary

**Headline finding:** across four UI locations, the MT translated **"Git" as "அறிவிலி"** — which means **"ignorant person / fool"** in Tamil. The version control system was literally being called an idiot throughout the UI. Plausible cause: MT confused the Latin word "git" with the British slang for "fool/jerk" rather than recognising it as the proper noun for the VCS.

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Use Git` | `அறிவிலி பயன்படுத்தவும்` | "use **ignorant**" | `கிட்டைப் பயன்படுத்தவும்` |
| 2 | `Git` | `அறிவிலி` | "**ignorant**" | `கிட்` |
| 3 | `Git push` | `அறிவிலி புச்` | "ignorant **poose**" (`புச்` is a malformed transliteration of "push") | `கிட் புஷ்` |
| 4 | `Git pull` | `அறிவிலி இழுத்தல்` | "ignorant pulling" | `கிட் இழுத்தல்` |
| 5 | `GPG key pair generation failed` | ends with `வேற்றுமடங்கு` | uncommon/awkward word choice for "failed" | ends with `தோல்வியடைந்தது` (matches usage elsewhere) |

**Note on consistency:** reviewer suggested `Git ஐப் பயன்படுத்தவும்` (Latin Git) for #1 but `கிட்` (transliterated) for #2-#4. Normalised everything to `கிட்` for cross-string consistency, matching the existing usage at line 207.

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6` → 299 finished + 5 unfinished (the 5 just fixed).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Revised Tamil translations for Git-related interface labels and commands (e.g., use, push, pull).
  * Updated Tamil wording for GPG key generation error messaging.
  * Users viewing the app in Tamil may notice updated phrasing for these Git/GPG UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->