### PR TITLE
i18n(he): fill empty plural forms with best-effort Hebrew

### DIFF
--- a/localization/localization_he.ts
+++ b/localization/localization_he.ts
@@ -1122,16 +1122,16 @@ You will not be able to decrypt any newly added passwords!</source>
         <location filename="../src/mainwindow.cpp" line="934"/>
         <source>Found %n match(es)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+            <numerusform>נמצאה %n התאמה</numerusform>
+            <numerusform>נמצאו %n התאמות</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/mainwindow.cpp" line="935"/>
         <source>in %n entr(ies).</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+            <numerusform>ב-%n רשומה.</numerusform>
+            <numerusform>ב-%n רשומות.</numerusform>
         </translation>
     </message>
     <message>


### PR DESCRIPTION
## Summary

Two plural-form entries had empty `type="unfinished"` numerusforms on `he`. Filled with best-effort Hebrew (singular + plural forms) and kept `type="unfinished"` for Weblate native review.

| Source | Singular | Plural |
|---|---|---|
| `Found %n match(es)` | `נמצאה %n התאמה` | `נמצאו %n התאמות` |
| `in %n entr(ies).` | `ב-%n רשומה.` | `ב-%n רשומות.` |

`%n` placeholder preserved on all four numerusforms.

## Test plan

- [x] `%n` preserved in all forms.
- [x] `lrelease6` → 33 finished + 9 unfinished (existing 5 unfinished entries + 4 new plural forms).
- [ ] CI green.
- [ ] Weblate native reviewer finalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Hebrew language translations for search result messages, adding proper singular and plural forms to ensure accurate and grammatically correct interface text for Hebrew-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->