### PR TITLE
i18n: extend password charset for 29 locales (3 commits)

### DIFF
--- a/localization/localization_cs.ts
+++ b/localization/localization_cs.ts
@@ -71,7 +71,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽabcdefghijklmnopqrstuvwxyzáčďéěíňóřšťúůýž0123456789</translation>
     </message>
     <message>
         <source>Use pwgen</source>

--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -261,7 +261,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜßabcdefghijklmnopqrstuvwxyzäöü0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>

--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -261,7 +261,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜßabcdefghijklmnopqrstuvwxyzäöü0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>

--- a/localization/localization_el.ts
+++ b/localization/localization_el.ts
@@ -122,7 +122,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩabcdefghijklmnopqrstuvwxyzαβγδεζηθικλμνξοπρστυφχψω0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_es_AR.ts
+++ b/localization/localization_es_AR.ts
@@ -275,7 +275,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÑabcdefghijklmnopqrstuvwxyzñ0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>

--- a/localization/localization_es_EC.ts
+++ b/localization/localization_es_EC.ts
@@ -275,7 +275,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÑabcdefghijklmnopqrstuvwxyzñ0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>

--- a/localization/localization_es_ES.ts
+++ b/localization/localization_es_ES.ts
@@ -275,7 +275,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÑabcdefghijklmnopqrstuvwxyzñ0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>

--- a/localization/localization_es_MX.ts
+++ b/localization/localization_es_MX.ts
@@ -275,7 +275,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÑabcdefghijklmnopqrstuvwxyzñ0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>

--- a/localization/localization_es_UY.ts
+++ b/localization/localization_es_UY.ts
@@ -275,7 +275,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÑabcdefghijklmnopqrstuvwxyzñ0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="450"/>

--- a/localization/localization_et.ts
+++ b/localization/localization_et.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZŠŽÄÖÕÜabcdefghijklmnopqrstuvwxyzšžäöõü0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -91,7 +91,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÀÂÇÉÈÊËÎÏÔÙÛÜabcdefghijklmnopqrstuvwxyzàâçéèêëîïôùûü0123456789</translation>
     </message>
     <message>
         <source>Use pwgen</source>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -91,7 +91,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÀÂÇÉÈÊËÎÏÔÙÛÜabcdefghijklmnopqrstuvwxyzàâçéèêëîïôùûü0123456789</translation>
     </message>
     <message>
         <source>Use pwgen</source>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -91,7 +91,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÀÂÇÉÈÊËÎÏÔÙÛÜabcdefghijklmnopqrstuvwxyzàâçéèêëîïôùûü0123456789</translation>
     </message>
     <message>
         <source>Use pwgen</source>

--- a/localization/localization_hr.ts
+++ b/localization/localization_hr.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZČĆĐŠŽabcdefghijklmnopqrstuvwxyzčćđšž0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_hu.ts
+++ b/localization/localization_hu.ts
@@ -136,7 +136,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÁÉÍÓÖŐÚÜŰabcdefghijklmnopqrstuvwxyzáéíóöőúüű0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_lt.ts
+++ b/localization/localization_lt.ts
@@ -122,7 +122,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZĄČĘĖĮŠŲŪŽabcdefghijklmnopqrstuvwxyząčęėįšųūž0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>

--- a/localization/localization_lv.ts
+++ b/localization/localization_lv.ts
@@ -122,7 +122,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZĀČĒĢĪĶĻŅŠŪŽabcdefghijklmnopqrstuvwxyzāčēģīķļņšūž0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>

--- a/localization/localization_pl.ts
+++ b/localization/localization_pl.ts
@@ -102,7 +102,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZĄĆĘŁŃÓŚŹŻabcdefghijklmnopqrstuvwxyząćęłńóśźż0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_pt_BR.ts
+++ b/localization/localization_pt_BR.ts
@@ -459,7 +459,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÁÂÃÇÉÊÍÓÔÕÚabcdefghijklmnopqrstuvwxyzáâãçéêíóôõú0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>

--- a/localization/localization_pt_PT.ts
+++ b/localization/localization_pt_PT.ts
@@ -459,7 +459,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÁÂÃÇÉÊÍÓÔÕÚabcdefghijklmnopqrstuvwxyzáâãçéêíóôõú0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="565"/>

--- a/localization/localization_ro.ts
+++ b/localization/localization_ro.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZĂÂÎȘȚabcdefghijklmnopqrstuvwxyzăâîșț0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_ru.ts
+++ b/localization/localization_ru.ts
@@ -236,7 +236,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯabcdefghijklmnopqrstuvwxyzабвгдеёжзийклмнопрстуфхцчшщъыьэюя0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>

--- a/localization/localization_sk.ts
+++ b/localization/localization_sk.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÁÄČĎÉÍĹĽŇÓÔŔŠŤÚÝŽabcdefghijklmnopqrstuvwxyzáäčďéíĺľňóôŕšťúýž0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_sl.ts
+++ b/localization/localization_sl.ts
@@ -122,7 +122,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZČŠŽabcdefghijklmnopqrstuvwxyzčšž0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>

--- a/localization/localization_sq.ts
+++ b/localization/localization_sq.ts
@@ -122,7 +122,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÇËabcdefghijklmnopqrstuvwxyzçë0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZАБВГДЂЕЖЗИЈКЛЉМНЊОПРСТЋУФХЦЧЏШabcdefghijklmnopqrstuvwxyzабвгдђежзијклљмнњопрстћуфхцчџш0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_sr_RS.ts
+++ b/localization/localization_sr_RS.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZČĆĐŠŽabcdefghijklmnopqrstuvwxyzčćđšž0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>

--- a/localization/localization_tr.ts
+++ b/localization/localization_tr.ts
@@ -122,7 +122,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZÇĞİÖŞÜabcdefghijklmnopqrstuvwxyzçğıöşü0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>

--- a/localization/localization_uk.ts
+++ b/localization/localization_uk.ts
@@ -126,7 +126,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="426"/>
         <source>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</source>
-        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</translation>
+        <translation type="unfinished">ABCDEFGHIJKLMNOPQRSTUVWXYZАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯabcdefghijklmnopqrstuvwxyzабвгґдеєжзиіїйклмнопрстуфхцчшщьюя0123456789</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="460"/>


### PR DESCRIPTION
## Summary

Extend the password generator's default character set with each locale's natively-typeable additional letters across 29 locales. Same **extend-don't-replace** principle as the existing `ca` / `da` / `fi` / `nb` extensions and the recently-fixed `bg` (#1403).

ASCII `A-Z`/`a-z` preserved everywhere → ASCII-only sites still work; users who want passwords with native characters now can; previously-stored passwords still validate.

All flagged `type="unfinished"` so Weblate native reviewers can adjust the letter selection per locale convention.

### Commit 1 — Germanic + Romance (12 locales)

| Locale | Added |
|---|---|
| de_DE, de_LU | `ÄÖÜß äöü` |
| es_AR, es_EC, es_ES, es_MX, es_UY | `Ñ ñ` |
| fr_BE, fr_FR, fr_LU | `ÀÂÇÉÈÊËÎÏÔÙÛÜ àâçéèêëîïôùûü` (skipped Œ/Æ/Ÿ — rare) |
| pt_BR, pt_PT | `ÁÂÃÇÉÊÍÓÔÕÚ áâãçéêíóôõú` |

### Commit 2 — Slavic Latin + other diacritic (13 locales)

| Locale | Added |
|---|---|
| pl | `ĄĆĘŁŃÓŚŹŻ ąćęłńóśźż` |
| cs | `ÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ áčďéěíňóřšťúůýž` |
| sk | `ÁÄČĎÉÍĹĽŇÓÔŔŠŤÚÝŽ áäčďéíĺľňóôŕšťúýž` |
| hr | `ČĆĐŠŽ čćđšž` |
| sr_RS (Latin) | `ČĆĐŠŽ čćđšž` |
| sl | `ČŠŽ čšž` |
| hu | `ÁÉÍÓÖŐÚÜŰ áéíóöőúüű` |
| ro | `ĂÂÎȘȚ ăâîșț` |
| sq | `ÇË çë` |
| tr | `ÇĞİÖŞÜ çğıöşü` (Turkish dotless `ı` distinct from ASCII `i`) |
| et | `ŠŽÄÖÕÜ šžäöõü` |
| lv | `ĀČĒĢĪĶĻŅŠŪŽ āčēģīķļņšūž` |
| lt | `ĄČĘĖĮŠŲŪŽ ąčęėįšųūž` |

### Commit 3 — Greek + Cyrillic (4 locales)

| Locale | Added |
|---|---|
| el | `ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ αβγδεζηθικλμνξοπρστυφχψω` (final sigma ς skipped) |
| ru | `АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ` (full Russian) |
| uk | `АБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯ` (Ukrainian-specific Ґ Є І Ї) |
| sr_Cyrl | `АБВГДЂЕЖЗИЈКЛЉМНЊОПРСТЋУФХЦЧЏШ` (Serbian Cyrillic-specific Ђ Ј Љ Њ Ћ Џ) |

Together with #1403 (`bg`), this covers all major Cyrillic-using locales.

## Test plan

- [x] All 29 locales had verbatim source pre-fix (no customisation clobbered).
- [x] `lrelease6` clean on all touched files.
- [x] All extensions preserve ASCII at the start (existing charset behaviour intact).
- [ ] CI green.
- [ ] Weblate native reviewers tune the letter selection per locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated password generator character sets across 26 language locales to include language-specific characters and diacritics, enabling users to generate passwords with culturally relevant characters for their region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->