### PR TITLE
i18n(sr_Cyrl): clean up vanished entries (4 reviewer findings)

### DIFF
--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -35,10 +35,6 @@
         <translation>Секунде</translation>
     </message>
     <message>
-        <source>Password Behaviour:</source>
-        <translation type="vanished">Начин рада лозинке:</translation>
-    </message>
-    <message>
         <location filename="../src/configdialog.ui" line="147"/>
         <source>Content panel behaviour:</source>
         <translation>Начин рада панела садржаја:</translation>
@@ -221,10 +217,6 @@
         <location filename="../src/configdialog.ui" line="565"/>
         <source>Extensions:</source>
         <translation>Екстензије:</translation>
-    </message>
-    <message>
-        <source>Use pass otp extension</source>
-        <translation type="vanished">Користи pass otp екстензију</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="624"/>

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -232,7 +232,7 @@
     </message>
     <message>
         <source>Use pass otp extension</source>
-        <translation type="vanished">Use pass otp extension</translation>
+        <translation type="vanished">Користи pass otp екстензију</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="624"/>

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -207,10 +207,6 @@
         <translation>Гит:</translation>
     </message>
     <message>
-        <source>Use git</source>
-        <translation type="vanished">Use git</translation>
-    </message>
-    <message>
         <location filename="../src/configdialog.ui" line="519"/>
         <source>Automatically add .gpg-id files</source>
         <translation>Аутоматски додај .gpg-id датотеке</translation>

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -36,7 +36,7 @@
     </message>
     <message>
         <source>Password Behaviour:</source>
-        <translation type="vanished">Password Behaviour:</translation>
+        <translation type="vanished">Начин рада лозинке:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="147"/>

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -179,10 +179,6 @@
         <translation>Тренутна путања</translation>
     </message>
     <message>
-        <source>Use pwgen</source>
-        <translation type="vanished">Use pwgen</translation>
-    </message>
-    <message>
         <location filename="../src/configdialog.ui" line="450"/>
         <source>Exclude capital letters</source>
         <translation>Искључи велика слова</translation>


### PR DESCRIPTION
_This PR applies 4/4 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Serbian (Cyrillic) localization by removing obsolete translation entries and ensuring current UI strings have proper Serbian translations for a clearer, more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->