### PR TITLE
refactor(util): drop redundant check + add 3 missing doc blocks

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -172,7 +172,7 @@ auto Util::findBinaryInPath(const QString &binary) -> QString {
   if (ret.isEmpty()) {
     static const QRegularExpression whitespaceRegex(QStringLiteral("\\s"));
     const bool hasWhitespace = binary.contains(whitespaceRegex);
-    if (!binary.isEmpty() && !hasWhitespace) {
+    if (!hasWhitespace) {
       QString wslCommand = QStringLiteral("wsl ") + binary;
 #ifdef QT_DEBUG
       dbg() << "Util::findBinaryInPath(): falling back to WSL for binary"
@@ -265,6 +265,11 @@ auto Util::getDir(const QModelIndex &index, bool forPass,
   return filePath;
 }
 
+/**
+ * @brief Returns a regex matching strings that end with the .gpg extension.
+ *
+ * @return QRegularExpression reference
+ */
 auto Util::endsWithGpg() -> const QRegularExpression & {
   static const QRegularExpression expr{"\\.gpg$"};
   return expr;
@@ -288,11 +293,35 @@ auto Util::protocolRegex() -> const QRegularExpression & {
   return regex;
 }
 
+/**
+ * @brief Returns a regex matching newline characters (CR or LF).
+ *
+ * Useful for detecting or sanitising line breaks in text content.
+ *
+ * @return QRegularExpression reference
+ */
 auto Util::newLinesRegex() -> const QRegularExpression & {
   static const QRegularExpression regex{"[\r\n]"};
   return regex;
 }
 
+/**
+ * @brief Validate whether a string is an accepted GPG key identifier.
+ *
+ * Accepted formats:
+ * - Hexadecimal key IDs / fingerprints, length 8 to 40 hex characters,
+ *   optionally prefixed with `0x` or `0X`.
+ * - Identifiers wrapped in angle brackets (`<...>`); brackets are stripped
+ *   before validation.
+ * - Special routing prefixes: `@`, `/`, `#`, `&` (used by GnuPG to look up
+ *   keys via mail-server / keyring / fingerprint substring matchers).
+ * - Email-style user IDs (any value containing `@`).
+ *
+ * Empty input is invalid.
+ *
+ * @param keyId Input key identifier string to validate.
+ * @return true if the input matches any accepted format; false otherwise.
+ */
 auto Util::isValidKeyId(const QString &keyId) -> bool {
   static const QRegularExpression hexPrefixRegex{"^0[xX]"};
   static const QRegularExpression specialPrefixRegex{"^[@/#&]"};


### PR DESCRIPTION
## Summary

Four reviewer findings on `src/util.cpp`. All valid, all applied.

| # | Function | Change |
|---|---|---|
| 1 | `findBinaryInPath` | Dropped redundant `!binary.isEmpty() &&` guard in the WSL fallback branch (became redundant when the early-return at the top got brace-wrapped in #1433) |
| 2 | `endsWithGpg` | Added `@brief` doc block |
| 3 | `newLinesRegex` | Added `@brief` doc block (CR/LF coverage + sanitisation use case) |
| 4 | `isValidKeyId` | Added full doc block — all four accepted formats (hex IDs / angle-bracket-wrapped / GnuPG `@/#&` special prefixes / email-style) |

## Test plan

- [x] `tst_util` passes (106 of 106).
- [x] `doxygen Doxyfile` — no new warnings.
- [x] Build clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified path validation logic for improved efficiency.

* **Documentation**
  * Enhanced internal developer documentation for utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->