### PR TITLE
i18n(sr_Cyrl): fix 5 reviewer-flagged typos / spelling errors

### DIFF
--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -61,7 +61,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
         <source>Use a monospace font</source>
-        <translation>Корисити фонт исте ширине</translation>
+        <translation type="unfinished">Користити фонт исте ширине</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="231"/>
@@ -131,7 +131,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="460"/>
         <source>Include special symbols</source>
-        <translation>Укључи специјанле симболе</translation>
+        <translation type="unfinished">Укључи специјалне симболе</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="599"/>
@@ -354,7 +354,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1058"/>
         <source>Use template</source>
-        <translation>Користе шаблон</translation>
+        <translation type="unfinished">Користи шаблон</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1065"/>
@@ -514,7 +514,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="100"/>
         <source>qrencode needs to be installed</source>
-        <translation>Треба да се уставе qrencode</translation>
+        <translation type="unfinished">Треба да се инсталира qrencode</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="914"/>
@@ -652,7 +652,7 @@ URL
         <location filename="../src/imitatepass.cpp" line="320"/>
         <location filename="../src/imitatepass.cpp" line="506"/>
         <source>Signature for %1 is invalid.</source>
-        <translation>Постпис за %1 није исправан.</translation>
+        <translation type="unfinished">Потпис за %1 није исправан.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="149"/>


### PR DESCRIPTION
## Summary

Five Serbian Cyrillic spelling fixes. Mostly simple typos; one is a wrong-direction verb.

| Source | Old | Issue | Fix |
|---|---|---|---|
| `Use a monospace font` | `Корисити` | missing 'т' | `Користити` |
| `Include special symbols` | `специјанле` | letter swap | `специјалне` |
| `Use template` | `Користе шаблон` | wrong conjugation ("they use") | `Користи шаблон` (imperative) |
| `qrencode needs to be installed` | `Треба да се **уставе**` | "уставе" ≈ "halt/stop" — opposite-direction verb! Error message read as "qrencode needs to be **stopped**" | `Треба да се инсталира` |
| `Signature for %1 is invalid.` | `Постпис за %1` | "Постпис" non-word (letter swap) | `Потпис за %1` |

The "уставе" goof joins the family of opposite-direction verb mistakes — same pattern as Tamil's "Re-encrypt" → "remove" and Sinhala's "Generate GPG key pair" → "Remove containing GPG actions".

## Test plan

- [x] All 5 verified `[FIN]` on current main before applying.
- [x] `%1` preserved on the Signature entry.
- [x] `lrelease6` → 299 finished + 5 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Serbian Cyrillic translations across multiple user interface dialogs and messages, including updates to settings options and validation alerts.
  * Corrected a spelling error in the signature validation message translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->