### PR TITLE
i18n(pa_IN): restore .gpg-id literal in 3 mangled translations

### DIFF
--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -592,7 +592,7 @@ URL
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
         <source>Check .gpg-id file signature!</source>
-        <translation>ਚੈਕ ਐਗਜ਼ੀਪਿਰੇਸ਼ਨ ਐਗਜ਼-ਆਈਡੀ ਫਾਈਲ ਦੀ ਸਿਗਨੇਚਰ!</translation>
+        <translation type="unfinished">.gpg-id ਫਾਈਲ ਦੇ ਦਸਤਖਤ ਦੀ ਜਾਂਚ ਕਰੋ!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -621,7 +621,7 @@ URL
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation>ਲਿਖਣ ਲਈ .gpg-ਐਇਡ ਉਸਾਰਨ ਵਿੱਚ ਅਸਫਲ ਹੋਣ.</translation>
+        <translation type="unfinished">ਲਿਖਣ ਲਈ .gpg-id ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਫਲ।</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="274"/>
@@ -708,7 +708,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="758"/>
         <source>Could not verify .gpg-id for directory.</source>
-        <translation>ਡਿਰੈਕਟਰੀ ਲਈ .ਜੀ.ਪੀ.ਜੀ-ਐਇਡ ਯਾਦੀ ਸਹੀ ਨਹੀਂ ਕੀਤੀ ਗਈ.</translation>
+        <translation type="unfinished">ਡਾਇਰੈਕਟਰੀ ਲਈ .gpg-id ਦੀ ਪੁਸ਼ਟੀ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ।</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="770"/>

--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -592,7 +592,7 @@ URL
         <location filename="../src/imitatepass.cpp" line="319"/>
         <location filename="../src/imitatepass.cpp" line="505"/>
         <source>Check .gpg-id file signature!</source>
-        <translation type="unfinished">.gpg-id ਫਾਈਲ ਦੇ ਦਸਤਖਤ ਦੀ ਜਾਂਚ ਕਰੋ!</translation>
+        <translation>.gpg-id ਫਾਈਲ ਦੇ ਦਸਤਖਤ ਦੀ ਜਾਂਚ ਕਰੋ!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="142"/>
@@ -621,7 +621,7 @@ URL
     <message>
         <location filename="../src/imitatepass.cpp" line="261"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation type="unfinished">ਲਿਖਣ ਲਈ .gpg-id ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਫਲ।</translation>
+        <translation>ਲਿਖਣ ਲਈ .gpg-id ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਫਲ।</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="274"/>
@@ -708,7 +708,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="758"/>
         <source>Could not verify .gpg-id for directory.</source>
-        <translation type="unfinished">ਡਾਇਰੈਕਟਰੀ ਲਈ .gpg-id ਦੀ ਪੁਸ਼ਟੀ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ।</translation>
+        <translation>ਡਾਇਰੈਕਟਰੀ ਲਈ .gpg-id ਦੀ ਪੁਸ਼ਟੀ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ।</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="770"/>


### PR DESCRIPTION
## Summary

Three more `.gpg-id` mangles found via cross-locale audit, same family of bug as the Tamil `.சிபிசி-ஐடி` (#1377) and Punjabi `ਗੈਸਟੀਡੀ-ਐਡੀ` (#1383) goofs already fixed. **Security-relevant**: error messages pointing at filenames that don't exist make troubleshooting impossible — user can't find the file the error claims has a problem.

| Source | Old translation | Issue | Fix |
|---|---|---|---|
| `Check .gpg-id file signature!` | contained `ਐਗਜ਼ੀਪਿਰੇਸ਼ਨ ਐਗਜ਼-ਆਈਡੀ` | "**expiration egzs-id**" instead of `.gpg-id` | `.gpg-id ਫਾਈਲ ਦੇ ਦਸਤਖਤ ਦੀ ਜਾਂਚ ਕਰੋ!` |
| `Failed to open .gpg-id for writing.` | contained `.gpg-ਐਇਡ` | partial mangle — leading dot kept, but "id" transliterated into Gurmukhi; also used `ਉਸਾਰਨ` (= "construct") instead of "open" | `ਲਿਖਣ ਲਈ .gpg-id ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਫਲ।` |
| `Could not verify .gpg-id for directory.` | contained `.ਜੀ.ਪੀ.ਜੀ-ਐਇਡ` | overly verbose with periods between letters | `ਡਾਇਰੈਕਟਰੀ ਲਈ .gpg-id ਦੀ ਪੁਸ਼ਟੀ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ।` |

## Test plan

- [x] All 3 verified `[FIN]` on current main.
- [x] `.gpg-id` literal preserved in all 3 new translations (audit-confirmed).
- [x] `lrelease6` → 262 finished + 42 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Revised three Punjabi (pa_IN) user-facing translations in the ImitatePass context for messages about checking a `.gpg-id` signature, opening a `.gpg-id` file for writing, and verifying a `.gpg-id` for a directory. These updates replace previous Punjabi phrasing with improved wording while keeping the original English source text unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->