### PR TITLE
i18n(sr_Cyrl): finalize 4 reviewer-signed-off translations from #1422

### DIFF
--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -56,7 +56,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="175"/>
         <source>Autoclear panel after:</source>
-        <translation type="unfinished">Аутоматско чишћење панела након:</translation>
+        <translation>Аутоматско чишћење панела након:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="224"/>
@@ -281,7 +281,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="740"/>
         <source>Native</source>
-        <translation type="unfinished">Изворни</translation>
+        <translation>Изворни</translation>
     </message>
     <message>
         <source>git</source>
@@ -326,7 +326,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="957"/>
         <source>Path</source>
-        <translation type="unfinished">Путања</translation>
+        <translation>Путања</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="978"/>
@@ -980,7 +980,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.ui" line="14"/>
         <source>QtPass</source>
-        <translation type="unfinished">QtPass</translation>
+        <translation>QtPass</translation>
     </message>
     <message>
         <source>Add</source>


### PR DESCRIPTION
## Summary

Pure finalisation — drop `type="unfinished"` on the 4 fixes from #1422 that CodeRabbit signed off on.

| Source | Translation |
|---|---|
| `Autoclear panel after:` | `Аутоматско чишћење панела након:` |
| `Native` | `Изворни` |
| `Path` | `Путања` |
| `QtPass` | `QtPass` (verbatim brand name) |

**sr_Cyrl back to 304 finished / 0 unfinished / 0 empty.**

## Test plan

- [x] All 4 verified `[UT]` on current main.
- [x] `lrelease6` → 304 finished, 0 unfinished, 0 ignored.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed Serbian language translations for UI elements including "Autoclear panel after", "Native", "Path", and application window title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->