### PR TITLE
i18n: finish translations for de_LU, el, fy_NL

### DIFF
--- a/localization/localization_de_LU.ts
+++ b/localization/localization_de_LU.ts
@@ -411,22 +411,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Der Pfad existiert nicht.</translation>
+        <translation>Der Pfad existiert nicht.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Der Pfad ist nicht lesbar.</translation>
+        <translation>Der Pfad ist nicht lesbar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Der Pfad ist kein Unix-Domain-Socket.</translation>
+        <translation>Der Pfad ist kein Unix-Domain-Socket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Möglicherweise ungültige SSH_AUTH_SOCK-Überschreibung</translation>
+        <translation>Möglicherweise ungültige SSH_AUTH_SOCK-Überschreibung</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -435,7 +435,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Der Überschreibungswert für SSH_AUTH_SOCK ist möglicherweise ungültig.
+        <translation>Der Überschreibungswert für SSH_AUTH_SOCK ist möglicherweise ungültig.
 
 %1
 
@@ -591,17 +591,17 @@ Der Wert wird dennoch wie eingegeben gespeichert.</translation>
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK überschreiben:</translation>
+        <translation>SSH_AUTH_SOCK überschreiben:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Optionaler Pfad zum Überschreiben von SSH_AUTH_SOCK. Leer lassen, um per gpgconf automatisch zu ermitteln (issue #543).</translation>
+        <translation>Optionaler Pfad zum Überschreiben von SSH_AUTH_SOCK. Leer lassen, um per gpgconf automatisch zu ermitteln (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatisch per gpgconf ermitteln)</translation>
+        <translation>(automatisch per gpgconf ermitteln)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>

--- a/localization/localization_el.ts
+++ b/localization/localization_el.ts
@@ -266,17 +266,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Παράκαμψη SSH_AUTH_SOCK:</translation>
+        <translation>Παράκαμψη SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Προαιρετική διαδρομή για παράκαμψη του SSH_AUTH_SOCK. Αφήστε κενό για αυτόματο εντοπισμό μέσω gpgconf (ζήτημα #543).</translation>
+        <translation>Προαιρετική διαδρομή για παράκαμψη του SSH_AUTH_SOCK. Αφήστε κενό για αυτόματο εντοπισμό μέσω gpgconf (ζήτημα #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(αυτόματος εντοπισμός μέσω gpgconf)</translation>
+        <translation>(αυτόματος εντοπισμός μέσω gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -387,22 +387,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Η διαδρομή δεν υπάρχει.</translation>
+        <translation>Η διαδρομή δεν υπάρχει.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Η διαδρομή δεν είναι αναγνώσιμη.</translation>
+        <translation>Η διαδρομή δεν είναι αναγνώσιμη.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Η διαδρομή δεν είναι Unix domain socket.</translation>
+        <translation>Η διαδρομή δεν είναι Unix domain socket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Πιθανώς μη έγκυρη παράκαμψη SSH_AUTH_SOCK</translation>
+        <translation>Πιθανώς μη έγκυρη παράκαμψη SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -411,7 +411,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Η τιμή παράκαμψης SSH_AUTH_SOCK μπορεί να μην είναι έγκυρη.
+        <translation>Η τιμή παράκαμψης SSH_AUTH_SOCK μπορεί να μην είναι έγκυρη.
 
 %1
 

--- a/localization/localization_fy_NL.ts
+++ b/localization/localization_fy_NL.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK oerskriuwe:</translation>
+        <translation>SSH_AUTH_SOCK oerskriuwe:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Opsjoneel paad om SSH_AUTH_SOCK te oerskriuwen. Lit leech foar autodeteksje fia gpgconf (kwestje #543).</translation>
+        <translation>Opsjoneel paad om SSH_AUTH_SOCK te oerskriuwen. Lit leech foar autodeteksje fia gpgconf (kwestje #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(autodeteksje fia gpgconf)</translation>
+        <translation>(autodeteksje fia gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">It paad bestiet net.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">It paad is net te lêzen.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">It paad is gjin Unix-domeinsocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Miskien ûnjildich SSH_AUTH_SOCK-oerskriuwing</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">De SSH_AUTH_SOCK-oerskriuwing-wearde kin ûnjildich wêze.
+
+%1
+
+De wearde wurdt altyd opslein as ynfierd.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>


### PR DESCRIPTION
## Summary

- **de_DE (German Germany)**: Already done in PR #1446 (no changes needed)
- **de_LU (German Luxembourg)**: Marked all 8 SSH_AUTH_SOCK translations as finished (same text as de_DE)
- **el (Greek)**: Marked all 8 SSH_AUTH_SOCK translations as finished
- **fy_NL (Frisian)**: Marked first 3 UI strings as finished, added 5 validation translations

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed German (de_LU), Greek (el), and Frisian (fy_NL) translations for configuration dialog messages, including validation error messages and SSH_AUTH_SOCK override guidance text that were previously marked as unfinished.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1450)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->