### PR TITLE
i18n: finish translations for da, nl_BE, en_GB, et

### DIFF
--- a/localization/localization_da.ts
+++ b/localization/localization_da.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK-tilsidesættelse:</translation>
+        <translation>SSH_AUTH_SOCK-tilsidesættelse:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Valgfri sti til at tilsidesætte SSH_AUTH_SOCK. Lad stå tom for automatisk registrering via gpgconf (issue #543).</translation>
+        <translation>Valgfri sti til at tilsidesætte SSH_AUTH_SOCK. Lad stå tom for automatisk registrering via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatisk registrering via gpgconf)</translation>
+        <translation>(automatisk registrering via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Stien eksisterer ikke.</translation>
+        <translation>Stien eksisterer ikke.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Stien er ikke læsbar.</translation>
+        <translation>Stien er ikke læsbar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Stien er ikke en Unix-domænesocket.</translation>
+        <translation>Stien er ikke en Unix-domænesocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Potentielt ugyldig SSH_AUTH_SOCK-tilsidesættelse</translation>
+        <translation>Potentielt ugyldig SSH_AUTH_SOCK-tilsidesættelse</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK-tilsidesættelsesværdien er muligvis ugyldig.
+        <translation>SSH_AUTH_SOCK-tilsidesættelsesværdien er muligvis ugyldig.
 
 %1
 

--- a/localization/localization_en_GB.ts
+++ b/localization/localization_en_GB.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK override:</translation>
+        <translation>SSH_AUTH_SOCK override:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</translation>
+        <translation>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(auto-probe via gpgconf)</translation>
+        <translation>(auto-probe via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">The path does not exist.</translation>
+        <translation>The path does not exist.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">The path is not readable.</translation>
+        <translation>The path is not readable.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">The path is not a Unix domain socket.</translation>
+        <translation>The path is not a Unix domain socket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Potentially invalid SSH_AUTH_SOCK override</translation>
+        <translation>Potentially invalid SSH_AUTH_SOCK override</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">The SSH_AUTH_SOCK override value may be invalid.
+        <translation>The SSH_AUTH_SOCK override value may be invalid.
 
 %1
 

--- a/localization/localization_et.ts
+++ b/localization/localization_et.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK alistamine:</translation>
+        <translation>SSH_AUTH_SOCK alistamine:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Valikuline tee SSH_AUTH_SOCK alistamiseks. Jätke tühjaks automaatseks tuvastamiseks gpgconf kaudu (issue #543).</translation>
+        <translation>Valikuline tee SSH_AUTH_SOCK alistamiseks. Jätke tühjaks automaatseks tuvastamiseks gpgconf kaudu (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automaatne tuvastamine gpgconf kaudu)</translation>
+        <translation>(automaatne tuvastamine gpgconf kaudu)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tee ei eksisteeri.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tee ei ole loetav.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tee ei ole Unix-domeenisokkel.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Võibolla kehtetu SSH_AUTH_SOCK alistamine</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">SSH_AUTH_SOCK alistamise väärtus võib olla kehtetu.
+
+%1
+
+Väärtus salvestatakse ikkagi sisestatud kujul.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>

--- a/localization/localization_et.ts
+++ b/localization/localization_et.ts
@@ -428,7 +428,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Tee ei ole Unix-domeenisokkel.</translation>
+        <translation>Tee ei ole Unixi domeenipesa.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>

--- a/localization/localization_nl_BE.ts
+++ b/localization/localization_nl_BE.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">SSH_AUTH_SOCK overschrijven:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Optioneel pad om SSH_AUTH_SOCK te overschrijven. Laat leeg om automatisch te detecteren via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">(automatisch detecteren via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Het pad bestaat niet.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Het pad is niet leesbaar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Het pad is geen Unix-domeinsocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mogelijk ongeldige SSH_AUTH_SOCK-overschrijving</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">De SSH_AUTH_SOCK-overschrijvingswaarde is mogelijk ongeldig.
+
+%1
+
+De waarde wordt nog steeds opgeslagen zoals ingevoerd.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>


### PR DESCRIPTION
## Summary

- **da (Danish)**: Marked all 8 SSH_AUTH_SOCK translations as finished
- **nl_BE (Dutch Belgium)**: Added all 8 SSH_AUTH_SOCK translations (matching nl_NL terminology)
- **en_GB (English UK)**: Marked all 8 SSH_AUTH_SOCK translations as finished (source = translation)
- **et (Estonian)**: Marked first 3 UI strings as finished, added 5 validation translations

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Completed translations for SSH authentication socket configuration labels, explanatory text, and validation/error messages in Danish, English (GB), Estonian, and Dutch (Belgium), improving clarity of the SSH_AUTH_SOCK override UI and its validation feedback across supported languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1447)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->