### PR TITLE
i18n: round 9 reviewer findings (4 locales, 4 commits, 23 fixes)

### DIFF
--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -16,7 +16,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="72"/>
         <source>Clipboard behaviour:</source>
-        <translation>Clipboard behaviour:</translation>
+        <translation>Clipboard behavior:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="91"/>
@@ -41,7 +41,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="147"/>
         <source>Content panel behaviour:</source>
-        <translation>Content panel behaviour:</translation>
+        <translation>Content panel behavior:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="159"/>
@@ -194,7 +194,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation>Generate easy to memorise but less secure passwords</translation>
+        <translation>Generate easy to memorize but less secure passwords</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
@@ -242,7 +242,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="636"/>
         <source>Use TrayIcon</source>
-        <translation>Use Tray icon</translation>
+        <translation>Use TrayIcon</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="643"/>
@@ -1003,7 +1003,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="201"/>
         <source>This operation can take some minutes.&lt;br /&gt;We need to generate a lot of random bytes. It is a good idea to perform some other action (type on the keyboard, move the mouse, utilize the disks) during the prime generation; this gives the random number generator a better chance to gain enough entropy.</source>
-        <translation>This operation can take some minutes.&lt;br /&gt;We need to generate a lot of random bytes. It is a good idea to perform some other action (type on the keyboard, move the mouse, utilise the disks) during the prime generation; this gives the random number generator a better chance to gain enough entropy.</translation>
+        <translation>This operation can take some minutes.&lt;br /&gt;We need to generate a lot of random bytes. It is a good idea to perform some other action (type on the keyboard, move the mouse, utilize the disks) during the prime generation; this gives the random number generator a better chance to gain enough entropy.</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_he.ts
+++ b/localization/localization_he.ts
@@ -26,7 +26,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="98"/>
         <source>Autoclear after:</source>
-        <translation>אוטומטי לאחר:</translation>
+        <translation type="unfinished">ניקוי אוטומטי לאחר:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="115"/>
@@ -47,12 +47,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="166"/>
         <source>Hide password</source>
-        <translation>הסתר ססמא</translation>
+        <translation type="unfinished">הסתר סיסמה</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation>פאנל אוטומטי לאחר:</translation>
+        <translation type="unfinished">ניקוי אוטומטי של הפאנל לאחר:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
@@ -137,7 +137,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <source>Exclude capital letters</source>
-        <translation>אי-כלילת אותיות רישיות</translation>
+        <translation type="unfinished">אל תכלול אותיות רישיות</translation>
     </message>
     <message>
         <source>Include special symbols </source>
@@ -206,7 +206,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="650"/>
         <source>Hide on close</source>
-        <translation>הסתתר מקרוב</translation>
+        <translation type="unfinished">הסתר בעת סגירה</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="657"/>

--- a/localization/localization_he.ts
+++ b/localization/localization_he.ts
@@ -52,7 +52,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation type="unfinished">ניקוי אוטומטי של הפאנל לאחר:</translation>
+        <translation>ניקוי אוטומטי של הלוח לאחר:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>

--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -1009,7 +1009,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.ui" line="420"/>
         <source>Ctrl+G</source>
-        <translation type="unfinished">Ctrl+G</translation>
+        <translation>Ctrl+G</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="425"/>

--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -865,7 +865,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation type="unfinished">ਨਾਮ ਦੀ ਕਦਮੀ 5 ਅੱਖਰਾਂ ਤੋਂ ਵੱਧ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ।</translation>
+        <translation>ਨਾਮ ਦੀ ਕਦਮੀ ਘੱਟੋ-ਘੱਟ 5 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>

--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -142,7 +142,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="467"/>
         <source>Generate easy to memorize but less secure passwords</source>
-        <translation type="unfinished">ਗੁੱਝ ਯਾਦ ਰੱਖਣ ਵਾਲੇ ਪਰ ਘੱਟ ਸੁਰੱਖਿਅਤ ਪੈਸਵਰਡ ਪੈਦਾ ਕਰੋ</translation>
+        <translation type="unfinished">ਆਸਾਨ ਯਾਦ ਰੱਖਣ ਵਾਲੇ ਪਰ ਘੱਟ ਸੁਰੱਖਿਅਤ ਪੈਸਵਰਡ ਪੈਦਾ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="474"/>
@@ -247,7 +247,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <source>Native</source>
-        <translation>ਨੇਤਿਵ</translation>
+        <translation type="unfinished">ਮੂਲ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
@@ -545,7 +545,7 @@ URL
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="52"/>
         <source>Copy to Clipboard</source>
-        <translation type="unfinished">ਕਾਪੀ ਕਰੋ ਕਲਿੱਪਬੋਰਡ</translation>
+        <translation type="unfinished">ਕਲਿੱਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/exportpublickeydialog.ui" line="59"/>
@@ -865,12 +865,12 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation>ਨਾਮ ਦੀ ਕਦਮੀ 5 ਚਰਕਿਆਂ ਤੋਂ ਵੱਧ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ।</translation>
+        <translation type="unfinished">ਨਾਮ ਦੀ ਕਦਮੀ 5 ਅੱਖਰਾਂ ਤੋਂ ਵੱਧ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ।</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>
         <source>Invalid email</source>
-        <translation>ਬੈਲੰਡ ਇਮੇਲ</translation>
+        <translation type="unfinished">ਗਲਤ ਈਮੇਲ</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="181"/>
@@ -1009,7 +1009,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.ui" line="420"/>
         <source>Ctrl+G</source>
-        <translation>^C+G</translation>
+        <translation type="unfinished">Ctrl+G</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="425"/>
@@ -1045,7 +1045,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.ui" line="449"/>
         <source>Config</source>
-        <translation>ਕਾਨੂੰਨ</translation>
+        <translation type="unfinished">ਸੰਰਚਨਾ</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="452"/>
@@ -1060,7 +1060,7 @@ You will not be able to change the user list!</source>
     <message>
         <location filename="../src/mainwindow.cpp" line="322"/>
         <source>Clear</source>
-        <translation>ਅਣਡੋਲਤਾ</translation>
+        <translation type="unfinished">ਸਾਫ਼ ਕਰੋ</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="323"/>

--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -534,7 +534,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="505"/>
         <source>Use Git</source>
-        <translation type="unfinished">கிட்டைப் பயன்படுத்தவும்</translation>
+        <translation>கிட்டைப் பயன்படுத்தவும்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
@@ -554,7 +554,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.ui" line="746"/>
         <source>Git</source>
-        <translation type="unfinished">கிட்</translation>
+        <translation>கிட்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="756"/>
@@ -1082,12 +1082,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>
         <source>Git push</source>
-        <translation type="unfinished">கிட் புஷ்</translation>
+        <translation>கிட் புஷ்</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="436"/>
         <source>Git pull</source>
-        <translation type="unfinished">கிட் இழுத்தல்</translation>
+        <translation>கிட் இழுத்தல்</translation>
     </message>
     <message>
         <source>git pull</source>
@@ -1803,7 +1803,7 @@ Continue?</source>
     <message>
         <location filename="../src/qtpass.cpp" line="306"/>
         <source>GPG key pair generation failed</source>
-        <translation type="unfinished">GPG விசை ஜோடி உருவாக்கம் தோல்வியடைந்தது</translation>
+        <translation>GPG விசை ஜோடி உருவாக்கம் தோல்வியடைந்தது</translation>
     </message>
     <message>
         <location filename="../src/qtpass.cpp" line="380"/>


### PR DESCRIPTION
## Summary

Combined PR for round-9 reviewer findings across 4 locales. One commit per locale.

### Commit 1 — `i18n(ta): finalize 5 reviewer-signed-off Git/GPG fixes`

Two-pass agreement on translations from #1394. ta returns to **304 finished / 0 unfinished / 0 empty**.

### Commit 2 — `i18n(en_US): use American spellings`

en_US should override British spellings. Sources stay British (project-wide policy).

| Translation | Was | Now |
|---|---|---|
| `Clipboard behaviour:` | British | `Clipboard behavior:` |
| `Content panel behaviour:` | British | `Content panel behavior:` |
| `…memorise…` | British | `…memorize…` |
| `Use Tray icon` | wrong capitalisation | `Use TrayIcon` |
| `…utilise…` | British | `…utilize…` |

### Commit 3 — `i18n(he): fix 5 reviewer-flagged mistranslations`

Notable goofs:

- `Autoclear after:` → `אוטומטי לאחר:` (= "automatic after:" — the **clear** action was missing!)
- `Hide on close` → `הסתתר מקרוב` (≈ "**hide-yourself from up close**" — wrong reflexive verb)
- `Hide password` → `ססמא` (archaic spelling) → `סיסמה`
- + `Autoclear panel after:` and `Exclude capital letters` cleanups.

### Commit 4 — `i18n(pa_IN): fix 8 reviewer-flagged mistranslations (round 9)`

| Source | Old | Fix |
|---|---|---|
| `…easy to memorize…` | started with `ਗੁੱਝ` (non-word) | starts with `ਆਸਾਨ` |
| `Copy to Clipboard` | `ਕਾਪੀ ਕਰੋ ਕਲਿੱਪਬੋਰਡ` (Eng word order) | `ਕਲਿੱਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕਰੋ` |
| `Invalid email` | `ਬੈਲੰਡ ਇਮੇਲ` (`ਬੈਲੰਡ` not a word) | `ਗਲਤ ਈਮੇਲ` |
| **`Ctrl+G`** | **`^C+G`** — broken shortcut! | `Ctrl+G` |
| `Native` | `ਨੇਤਿਵ` (transliteration) | `ਮੂਲ` |
| `Name must be at least 5 characters long.` | typo `ਚਰਕਿਆਂ` | `ਅੱਖਰਾਂ` |
| `Config` | `ਕਾਨੂੰਨ` = "**law**"! | `ਸੰਰਚਨਾ` |
| `Clear` | `ਅਣਡੋਲਤਾ` (non-coherent) | `ਸਾਫ਼ ਕਰੋ` |

**`Ctrl+G` → `^C+G` is the most concerning** — keyboard shortcut would have completely failed in pa_IN locale (Qt expects the source string verbatim for accelerator binding). Functional UI bug, not just wrong word.

**Pushed back:** the reviewer also suggested changing `.gpg-id ਫਾਈਲ ਦੇ ਦਸਤਖਤ ਦੀ ਜਾਂਚ ਕਰੋ!` → `…ਸਿਗਨੇਚਰ ਜਾਂਚੋ!`. Skipped — current uses proper Punjabi `ਦਸਤਖਤ` (= "signature"), reviewer wanted the transliterated `ਸਿਗਨੇਚਰ`. Keeping the better translation.

## Test plan

- [x] All findings verified against current main before applying.
- [x] `lrelease6` clean on all four files.
- [x] ta back to 304 finished.
- [ ] CI green.
- [ ] Weblate native reviewers finalise the unfinished entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Standardized English UI text to US spellings and refined a tray label
  * Updated Hebrew translations for several configuration dialog options (some entries marked as unfinished)
  * Revised Punjabi translations with clearer wording, validation phrasing, and several unfinished entries updated
  * Completed several Tamil Git/GPG-related translations by removing unfinished markers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->