### PR TITLE
i18n(sr_Cyrl): apply 4 reviewer findings (skip vanished entry)

### DIFF
--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -56,7 +56,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation>Аутоочиштење панела након:</translation>
+        <translation type="unfinished">Аутоматско чишћење панела након:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
@@ -281,7 +281,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <source>Native</source>
-        <translation>Натив</translation>
+        <translation type="unfinished">Изворни</translation>
     </message>
     <message>
         <source>git</source>
@@ -326,7 +326,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
         <source>Path</source>
-        <translation>Пут</translation>
+        <translation type="unfinished">Путања</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="978"/>
@@ -980,7 +980,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.ui" line="14"/>
         <source>QtPass</source>
-        <translation>КтПас</translation>
+        <translation type="unfinished">QtPass</translation>
     </message>
     <message>
         <source>Add</source>


### PR DESCRIPTION
## Summary

Five reviewer findings; #1 is on a `type="vanished"` entry (no longer in code, not user-facing) — skipped. Applied the other 4.

| # | Source | Old | Issue | Fix |
|---|---|---|---|---|
| 1 | `Password Behaviour:` (vanished) | — | source no longer in code | **skipped** |
| 2 | `Autoclear panel after:` | `Аутоочиштење панела након:` | unclear compound word | `Аутоматско чишћење панела након:` (idiomatic; matches adjacent `Autoclear after:`) |
| 3 | `Native` | `Натив` | transliteration | `Изворни` (= "original/native"). Same family as recent pa_IN/id "Native" fixes |
| 4 | `Path` | `Пут` | ambiguous (also "road/way") | `Путања` (specifically file path; matches line 164) |
| 5 | `QtPass` | `КтПас` | brand name transliterated | `QtPass` (verbatim) |

## Test plan

- [x] All 5 verified on current main; #1 confirmed vanished and skipped.
- [x] `lrelease6` → 300 finished + 4 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved Serbian language support with comprehensive translation updates across the application. Changes include refined messaging for autoclear notifications, clarified labels for options and form fields, and adjusted application branding terminology. These updates enhance clarity and provide a better experience for Serbian-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->