### PR TITLE
i18n: finish translations for es_EC, es_UY

### DIFF
--- a/localization/localization_es_EC.ts
+++ b/localization/localization_es_EC.ts
@@ -365,17 +365,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Anulación de SSH_AUTH_SOCK:</translation>
+        <translation>Anulación de SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Ruta opcional para anular SSH_AUTH_SOCK. Dejar en blanco para auto-detección vía gpgconf (issue #543).</translation>
+        <translation>Ruta opcional para anular SSH_AUTH_SOCK. Dejar en blanco para auto-detección vía gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(auto-detección vía gpgconf)</translation>
+        <translation>(auto-detección vía gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -466,22 +466,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">La ruta no existe.</translation>
+        <translation>La ruta no existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">La ruta no es legible.</translation>
+        <translation>La ruta no es legible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">La ruta no es un socket de dominio Unix.</translation>
+        <translation>La ruta no es un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Anulación de SSH_AUTH_SOCK potencialmente inválida</translation>
+        <translation>Anulación de SSH_AUTH_SOCK potencialmente inválida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -490,7 +490,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">El valor de anulación de SSH_AUTH_SOCK puede ser inválido.
+        <translation>El valor de anulación de SSH_AUTH_SOCK puede ser inválido.
 
 %1
 

--- a/localization/localization_es_UY.ts
+++ b/localization/localization_es_UY.ts
@@ -365,17 +365,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Sobrescribir SSH_AUTH_SOCK:</translation>
+        <translation>Sobrescribir SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Ruta opcional para sobrescribir SSH_AUTH_SOCK. Dejar vacío para que se detecte automáticamente vía gpgconf (issue #543).</translation>
+        <translation>Ruta opcional para sobrescribir SSH_AUTH_SOCK. Dejar vacío para que se detecte automáticamente vía gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detección automática vía gpgconf)</translation>
+        <translation>(detección automática vía gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -466,22 +466,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">La ruta no existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">La ruta no es legible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">La ruta no es un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sobrescritura de SSH_AUTH_SOCK potencialmente inválida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -490,7 +490,11 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">El valor de sobrescritura de SSH_AUTH_SOCK puede ser inválido.
+
+%1
+
+El valor se guardará tal como fue ingresado.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="753"/>


### PR DESCRIPTION
## Summary

- **es_EC (Spanish Ecuador)**: Removed `type="unfinished"` from all 8 SSH_AUTH_SOCK translations (already had valid translations)
- **es_UY (Spanish Uruguay)**: 
  - Removed `type="unfinished"` from first 3 translations
  - Added last 5 validation translations with `type="unfinished"` for Weblate review

**Note**: es_AR and es_MX already had all 8 translations complete without `type="unfinished"`.

Part of finishing i18n coverage for the SSH_AUTH_SOCK auto-probe + override feature (PR #1438).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Completed Spanish translations for Ecuador and Uruguay variants, including configuration dialog messages and validation alerts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1458)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->