### PR TITLE
refactor(util): use raw-string literal for endsWithGpg regex

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -295,7 +295,7 @@ auto Util::getDir(const QModelIndex &index, bool forPass,
  * @return QRegularExpression reference
  */
 auto Util::endsWithGpg() -> const QRegularExpression & {
-  static const QRegularExpression expr{"\\.gpg$"};
+  static const QRegularExpression expr{R"(\.gpg$)"};
   return expr;
 }
 


### PR DESCRIPTION
## Summary

One real reviewer finding applied; three repeat-of-#1436 concurrency suggestions skipped with reason.

### Applied

| Source | Change |
|---|---|
| `endsWithGpg()` regex | `"\\.gpg$"` → `R"(\.gpg$)"` (raw string, fewer backslashes) |

### Skipped (all single-threaded-codebase / C++17-magic-statics arguments — same as #1436)

| Reviewer suggestion | Why skipped |
|---|---|
| Add `std::call_once` around `initialiseEnvironment` | No other concurrency primitives anywhere in the codebase; access is main-thread-only. |
| Add `QMutex` around `wslBinaryCache` in `findBinaryInPath` | Same — `findBinaryInPath` runs on the main thread; #1436 rejected the equivalent QReadWriteLock suggestion on the same grounds. |
| Static init of `wslAvailable` not thread-safe in C++03/98 | Project is C++17 (`qtpass.pri` sets `CONFIG += c++17`). C++11+ guarantees thread-safe "magic statics". |

## Test plan

- [x] `tst_util` passes (106 / 106).
- [x] Build clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code readability through internal refactoring with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->