### PR TITLE
i18n(si): fix 2 audit-flagged mistranslations

### DIFF
--- a/localization/localization_si.ts
+++ b/localization/localization_si.ts
@@ -1502,7 +1502,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1488"/>
         <source>Failed to create .gpg-id file in: %1</source>
-        <translation>ක්‍රම අයිඩිතය කොට ඇත: %1</translation>
+        <translation type="unfinished">.gpg-id ගොනුව %1 හි සෑදීමට අසමත් විය</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1510"/>
@@ -1869,7 +1869,7 @@ Red entries are not valid, you will not be able to encrypt to these.</translatio
     <message>
         <location filename="../src/usersdialog.cpp" line="76"/>
         <source>Keylist missing</source>
-        <translation>කළමනාකරුව හෝ විද්‍යුත් කලනය කළමනාකරුව නගර කරන්න</translation>
+        <translation type="unfinished">යතුරු ලැයිස්තුව නැත</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="77"/>


### PR DESCRIPTION
## Summary

Two findings on `localization/localization_si.ts` from a cross-locale audit sweep (length-ratio + `.gpg-id` literal preservation checks).

| Source | Old translation | Issue | Fix |
|---|---|---|---|
| `Failed to create .gpg-id file in: %1` | `ක්‍රム අයිඩිතය කොට ඇත: %1` | "method ID has been done: %1" — the literal `.gpg-id` filename is **gone entirely**; user would see an error message about a "method ID" that doesn't exist anywhere | `.gpg-id ගොනුව %1 හි සෑදීමට අසමත් විය` |
| `Keylist missing` | `කළමනාකරුව හෝ විද්‍යුත් කලනය කළමනාකරුව නගර කරන්න` | ≈ "manager or electronic spread manager city do" — 47 chars for a 15-char source, completely incoherent | `යතුරු ලැයිස්තුව නැත` |

Both flagged `type="unfinished"` for Weblate native-reviewer finalisation.

## Test plan

- [x] Both verified `[FIN]` on current main.
- [x] `%1` and `.gpg-id` literal both preserved on #1.
- [x] `lrelease6` → 302 finished + 2 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Localization
* Updated Sinhala language translations for application messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->