### PR TITLE
refactor: 6 reviewer cleanups in util.cpp + qtpass.cpp

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -40,13 +40,22 @@ QtPass::QtPass(MainWindow *mainWindow) : m_mainWindow(mainWindow) {
           &QtPass::clearClipboard);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #endif
   QObject::connect(qApp, &QApplication::aboutToQuit, this,
                    &QtPass::clearClipboard);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#elif defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 #endif
 
   setMainWindow();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -17,6 +17,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QHash>
 #include <QSaveFile>
 #include <QTextStream>
 #include <algorithm>
@@ -88,9 +89,10 @@ auto Util::findPasswordStore() -> QString {
   initialiseEnvironment();
   if (_env.contains("PASSWORD_STORE_DIR")) {
     path = _env.value("PASSWORD_STORE_DIR");
-    // Expand a leading "~" — env vars set in non-shell contexts (systemd
-    // units, .desktop entries, quoted shell assignments) skip the shell's
-    // tilde expansion, leaving "~" as a literal directory component.
+    // Expand current-user tilde forms ("~" and "~/...") — env vars set in
+    // non-shell contexts (systemd units, .desktop entries, quoted shell
+    // assignments) skip shell tilde expansion, leaving "~" literal.
+    // Note: "~username" forms are intentionally not resolved here.
     if (path == "~") {
       path = QDir::homePath();
     } else if (path.startsWith("~/")) {
@@ -145,7 +147,11 @@ auto Util::findBinaryInPath(const QString &binary) -> QString {
 
   if (_env.contains("PATH")) {
     QString path = _env.value("PATH");
-    const QChar delimiter = QDir::separator() == '\\' ? ';' : ':';
+#ifdef Q_OS_WIN
+    const QChar delimiter = ';';
+#else
+    const QChar delimiter = ':';
+#endif
     QStringList entries = path.split(delimiter);
 
     for (const QString &entryConst : entries) {
@@ -170,22 +176,35 @@ auto Util::findBinaryInPath(const QString &binary) -> QString {
   }
 #ifdef Q_OS_WIN
   if (ret.isEmpty()) {
-    static const QRegularExpression whitespaceRegex(QStringLiteral("\\s"));
-    const bool hasWhitespace = binary.contains(whitespaceRegex);
+    // Cache per-binary WSL lookup result — the wsl --version probe is a
+    // blocking subprocess that can run several times per session for
+    // missing binaries; once decided, the answer doesn't change at runtime.
+    static QHash<QString, QString> wslBinaryCache;
+    const bool hasWhitespace =
+        std::any_of(binary.cbegin(), binary.cend(),
+                    [](const QChar ch) { return ch.isSpace(); });
     if (!hasWhitespace) {
-      QString wslCommand = QStringLiteral("wsl ") + binary;
+      auto cached = wslBinaryCache.constFind(binary);
+      if (cached != wslBinaryCache.constEnd()) {
+        ret = cached.value();
+      } else {
+        QString wslCommand = QStringLiteral("wsl ") + binary;
 #ifdef QT_DEBUG
-      dbg() << "Util::findBinaryInPath(): falling back to WSL for binary"
-            << binary;
+        dbg() << "Util::findBinaryInPath(): falling back to WSL for binary"
+              << binary;
 #endif
-      QString out, err;
-      if (Executor::executeBlocking(wslCommand, {"--version"}, &out, &err) ==
-              0 &&
-          !out.isEmpty() && err.isEmpty()) {
+        QString out, err;
+        QString cachedResult;
+        if (Executor::executeBlocking(wslCommand, {"--version"}, &out, &err) ==
+                0 &&
+            !out.isEmpty() && err.isEmpty()) {
 #ifdef QT_DEBUG
-        dbg() << "Util::findBinaryInPath(): using WSL binary" << wslCommand;
+          dbg() << "Util::findBinaryInPath(): using WSL binary" << wslCommand;
 #endif
-        ret = wslCommand;
+          cachedResult = wslCommand;
+        }
+        wslBinaryCache.insert(binary, cachedResult);
+        ret = cachedResult;
       }
     }
   }
@@ -216,12 +235,17 @@ auto Util::configIsValid() -> bool {
                                  : QtPassSettings::getGpgExecutable();
 
   if (executable.startsWith(QStringLiteral("wsl "))) {
-    QString out;
-    QString err;
-    if (Executor::executeBlocking(QStringLiteral("wsl"),
-                                  {QStringLiteral("--version")}, &out,
-                                  &err) == 0 &&
-        !out.isEmpty() && err.isEmpty()) {
+    // Probe WSL once per session — availability doesn't change at runtime
+    // and the executeBlocking call is a blocking subprocess.
+    static const bool wslAvailable = []() {
+      QString out;
+      QString err;
+      return Executor::executeBlocking(QStringLiteral("wsl"),
+                                       {QStringLiteral("--version")}, &out,
+                                       &err) == 0 &&
+             !out.isEmpty() && err.isEmpty();
+    }();
+    if (wslAvailable) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary

Combined batch of reviewer findings across `src/util.cpp` (5) and `src/qtpass.cpp` (1). One reviewer finding skipped with reason.

### Applied — util.cpp

| # | Change | Why |
|---|---|---|
| 1 | Tilde comment notes "~username" intentionally unsupported | Documentation completeness |
| 2 | PATH delimiter: runtime check → `#ifdef Q_OS_WIN` | Compile-time intent is clearer |
| 3 | `findBinaryInPath` whitespace check: static `QRegularExpression` → `std::any_of` + `QChar::isSpace()` | Same Unicode coverage, no regex compile cost |
| 4 | `findBinaryInPath` WSL fallback: cache results in static `QHash<QString, QString>` | `wsl --version` is a blocking subprocess, was running once per call for any binary not on PATH |
| 5 | `configIsValid` WSL probe: wrap in lambda-initialised `static const bool` | Same caching pattern; WSL availability doesn't change at runtime |

### Applied — qtpass.cpp

| # | Change |
|---|---|
| 6 | `aboutToQuit` deprecation pragma now supports MSVC (`#pragma warning(push)` / `disable : 4996` / `pop`) alongside the existing GCC/clang block |

### Skipped

| Reviewer claim | Why skipped |
|---|---|
| `qtpass.cpp` calls `dwordBytes` but the helper is "not defined" → would cause Windows build failure | `dwordBytes` IS defined at `qtpass.h:29` as `static inline`, visible at every call site through the existing `#include "qtpass.h"`. No build error. |

## Test plan

- [x] `tst_util` passes (106 / 106).
- [x] `clang-tidy` 0 findings on touched files.
- [x] `clang-format --dry-run --Werror` clean.
- [x] Full build clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compiler deprecation warnings for Qt 6.0.0 and newer versions

* **Performance**
  * Optimized binary path lookups on Windows through improved caching mechanisms
  * Improved path resolution efficiency by reducing redundant system checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->