### PR TITLE
i18n(pa_IN): fix 5 reviewer-flagged mistranslations (round 8)

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -217,7 +217,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <source>Hide on close</source>
-        <translation>ਬੰਦ ਹੋਣ &apos;ਤੇ ਗਵਾਹੀ ਕਰੋ</translation>
+        <translation type="unfinished">ਬੰਦ ਹੋਣ &apos;ਤੇ ਲੁਕਾਓ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>
@@ -395,7 +395,7 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="68"/>
         <source>System tray is not available</source>
-        <translation>ਸੰਚਾਰ ਟ੍ਰੇਅ ਨਹੀਂ ਮਿਲਦਾ</translation>
+        <translation type="unfinished">ਸਿਸਟਮ ਟਰੇ ਨਹੀਂ ਮਿਲਦਾ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="95"/>
@@ -467,7 +467,7 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="811"/>
         <source>No profile selected to delete</source>
-        <translation>ਕੋਈ ਪ੍ਰੋਫਾਈਲ ਦੇਖਣ ਲਈ ਚੁਣਿਆ ਨਹੀਂ ਹੈ ਅਤੇ ਉਸ ਨੂੰ ਮਾਰ ਦਿੱਤਾ ਜਾ ਸਕਦਾ ਹੈ</translation>
+        <translation type="unfinished">ਮਿਟਾਉਣ ਲਈ ਕੋਈ ਪ੍ਰੋਫਾਈਲ ਚੁਣਿਆ ਨਹੀਂ ਹੈ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="911"/>
@@ -497,7 +497,7 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="980"/>
         <source>Would you like to create a password-store at %1?</source>
-        <translation>ਤੁਸੀਂ ਇੱਕ ਪਾਸਵਰਡ ਸਟੋਰ ਬਣਾਉਣ ਦੀ ਯੋਜਨਾ ਕਿਉਂਕਿ %1?</translation>
+        <translation type="unfinished">ਕੀ ਤੁਸੀਂ %1 ਤੇ ਪਾਸਵਰਡ-ਸਟੋਰ ਬਣਾਉਣਾ ਚਾਹੋਗੇ?</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="986"/>
@@ -810,7 +810,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/keygendialog.ui" line="14"/>
         <source>Generate GnuPG keypair</source>
-        <translation>ਕੀ ਪੰਜਵੇਂ ਨੂੰ ਸਿੰਕ ਕਰੋ</translation>
+        <translation type="unfinished">GnuPG ਕੁੰਜੀ ਜੋੜੀ ਬਣਾਓ</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>


### PR DESCRIPTION
## Summary

Round 8 of reviewer findings on `localization/localization_pa_IN.ts`. All five verified, applied with `type="unfinished"` so Weblate native review can finalize.

This batch contains some of the wildest goofs yet — a hallucinated death threat, a question turned into a wrong-conjunction statement, and "Generate GnuPG keypair" rewritten as "sync the fifth one":

| # | Source | Old translation | Issue | Fix |
|---|---|---|---|---|
| 1 | `Hide on close` | `ਬੰਦ ਹੋਣ 'ਤੇ ਗਵਾਹੀ ਕਰੋ` | "**give testimony** on close" — verb hallucinated into a courtroom action | `ਬੰਦ ਹੋਣ 'ਤੇ ਲੁਕਾਓ` |
| 2 | `System tray is not available` | starts with `ਸੰਚਾਰ ਟ੍ਰੇਅ` | "**communication tray**" — system → communication | `ਸਿਸਟਮ ਟਰੇ ਨਹੀਂ ਮਿਲਦਾ` |
| 3 | `No profile selected to delete` | `ਕੋਈ ਪ੍ਰੋਫਾਈਲ ਦੇਖਣ ਲਈ ਚੁਣਿਆ ਨਹੀਂ ਹੈ ਅਤੇ ਉਸ ਨੂੰ **ਮਾਰ ਦਿੱਤਾ ਜਾ ਸਕਦਾ ਹੈ**` | "...AND it can be **killed/murdered**" — hallucinated a violent threat | `ਮਿਟਾਉਣ ਲਈ ਕੋਈ ਪ੍ਰੋਫਾਈਲ ਚੁਣਿਆ ਨਹੀਂ ਹੈ` |
| 4 | `Would you like to create a password-store at %1?` | `…ਯੋਜਨਾ **ਕਿਉਂਕਿ** %1?` | "...you plan to create...**because** %1?" — question particle replaced with wrong conjunction; reads as a confused statement | `ਕੀ ਤੁਸੀਂ %1 ਤੇ ਪਾਸਵਰਡ-ਸਟੋਰ ਬਣਾਉਣਾ ਚਾਹੋਗੇ?` (`%1` preserved) |
| 5 | `Generate GnuPG keypair` | `ਕੀ ਪੰਜਵੇਂ ਨੂੰ ਸਿੰਕ ਕਰੋ` | "**sync the fifth one?**" — total hallucination, no relation to the source | `GnuPG ਕੁੰਜੀ ਜੋੜੀ ਬਣਾਓ` |

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] `%1` preserved on #4.
- [x] Audit clean: 0 placeholder / 0 HTML / 0 mnemonic / 0 mixed-script.
- [x] `lrelease6` → 265 finished + 39 unfinished (34 earlier-round + 5 just fixed).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Punjabi language translations for user interface prompts and error messages, including system notifications, window behavior descriptions, and account management confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->