### PR TITLE
i18n(en_US): fill empty plural forms

### DIFF
--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -1335,7 +1335,7 @@ p, li { white-space: pre-wrap; }
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="934"/>
         <source>Found %n match(es)</source>
-        <translation>
+        <translation type="unfinished">
             <numerusform>Found %n match</numerusform>
             <numerusform>Found %n matches</numerusform>
         </translation>
@@ -1470,7 +1470,7 @@ p, li { white-space: pre-wrap; }
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="935"/>
         <source>in %n entr(ies).</source>
-        <translation>
+        <translation type="unfinished">
             <numerusform>in %n entry.</numerusform>
             <numerusform>in %n entries.</numerusform>
         </translation>

--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -1335,9 +1335,9 @@ p, li { white-space: pre-wrap; }
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="934"/>
         <source>Found %n match(es)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Found %n match</numerusform>
+            <numerusform>Found %n matches</numerusform>
         </translation>
     </message>
     <message>
@@ -1470,9 +1470,9 @@ p, li { white-space: pre-wrap; }
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="935"/>
         <source>in %n entr(ies).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>in %n entry.</numerusform>
+            <numerusform>in %n entries.</numerusform>
         </translation>
     </message>
     <message>


### PR DESCRIPTION
## Summary

Two plural-form entries had empty `type="unfinished"` numerusforms on `en_US`. Since `en_US` is just the US-English variant of the source language, no translation is needed — filled with the natural singular/plural English forms and finalised.

| Source | Singular | Plural |
|---|---|---|
| `Found %n match(es)` | `Found %n match` | `Found %n matches` |
| `in %n entr(ies).` | `in %n entry.` | `in %n entries.` |

## Test plan

- [x] `lrelease6` → 196 finished + 1 unfinished, 107 ignored. The 107 ignored are entries that legitimately fall back to the English source (en_US ≈ source language).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed English singular/plural translations for status/result messages that report counts (matches and entries), ensuring grammatically correct singular and plural wording when displaying numeric counts—improves clarity and readability of count notifications across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->