### PR TITLE
i18n: finish translations for fi, fr_BE, fr_LU

### DIFF
--- a/localization/localization_fi.ts
+++ b/localization/localization_fi.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK-ohitus:</translation>
+        <translation>SSH_AUTH_SOCK-ohitus:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Valinnainen polku SSH_AUTH_SOCK-ohitukselle. Jätä tyhjäksi automaattista tunnistusta varten gpgconf-ohjelman kautta (issue #543).</translation>
+        <translation>Valinnainen polku SSH_AUTH_SOCK-ohitukselle. Jätä tyhjäksi automaattista tunnistusta varten gpgconf-ohjelman kautta (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automaattinen tunnistus gpgconf-ohjelman kautta)</translation>
+        <translation>(automaattinen tunnistus gpgconf-ohjelman kautta)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Polku ei ole olemassa.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Polku ei ole luettavissa.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Polku ei ole Unix-domeenisoketti.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mahdollisesti virheellinen SSH_AUTH_SOCK-ohitus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">SSH_AUTH_SOCK-ohitusarvo voi olla virheellinen.
+
+%1
+
+Arvo tallennetaan silti sellaisenaan kuin se on syötetty.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -314,22 +314,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'existe pas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'est pas lisible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'est pas un socket de domaine Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -338,7 +338,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
+
+%1
+
+La valeur sera néanmoins enregistrée telle quelle.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>
@@ -591,17 +595,17 @@ The value will still be saved as entered.</source>
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Remplacement de SSH_AUTH_SOCK :</translation>
+        <translation>Remplacement de SSH_AUTH_SOCK :</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Chemin optionnel pour remplacer SSH_AUTH_SOCK. Laisser vide pour la détection automatique via gpgconf (issue #543).</translation>
+        <translation>Chemin optionnel pour remplacer SSH_AUTH_SOCK. Laisser vide pour la détection automatique via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(détection automatique via gpgconf)</translation>
+        <translation>(détection automatique via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -314,22 +314,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'existe pas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'est pas lisible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le chemin n'est pas un socket de domaine Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -338,7 +338,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
+
+%1
+
+La valeur sera néanmoins enregistrée telle quelle.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>
@@ -591,17 +595,17 @@ The value will still be saved as entered.</source>
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Remplacement de SSH_AUTH_SOCK :</translation>
+        <translation>Remplacement de SSH_AUTH_SOCK :</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Chemin optionnel pour remplacer SSH_AUTH_SOCK. Laisser vide pour autodétection via gpgconf (problème #543).</translation>
+        <translation>Chemin optionnel pour remplacer SSH_AUTH_SOCK. Laisser vide pour autodétection via gpgconf (problème #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(autodétection via gpgconf)</translation>
+        <translation>(autodétection via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>


### PR DESCRIPTION
## Summary

- **fi (Finnish)**: Marked first 3 UI strings as finished, added 5 validation translations
- **fr_BE (French Belgium)**: Marked first 3 UI strings as finished, added 5 validation translations (using fr_FR terminology)
- **fr_LU (French Luxembourg)**: Marked first 3 UI strings as finished, added 5 validation translations (using fr_FR terminology)
- **fr_FR (French France)**: Already done in PR #1446

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed translations for SSH authentication socket configuration messages and validation errors in Finnish, French (Belgium), and French (Luxembourg) language packs
  * Improved clarity of SSH override field labels and error messages for non-existent, non-readable, and invalid socket paths

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1449)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->