### PR TITLE
i18n(sr_Cyrl): apply 5 reviewer findings (terminology consistency)

### DIFF
--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -171,7 +171,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="968"/>
         <source>Optional: GPG key to sign .gpg-id files for integrity verification. Leave empty unless you need to protect the user list from tampering.</source>
-        <translation>Опционо: Кључ GPG за потписивање фајлова са проширењем .gpg-id за верификацију интегритета. Оставите празно, осим ако вам није потребно да заштитите листу корисника од манипулације.</translation>
+        <translation type="unfinished">Опционо: Кључ GPG за потписивање датотека са проширењем .gpg-id за верификацију интегритета. Оставите празно, осим ако вам није потребно да заштитите листу корисника од манипулације.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1008"/>
@@ -443,7 +443,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="925"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;gpg&lt;/strong&gt; using your favorite package manager&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation>Молимо, поставите GnuPG на вашу рачунарску опрему.&lt;br&gt;Инсталирајте &lt;strong&gt;gpg&lt;/strong&gt; користећи свој избор пакета за управљање пакетима&lt;br&gt;или преузмите га са &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;GnuPG.org&lt;/a&gt;</translation>
+        <translation type="unfinished">Молимо, поставите GnuPG на вашу рачунарску опрему.&lt;br&gt;Инсталирајте &lt;strong&gt;gpg&lt;/strong&gt; користећи свој омиљени менаџер пакета&lt;br&gt;или преузмите га са &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;GnuPG.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="979"/>
@@ -474,7 +474,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1018"/>
         <source>The folder %1 doesn&apos;t seem to be a password store or is not yet initialised.</source>
-        <translation>Фајл %1 не изгледа као паролски архив или још увек није почео да ради.</translation>
+        <translation type="unfinished">Фасцикла %1 не изгледа као паролски архив или још увек није иницијализована.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1263"/>
@@ -664,7 +664,7 @@ URL
         <location filename="../src/imitatepass.cpp" line="150"/>
         <location filename="../src/imitatepass.cpp" line="599"/>
         <source>Could not read encryption key to use, .gpg-id file missing or invalid.</source>
-        <translation>Није могуће прочитати кључ за крипцију, .gpg-id датотека не постоји или није исправна.</translation>
+        <translation type="unfinished">Није могуће прочитати кључ за шифровање, .gpg-id датотека не постоји или није исправна.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="314"/>
@@ -752,7 +752,7 @@ You will not be able to decrypt any newly added passwords!</source>
     <message>
         <location filename="../src/imitatepass.cpp" line="729"/>
         <source>Re-encrypting from folder %1</source>
-        <translation>Поново се криптује из фасцикле %1</translation>
+        <translation type="unfinished">Поново се шифрује из фасцикле %1</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="732"/>


### PR DESCRIPTION
## Summary

Five reviewer findings, all about preferring native Serbian terms over Russian-influenced loanwords + one wrong-noun fix.

| # | Source | Old | Issue | Fix |
|---|---|---|---|---|
| 1 | Optional GPG-key tooltip | `…потписивање фајлова са…` | `фајл` is Russian loanword | `…потписивање датотека са…` (native Serbian) |
| 2 | install hint (gpg + package manager) | `…користећи свој избор пакета за управљање пакетима…` | clunky double `пакета` reference | `…користећи свој омиљени менаџер пакета…` (matches line 527) |
| 3 | `The folder %1 doesn't seem to be a password store…` | starts `Фајл` (= **File**, wrong noun) ends `почео да ради` (= "started working") | wrong word + awkward phrasing | starts `Фасцикла` (= folder), ends `иницијализована` (matches line 472) |
| 4 | `Could not read encryption key…` | `крипцију` (Russian-style loanword) | non-native Serbian | `шифровање` (native) |
| 5 | `Re-encrypting from folder %1` | `криптује` | same крипт→шифр normalisation | `шифрује` |

The encryption terminology fixes (#4, #5) are particularly worth landing — having two different Serbian words for the same crypto concept across one file would confuse users.

## Test plan

- [x] All 5 verified on current main.
- [x] `%1` placeholders preserved on #3 and #5.
- [x] `lrelease6` → 299 finished + 5 unfinished.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Serbian language translations for multiple UI messages, including error messages, installation instructions, and status text related to password management and encryption functionality. Some translations marked as unfinished pending further refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->