### PR TITLE
i18n(ru): fill empty plural forms with best-effort Russian

### DIFF
--- a/localization/localization_ru.ts
+++ b/localization/localization_ru.ts
@@ -1226,9 +1226,9 @@ Expire-Date: 0
         <location filename="../src/mainwindow.cpp" line="934"/>
         <source>Found %n match(es)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+            <numerusform>Найдено %n совпадение</numerusform>
+            <numerusform>Найдено %n совпадения</numerusform>
+            <numerusform>Найдено %n совпадений</numerusform>
         </translation>
     </message>
     <message>
@@ -1429,9 +1429,9 @@ Expire-Date: 0
         <location filename="../src/mainwindow.cpp" line="935"/>
         <source>in %n entr(ies).</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+            <numerusform>в %n записи.</numerusform>
+            <numerusform>в %n записях.</numerusform>
+            <numerusform>в %n записях.</numerusform>
         </translation>
     </message>
     <message>


### PR DESCRIPTION
## Summary

Two plural-form entries had empty `type="unfinished"` numerusforms on `ru`. Russian has 3 plural categories (one / few / many), so each entry needed three filled forms. Filled with best-effort Russian and kept `type="unfinished"` for Weblate native review.

**Found %n match(es):**

| Form | Translation |
|---|---|
| one (1) | `Найдено %n совпадение` |
| few (2-4) | `Найдено %n совпадения` |
| many (5+, 0) | `Найдено %n совпадений` |

**in %n entr(ies).:**

| Form | Translation |
|---|---|
| one (1) | `в %n записи.` |
| few (2-4) | `в %n записях.` |
| many (5+, 0) | `в %n записях.` |

`%n` placeholder preserved on all six numerusforms.

## Test plan

- [x] `%n` preserved in all forms.
- [x] `lrelease6` → 214 finished + 2 unfinished.
- [ ] CI green.
- [ ] Weblate native reviewer finalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed Russian language translations for search result status messages, adding proper plural forms for "found matches" and "entries" strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->