### PR TITLE
i18n(sq): translate 4 tray menu items left verbatim English

### DIFF
--- a/localization/localization_sq.ts
+++ b/localization/localization_sq.ts
@@ -1624,22 +1624,22 @@ Të vazhdohet?</translation>
     <message>
         <location filename="../src/trayicon.cpp" line="72"/>
         <source>Mi&amp;nimize</source>
-        <translation>Mi&amp;nimize</translation>
+        <translation type="unfinished">Mi&amp;nimizo</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="75"/>
         <source>Ma&amp;ximize</source>
-        <translation>Ma&amp;ximize</translation>
+        <translation type="unfinished">Ma&amp;ksimizo</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="78"/>
         <source>&amp;Restore</source>
-        <translation>&amp;Restore</translation>
+        <translation type="unfinished">&amp;Rikthe</translation>
     </message>
     <message>
         <location filename="../src/trayicon.cpp" line="81"/>
         <source>&amp;Quit</source>
-        <translation>&amp;Quit</translation>
+        <translation type="unfinished">&amp;Dil</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Summary

Cross-locale verbatim-untranslated audit found four tray-icon menu items with Albanian translations identical to the English source — MT/translator skipped these entries entirely.

| Source | Old (verbatim) | Fix |
|---|---|---|
| `Mi&nimize` | `Mi&nimize` | `Mi&nimizo` |
| `Ma&ximize` | `Ma&ximize` | `Ma&ksimizo` |
| `&Restore` | `&Restore` | `&Rikthe` |
| `&Quit` | `&Quit` | `&Dil` |

Mnemonic accelerator preserved on the same letter position in each translation (Latin-script in-word `&` convention).

Flagged `type="unfinished"` for Weblate native review.

## Test plan

- [x] All 4 verified `[FIN]` and verbatim-source on current main.
- [x] Audit confirms mnemonic preserved in all 4 new translations.
- [x] `lrelease6` → 300 finished + 4 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Albanian translations for system tray menu items (minimize, maximize, restore, and quit options).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->