### PR TITLE
i18n: finish translations for hi, hu, id

### DIFF
--- a/localization/localization_hi.ts
+++ b/localization/localization_hi.ts
@@ -306,17 +306,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ओवरराइड:</translation>
+        <translation>SSH_AUTH_SOCK ओवरराइड:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">SSH_AUTH_SOCK को ओवरराइड करने के लिए वैकल्पिक पथ। gpgconf के माध्यम से स्वतः-जांच के लिए खाली छोड़ें (issue #543).</translation>
+        <translation>SSH_AUTH_SOCK को ओवरराइड करने के लिए वैकल्पिक पथ। gpgconf के माध्यम से स्वतः-जांच के लिए खाली छोड़ें (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(gpgconf के माध्यम से स्वतः-जांच)</translation>
+        <translation>(gpgconf के माध्यम से स्वतः-जांच)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -446,22 +446,22 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">पथ मौजूद नहीं है।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">पथ पठनीय नहीं है।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">पथ एक Unix डोमेन सॉकेट नहीं है।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">संभावित रूप से अमान्य SSH_AUTH_SOCK ओवरराइड</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,11 @@ URL
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">SSH_AUTH_SOCK ओवरराइड मान अमान्य हो सकता है।
+
+%1
+
+मान अभी भी दर्ज किए गए रूप में सहेजा जाएगा।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>

--- a/localization/localization_hu.ts
+++ b/localization/localization_hu.ts
@@ -166,17 +166,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK felülírása:</translation>
+        <translation>SSH_AUTH_SOCK felülírása:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Opcionális elérési út az SSH_AUTH_SOCK felülírásához. Hagyja üresen az automatikus felderítéshez gpgconf segítségével (hiba #543).</translation>
+        <translation>Opcionális elérési út az SSH_AUTH_SOCK felülírásához. Hagyja üresen az automatikus felderítéshez gpgconf segítségével (hiba #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatikus felderítés gpgconf segítségével)</translation>
+        <translation>(automatikus felderítés gpgconf segítségével)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -439,22 +439,22 @@ e-mail</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Az elérési út nem létezik.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Az elérési út nem olvasható.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Az elérési út nem Unix-domainsocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Lehet, hogy érvénytelen SSH_AUTH_SOCK felülírás</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -463,7 +463,11 @@ e-mail</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Az SSH_AUTH_SOCK felülírási értéke érvénytelen lehet.
+
+%1
+
+Az érték még akkor is el lesz mentve, ahogy be lett írva.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>

--- a/localization/localization_id.ts
+++ b/localization/localization_id.ts
@@ -306,17 +306,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Timpa SSH_AUTH_SOCK:</translation>
+        <translation>Timpa SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Jalur opsional untuk menimpa SSH_AUTH_SOCK. Kosongkan untuk deteksi otomatis melalui gpgconf (issue #543).</translation>
+        <translation>Jalur opsional untuk menimpa SSH_AUTH_SOCK. Kosongkan untuk deteksi otomatis melalui gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(deteksi otomatis melalui gpgconf)</translation>
+        <translation>(deteksi otomatis melalui gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -446,22 +446,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Jalur tidak ada.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Jalur tidak dapat dibaca.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Jalur bukan soket domain Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Timpa SSH_AUTH_SOCK yang berpotensi tidak valid</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,11 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nilai timpa SSH_AUTH_SOCK mungkin tidak valid.
+
+%1
+
+Nilai akan tetap disimpan seperti yang dimasukkan.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>


### PR DESCRIPTION
## Summary

- **it (Italian)**: Already done in PR #1446 (no changes needed)
- **hi (Hindi)**: Marked first 3 UI strings as finished, added 5 validation translations
- **hu (Hungarian)**: Marked first 3 UI strings as finished, added 5 validation translations
- **id (Indonesian)**: Marked first 3 UI strings as finished, added 5 validation translations

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed translations for Hindi, Hungarian, and Indonesian localization files, including configuration dialog labels, user guidance text, validation messages, and warning notifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->