### PR TITLE
i18n(pl): fix 4 Polish typo / diacritic entries

### DIFF
--- a/localization/localization_pl.ts
+++ b/localization/localization_pl.ts
@@ -418,7 +418,7 @@
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;gpg&lt;/strong&gt; using your favorite package manager&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation>Zainstaluj GnuPG na swoim systemie.&lt;br&gt;Zainstaluj &lt;strong&gt;gpg&lt;/strong&gt; używając twojego ulubionego menedżera proramów&lt;br&gt;lub &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;zainstaluj&lt;/a&gt; z GnuPG.org</translation>
+        <translation type="unfinished">Zainstaluj GnuPG na swoim systemie.&lt;br&gt;Zainstaluj &lt;strong&gt;gpg&lt;/strong&gt; używając twojego ulubionego menedżera programów&lt;br&gt;lub &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;zainstaluj&lt;/a&gt; z GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="979"/>
@@ -479,7 +479,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="574"/>
         <source>Use QRencode</source>
-        <translation>Uzyj QRencode</translation>
+        <translation type="unfinished">Użyj QRencode</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="588"/>
@@ -810,12 +810,12 @@ Nie będziesz w stanie rozszyfrować żadnych nowych haseł!</translation>
     <message>
         <location filename="../src/keygendialog.ui" line="14"/>
         <source>Generate GnuPG keypair</source>
-        <translation>Generuj pare kluczy GnuPG</translation>
+        <translation type="unfinished">Generuj parę kluczy GnuPG</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="42"/>
         <source>Generate a new key pair</source>
-        <translation>Generuj nową pare kluczy</translation>
+        <translation type="unfinished">Generuj nową parę kluczy</translation>
     </message>
     <message>
         <location filename="../src/keygendialog.ui" line="91"/>


### PR DESCRIPTION
## Summary

Four Polish entries had clear typos / missing diacritics. No semantic changes, just orthography.

| Source | Old | Issue | Fix |
|---|---|---|---|
| install hint | `proramów` | missing 'g' | `programów` |
| `Use QRencode` | `Uzyj QRencode` | missing ż diacritic | `Użyj QRencode` |
| `Generate GnuPG keypair` | `Generuj pare kluczy GnuPG` | missing ę diacritic | `Generuj parę kluczy GnuPG` |
| `Generate a new key pair` | `Generuj nową pare kluczy` | missing ę diacritic | `Generuj nową parę kluczy` |

Marked `type="unfinished"` per project convention so Weblate native review can confirm the forms before finalising.

## Test plan

- [x] All 4 verified on current main.
- [x] `lrelease6` → 300 finished + 4 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Polish translations with corrected grammar and diacritics for UI strings, including GnuPG installation messages and key generation labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->