### PR TITLE
i18n: round 10 audit findings (4 locales, 4 commits)

### DIFF
--- a/localization/localization_gl.ts
+++ b/localization/localization_gl.ts
@@ -1000,7 +1000,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation>O nome debe ter máis de 4 caracteres.</translation>
+        <translation type="unfinished">O nome debe ter polo menos 5 caracteres.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>

--- a/localization/localization_gl.ts
+++ b/localization/localization_gl.ts
@@ -1000,7 +1000,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation type="unfinished">O nome debe ter polo menos 5 caracteres.</translation>
+        <translation>O nome debe ter polo menos 5 caracteres.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>

--- a/localization/localization_nb.ts
+++ b/localization/localization_nb.ts
@@ -901,7 +901,7 @@ Utløpsdato: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation>Navn må være mer enn 5 tegn.</translation>
+        <translation type="unfinished">Navnet må ha minst 5 tegn.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>

--- a/localization/localization_nb.ts
+++ b/localization/localization_nb.ts
@@ -901,7 +901,7 @@ Utløpsdato: 0
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation type="unfinished">Navnet må ha minst 5 tegn.</translation>
+        <translation>Navnet må ha minst 5 tegn.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>

--- a/localization/localization_si.ts
+++ b/localization/localization_si.ts
@@ -925,7 +925,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/keygendialog.cpp" line="169"/>
         <source>Name must be at least 5 characters long.</source>
-        <translation>සමඟ්‍යන්තර විශාලයක් කොටස් සහ හෝ ඉතිහාසයක් විශාලයක් සමඟ්‍යන්තර විශාලයක් කොටස් නැව්ද.</translation>
+        <translation type="unfinished">නම අවම වශයෙන් අක්ෂර 5ක් දිගු විය යුතුය.</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.cpp" line="180"/>

--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -1062,7 +1062,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="385"/>
         <source>Ctrl+N</source>
-        <translation>Ctrl+n</translation>
+        <translation type="unfinished">Ctrl+N</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="414"/>
@@ -1077,7 +1077,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.ui" line="420"/>
         <source>Ctrl+G</source>
-        <translation>Ctrl+g</translation>
+        <translation type="unfinished">Ctrl+G</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="428"/>


### PR DESCRIPTION
## Summary

Proactive audit sweep — found 4 issues across 4 locales by checking keyboard accelerators and "at least N" patterns.

### Commit 1 — `i18n(ta): fix Ctrl shortcut letter case`

`Ctrl+G` and `Ctrl+N` were translated with lowercase letter (`Ctrl+g` / `Ctrl+n`). Qt's QKeySequence is case-insensitive for letter matching so binding still works, but menu label rendering looks inconsistent. Restored uppercase.

Sibling to the recent pa_IN `Ctrl+G → ^C+G` fix (#1405) — same class of "translator touched a string they shouldn't have", less severe.

### Commit 2 — `i18n(nb): fix off-by-one in name-length validation`

`Navn må være **mer enn** 5 tegn.` (= "more than 5") → `Navnet må ha **minst** 5 tegn.` (= "at least 5"). Real semantic bug — "more than 5" rejects 5-char names; source is "at least 5".

Same family as the off-by-one I introduced in pa_IN that CodeRabbit caught in #1405.

### Commit 3 — `i18n(gl): rephrase name-length to match source structure`

`O nome debe ter **máis de 4** caracteres.` (= "more than 4") → `O nome debe ter **polo menos 5** caracteres.` (= "at least 5"). Mathematically equivalent but confusing — source mentions 5, translation mentions 4.

### Commit 4 — `i18n(si): replace gibberish name-length translation`

Was: `සමඟ්‍යන්තර විශාලයක් කොටස් සහ හෝ ඉතිහාසයක් විශාලයක් සමඟ්‍යන්තර විශාලයක් කොටස් නැව්ද.`

≈ "together-internal big parts and or history big together-internal big parts not-yet-no" — Sinhala syllables that don't form a coherent sentence; the phrase "සමඟ්‍යන්තර විශාලයක් කොටස්" repeats twice (classic MT repetition glitch).

Fixed: `නම අවම වශයෙන් අක්ෂර 5ක් දිගු විය යුතුය.` (= proper "Name must be at least 5 characters long.").

## Test plan

- [x] All 4 verified on current main before applying.
- [x] `lrelease6` clean on all 4 files.
- [x] de_DE / de_LU's `Ctrl+G → Strg+G` left alone — intentional German convention (Strg = Steuerung; Qt handles localized parsing).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated Galician and Norwegian wording to state "at least 5 characters" for name-length validation.
  * Replaced Sinhala validation text with a shorter, clearer translation (marked as unfinished).
  * Restored Tamil shortcut labels to match original casing (marked as unfinished).
  * Improved overall translation clarity for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->