### PR TITLE
i18n(bg): extend password charset to include both ASCII and Cyrillic

### DIFF
--- a/localization/localization_bg.ts
+++ b/localization/localization_bg.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЮЯабвгдежзийклмнопрстуфхцчшщъьюя0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЬЮЯабвгдежзийклмнопрстуфхцчшщъьюя0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>


### PR DESCRIPTION
## Summary

Bulgarian had its password-generator default charset *replacing* ASCII A-Z/a-z with Cyrillic, instead of *extending* it. So a Bulgarian-locale user's generated passwords would look like `Шж9РБлъ` instead of `Mz9PBlu` — unusable on:

- Most websites (ASCII-only password fields)
- Non-Cyrillic keyboards
- Sites/APIs that don't expect non-ASCII in passwords

Restored ASCII, kept Cyrillic as an extension (consistent with how `ca` / `da` / `fi` / `nb` *extend* with their locale-specific letters rather than replacing).

Also fixed a typo: the previous string had 29 Cyrillic uppercase letters but 30 lowercase (missing `Ь` in uppercase). New string has the full 30-letter Bulgarian alphabet in both cases.

| Slice | Pre | Post |
|---|---:|---:|
| ASCII upper | 0 | 26 |
| ASCII lower | 0 | 26 |
| Cyrillic upper | 29 (incomplete) | 30 (full) |
| Cyrillic lower | 30 | 30 |
| Digits | 10 | 10 |
| **Total** | **69** | **122** |

## Test plan

- [x] `lrelease6` → 303 finished + 1 unfinished.
- [ ] CI green.
- [ ] Weblate native reviewer finalises.

## Follow-up

Could open similar enhancement PRs for other locales whose users have additional native letters on their keyboards (de, es, fr, pt, pl, cs, sk, ru, uk, el, tr, etc.) — but those would extend behaviour, not fix a bug. Worth a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Bulgarian language translations for configuration dialogs have been updated with refinements to character-set and alphabetic sequence representations. These updated translations now appear throughout the application's entire configuration interface, providing Bulgarian-speaking users with enhanced localized text for character-set specifications, keyboard layouts, alphabets, and related configuration dialog content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->