### PR TITLE
i18n: finish translations for de, fr, it, es variants

### DIFF
--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -421,22 +421,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Der Pfad existiert nicht.</translation>
+        <translation>Der Pfad existiert nicht.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Der Pfad ist nicht lesbar.</translation>
+        <translation>Der Pfad ist nicht lesbar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Der Pfad ist kein Unix-Domain-Socket.</translation>
+        <translation>Der Pfad ist kein Unix-Domain-Socket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Möglicherweise ungültige SSH_AUTH_SOCK-Überschreibung</translation>
+        <translation>Möglicherweise ungültige SSH_AUTH_SOCK-Überschreibung</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -445,7 +445,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Der Überschreibungswert für SSH_AUTH_SOCK ist möglicherweise ungültig.
+        <translation>Der Überschreibungswert für SSH_AUTH_SOCK ist möglicherweise ungültig.
 
 %1
 
@@ -592,17 +592,17 @@ Der Wert wird dennoch wie eingegeben gespeichert.</translation>
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK überschreiben:</translation>
+        <translation>SSH_AUTH_SOCK überschreiben:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Optionaler Pfad zum Überschreiben von SSH_AUTH_SOCK. Leer lassen, um per gpgconf automatisch zu ermitteln (issue #543).</translation>
+        <translation>Optionaler Pfad zum Überschreiben von SSH_AUTH_SOCK. Leer lassen, um per gpgconf automatisch zu ermitteln (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatisch per gpgconf ermitteln)</translation>
+        <translation>(automatisch per gpgconf ermitteln)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>

--- a/localization/localization_es_AR.ts
+++ b/localization/localization_es_AR.ts
@@ -365,17 +365,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Sustitución de SSH_AUTH_SOCK:</translation>
+        <translation>Sustitución de SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Ruta opcional para suplantar SSH_AUTH_SOCK. Dejar en blanco para detección automática vía gpgconf (issue #543).</translation>
+        <translation>Ruta opcional para suplantar SSH_AUTH_SOCK. Dejar en blanco para detección automática vía gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detección automática vía gpgconf)</translation>
+        <translation>(detección automática vía gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -466,22 +466,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">La ruta no existe.</translation>
+        <translation>La ruta no existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">La ruta no es legible.</translation>
+        <translation>La ruta no es legible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">La ruta no es un socket de dominio Unix.</translation>
+        <translation>La ruta no es un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Sustitución de SSH_AUTH_SOCK potencialmente inválida</translation>
+        <translation>Sustitución de SSH_AUTH_SOCK potencialmente inválida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -490,7 +490,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">El valor de sustitución de SSH_AUTH_SOCK puede ser inválido.
+        <translation>El valor de sustitución de SSH_AUTH_SOCK puede ser inválido.
 
 %1
 

--- a/localization/localization_es_ES.ts
+++ b/localization/localization_es_ES.ts
@@ -365,17 +365,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Sustitución de SSH_AUTH_SOCK:</translation>
+        <translation>Sustitución de SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Ruta opcional para sustituir SSH_AUTH_SOCK. Dejar en blanco para detección automática vía gpgconf (issue #543).</translation>
+        <translation>Ruta opcional para sustituir SSH_AUTH_SOCK. Dejar en blanco para detección automática vía gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detección automática vía gpgconf)</translation>
+        <translation>(detección automática vía gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -466,22 +466,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">La ruta no existe.</translation>
+        <translation>La ruta no existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">La ruta no es legible.</translation>
+        <translation>La ruta no es legible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">La ruta no es un socket de dominio Unix.</translation>
+        <translation>La ruta no es un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Sustitución de SSH_AUTH_SOCK potencialmente inválida</translation>
+        <translation>Sustitución de SSH_AUTH_SOCK potencialmente inválida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -490,7 +490,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">El valor de sustitución de SSH_AUTH_SOCK puede ser inválido.
+        <translation>El valor de sustitución de SSH_AUTH_SOCK puede ser inválido.
 
 %1
 

--- a/localization/localization_es_MX.ts
+++ b/localization/localization_es_MX.ts
@@ -365,17 +365,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Sustitución de SSH_AUTH_SOCK:</translation>
+        <translation>Sustitución de SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Ruta opcional para sobrescribir SSH_AUTH_SOCK. Deja vacío para detectarlo automáticamente vía gpgconf (issue #543).</translation>
+        <translation>Ruta opcional para sobrescribir SSH_AUTH_SOCK. Deja vacío para detectarlo automáticamente vía gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detección automática vía gpgconf)</translation>
+        <translation>(detección automática vía gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -466,22 +466,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">La ruta no existe.</translation>
+        <translation>La ruta no existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">La ruta no es legible.</translation>
+        <translation>La ruta no es legible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">La ruta no es un socket de dominio Unix.</translation>
+        <translation>La ruta no es un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Sustitución de SSH_AUTH_SOCK potencialmente inválida</translation>
+        <translation>Sustitución de SSH_AUTH_SOCK potencialmente inválida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -490,7 +490,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">El valor de sustitución de SSH_AUTH_SOCK puede ser inválido.
+        <translation>El valor de sustitución de SSH_AUTH_SOCK puede ser inválido.
 
 %1
 

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -314,22 +314,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'existe pas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'est pas lisible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'est pas un socket de domaine Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -338,7 +338,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
+
+%1
+
+La valeur sera néanmoins enregistrée telle quelle.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>
@@ -591,17 +595,17 @@ The value will still be saved as entered.</source>
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Remplacement de SSH_AUTH_SOCK :</translation>
+        <translation>Remplacement de SSH_AUTH_SOCK :</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Chemin optionnel pour remplacer SSH_AUTH_SOCK. Laisser vide pour la détection automatique via gpgconf (issue #543).</translation>
+        <translation>Chemin optionnel pour remplacer SSH_AUTH_SOCK. Laisser vide pour la détection automatique via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(détection automatique via gpgconf)</translation>
+        <translation>(détection automatique via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>

--- a/localization/localization_fr_FR.ts
+++ b/localization/localization_fr_FR.ts
@@ -314,22 +314,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Le chemin n'existe pas.</translation>
+        <translation>Le chemin n'existe pas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Le chemin n'est pas lisible.</translation>
+        <translation>Le chemin n'est pas lisible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Le chemin n'est pas un socket de domaine Unix.</translation>
+        <translation>Le chemin n'est pas un socket de domaine Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
+        <translation>Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -338,7 +338,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
+        <translation>La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
 
 %1
 

--- a/localization/localization_it.ts
+++ b/localization/localization_it.ts
@@ -429,22 +429,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Il percorso non esiste.</translation>
+        <translation>Il percorso non esiste.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Il percorso non è leggibile.</translation>
+        <translation>Il percorso non è leggibile.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Il percorso non è un socket di dominio Unix.</translation>
+        <translation>Il percorso non è un socket di dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Sovrascrittura SSH_AUTH_SOCK potenzialmente non valida</translation>
+        <translation>Sovrascrittura SSH_AUTH_SOCK potenzialmente non valida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -453,7 +453,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Il valore di sovrascrittura SSH_AUTH_SOCK potrebbe non essere valido.
+        <translation>Il valore di sovrascrittura SSH_AUTH_SOCK potrebbe non essere valido.
 
 %1
 

--- a/localization/localization_it.ts
+++ b/localization/localization_it.ts
@@ -157,17 +157,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Sovrascrittura SSH_AUTH_SOCK:</translation>
+        <translation>Sovrascrittura SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Percorso opzionale per sovrascrivere SSH_AUTH_SOCK. Lasciare vuoto per rilevamento automatico tramite gpgconf (issue #543).</translation>
+        <translation>Percorso opzionale per sovrascrivere SSH_AUTH_SOCK. Lasciare vuoto per rilevamento automatico tramite gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(rilevamento automatico tramite gpgconf)</translation>
+        <translation>(rilevamento automatico tramite gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -429,22 +429,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Il percorso non esiste.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Il percorso non è leggibile.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Il percorso non è un socket di dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sovrascrittura SSH_AUTH_SOCK potenzialmente non valida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -453,7 +453,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Il valore di sovrascrittura SSH_AUTH_SOCK potrebbe non essere valido.
+
+%1
+
+Il valore verrà comunque salvato come inserito.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>


### PR DESCRIPTION
## Summary

- **de_DE**: Marked all 8 SSH_AUTH_SOCK translations as finished
- **fr_FR**: Marked first 3 UI strings as finished, added 5 validation translations
- **it**: Marked first 3 UI strings as finished, added 5 validation translations
- **es_ES, es_AR, es_MX**: Marked all 8 SSH_AUTH_SOCK translations as finished (preserving regional wording differences: "sustituir" vs "suplantar" vs "sobrescribir")

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Completed and refined translations for the SSH_AUTH_SOCK override label, helper text, and related validation/warning messages in German, French, Italian, and Spanish (ES, AR, MX), improving clarity in the configuration dialog and validation feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1446)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->