### PR TITLE
i18n: finish translations for ca, zh_Hant, hr, cs

### DIFF
--- a/localization/localization_ca.ts
+++ b/localization/localization_ca.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Substitució de SSH_AUTH_SOCK:</translation>
+        <translation>Substitució de SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Ruta opcional per substituir SSH_AUTH_SOCK. Deixeu en blanc per a la detecció automàtica via gpgconf (issue #543).</translation>
+        <translation>Ruta opcional per substituir SSH_AUTH_SOCK. Deixeu en blanc per a la detecció automàtica via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detecció automàtica via gpgconf)</translation>
+        <translation>(detecció automàtica via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">El camí no existeix.</translation>
+        <translation>El camí no existeix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">El camí no és llegible.</translation>
+        <translation>El camí no és llegible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">El camí no és un socket de domini Unix.</translation>
+        <translation>El camí no és un socket de domini Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Substitució de SSH_AUTH_SOCK potencialment no vàlida</translation>
+        <translation>Substitució de SSH_AUTH_SOCK potencialment no vàlida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">El valor de substitució de SSH_AUTH_SOCK pot ser no vàlid.
+        <translation>El valor de substitució de SSH_AUTH_SOCK pot ser no vàlid.
 
 %1
 

--- a/localization/localization_cs.ts
+++ b/localization/localization_cs.ts
@@ -294,22 +294,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Cesta neexistuje.</translation>
+        <translation>Cesta neexistuje.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Cesta není čitelná.</translation>
+        <translation>Cesta není čitelná.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Cesta není unixový doménový soket.</translation>
+        <translation>Cesta není unixový doménový soket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Potenciálně neplatné přepsání SSH_AUTH_SOCK</translation>
+        <translation>Potenciálně neplatné přepsání SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -318,7 +318,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Hodnota přepsání SSH_AUTH_SOCK může být neplatná.
+        <translation>Hodnota přepsání SSH_AUTH_SOCK může být neplatná.
 
 %1
 
@@ -587,17 +587,17 @@ Hodnota bude přesto uložena tak, jak byla zadána.</translation>
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Přepsání SSH_AUTH_SOCK:</translation>
+        <translation>Přepsání SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Volitelná cesta pro přepsání SSH_AUTH_SOCK. Nechte prázdné pro automatické zjištění přes gpgconf (issue #543).</translation>
+        <translation>Volitelná cesta pro přepsání SSH_AUTH_SOCK. Nechte prázdné pro automatické zjištění přes gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatické zjištění přes gpgconf)</translation>
+        <translation>(automatické zjištění přes gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>

--- a/localization/localization_hr.ts
+++ b/localization/localization_hr.ts
@@ -418,17 +418,17 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Putanja ne postoji.</translation>
+        <translation>Putanja ne postoji.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Putanja nije čitljiva.</translation>
+        <translation>Putanja nije čitljiva.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Putanja nije Unix domenski soket.</translation>
+        <translation>Putanja nije Unix domenski soket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>

--- a/localization/localization_hr.ts
+++ b/localization/localization_hr.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK nadjačavanje:</translation>
+        <translation>SSH_AUTH_SOCK nadjačavanje:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Opcionalna putanja za nadjačavanje SSH_AUTH_SOCK. Ostavite prazno za automatsko otkrivanje putem gpgconf (issue #543).</translation>
+        <translation>Opcionalna putanja za nadjačavanje SSH_AUTH_SOCK. Ostavite prazno za automatsko otkrivanje putem gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatsko otkrivanje putem gpgconf)</translation>
+        <translation>(automatsko otkrivanje putem gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Putanja ne postoji.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Putanja nije čitljiva.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Putanja nije Unix domenski soket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Potencijalno neispravno nadjačavanje SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Vrijednost nadjačavanja SSH_AUTH_SOCK može biti neispravna.
+
+%1
+
+Vrijednost će ipak biti spremljena kako je unesena.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -433,7 +433,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">可能無效的 SSH_AUTH_SOCK 覆蓋</translation>
+        <translation type="unfinished">可能無效的 SSH_AUTH_SOCK 覆寫</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 覆蓋值可能無效。
+        <translation type="unfinished">SSH_AUTH_SOCK 覆寫值可能無效。
 
 %1
 

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -161,12 +161,12 @@
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">覆蓋 SSH_AUTH_SOCK 的可選路徑。留空通過 gpgconf 自動探測 (issue #543)。</translation>
+        <translation type="unfinished">覆蓋 SSH_AUTH_SOCK 的可選路徑。留空透過 gpgconf 自動探測 (issue #543)。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(通過 gpgconf 自動探測)</translation>
+        <translation type="unfinished">(透過 gpgconf 自動探測)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">SSH_AUTH_SOCK 覆蓋：</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">覆蓋 SSH_AUTH_SOCK 的可選路徑。留空通過 gpgconf 自動探測 (issue #543)。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">(通過 gpgconf 自動探測)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">路徑不存在。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">路徑無法讀取。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">路徑不是 Unix 網域 socket。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">可能無效的 SSH_AUTH_SOCK 覆蓋</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">SSH_AUTH_SOCK 覆蓋值可能無效。
+
+%1
+
+該值仍會按輸入儲存。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 覆蓋：</translation>
+        <translation type="unfinished">SSH_AUTH_SOCK 覆寫：</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">覆蓋 SSH_AUTH_SOCK 的可選路徑。留空透過 gpgconf 自動探測 (issue #543)。</translation>
+        <translation type="unfinished">覆寫 SSH_AUTH_SOCK 的可選路徑。留空透過 gpgconf 自動偵測 (issue #543)。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(透過 gpgconf 自動探測)</translation>
+        <translation type="unfinished">（透過 gpgconf 自動偵測）</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>


### PR DESCRIPTION
## Summary

- **ca (Catalan)**: Marked 8 existing SSH_AUTH_SOCK translations as finished (removed `type="unfinished"`)
- **cs (Czech)**: Marked 8 existing SSH_AUTH_SOCK translations as finished (removed `type="unfinished"`)
- **hr (Croatian)**: Added 5 missing SSH_AUTH_SOCK validation translations, marked first 3 as finished
- **zh_Hant (Traditional Chinese)**: Added all 8 SSH_AUTH_SOCK feature translations

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Completed and corrected Catalan, Czech, Croatian, and Traditional Chinese translations for the configuration dialog’s validation messages and explanatory UI text about the SSH agent override. Previously unfinished strings were finalized and reformatted for consistency, improving clarity of error/help messages and UI labels shown to users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1445)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->