### PR TITLE
i18n: promote 31 locales from ≥95% to 100% finished

### DIFF
--- a/localization/localization_cy.ts
+++ b/localization/localization_cy.ts
@@ -1715,7 +1715,7 @@ Parhau?</translation>
     <message>
         <location filename="../src/trayicon.cpp" line="66"/>
         <source>&amp;Quit</source>
-        <translation type="unfinished">&amp;Gadael</translation>
+        <translation>&amp;Gadael</translation>
     </message>
 </context>
 <context>
@@ -1756,7 +1756,7 @@ Nid yw cofnodion coch yn ddilys, ni fyddwch yn gallu amgryptio i&apos;r rhain.</
     <message>
         <location filename="../src/usersdialog.ui" line="77"/>
         <source>Show unusable keys</source>
-        <translation type="unfinished">Dangos bysellau na ellir eu defnyddio</translation>
+        <translation>Dangos bysellau na ellir eu defnyddio</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.ui" line="84"/>

--- a/localization/localization_es_UY.ts
+++ b/localization/localization_es_UY.ts
@@ -466,22 +466,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">La ruta no existe.</translation>
+        <translation>La ruta no existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">La ruta no es legible.</translation>
+        <translation>La ruta no es legible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">La ruta no es un socket de dominio Unix.</translation>
+        <translation>La ruta no es un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Sobrescritura de SSH_AUTH_SOCK potencialmente inválida</translation>
+        <translation>Sobrescritura de SSH_AUTH_SOCK potencialmente inválida</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -490,7 +490,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">El valor de sobrescritura de SSH_AUTH_SOCK puede ser inválido.
+        <translation>El valor de sobrescritura de SSH_AUTH_SOCK puede ser inválido.
 
 %1
 

--- a/localization/localization_et.ts
+++ b/localization/localization_et.ts
@@ -418,12 +418,12 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Tee ei eksisteeri.</translation>
+        <translation>Tee ei eksisteeri.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Tee ei ole loetav.</translation>
+        <translation>Tee ei ole loetav.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
@@ -433,7 +433,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Võibolla kehtetu SSH_AUTH_SOCK alistamine</translation>
+        <translation>Võibolla kehtetu SSH_AUTH_SOCK alistamine</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK alistamise väärtus võib olla kehtetu.
+        <translation>SSH_AUTH_SOCK alistamise väärtus võib olla kehtetu.
 
 %1
 

--- a/localization/localization_fi.ts
+++ b/localization/localization_fi.ts
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Polku ei ole olemassa.</translation>
+        <translation>Polku ei ole olemassa.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Polku ei ole luettavissa.</translation>
+        <translation>Polku ei ole luettavissa.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Polku ei ole Unix-domeenisoketti.</translation>
+        <translation>Polku ei ole Unix-domeenisoketti.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Mahdollisesti virheellinen SSH_AUTH_SOCK-ohitus</translation>
+        <translation>Mahdollisesti virheellinen SSH_AUTH_SOCK-ohitus</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK-ohitusarvo voi olla virheellinen.
+        <translation>SSH_AUTH_SOCK-ohitusarvo voi olla virheellinen.
 
 %1
 

--- a/localization/localization_fr_BE.ts
+++ b/localization/localization_fr_BE.ts
@@ -314,22 +314,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Le chemin n'existe pas.</translation>
+        <translation>Le chemin n'existe pas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Le chemin n'est pas lisible.</translation>
+        <translation>Le chemin n'est pas lisible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Le chemin n'est pas un socket de domaine Unix.</translation>
+        <translation>Le chemin n'est pas un socket de domaine Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
+        <translation>Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -338,7 +338,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
+        <translation>La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
 
 %1
 

--- a/localization/localization_fr_LU.ts
+++ b/localization/localization_fr_LU.ts
@@ -314,22 +314,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Le chemin n'existe pas.</translation>
+        <translation>Le chemin n'existe pas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Le chemin n'est pas lisible.</translation>
+        <translation>Le chemin n'est pas lisible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Le chemin n'est pas un socket de domaine Unix.</translation>
+        <translation>Le chemin n'est pas un socket de domaine Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
+        <translation>Remplacement SSH_AUTH_SOCK potentiellement invalide</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -338,7 +338,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
+        <translation>La valeur de remplacement de SSH_AUTH_SOCK peut être invalide.
 
 %1
 

--- a/localization/localization_fy_NL.ts
+++ b/localization/localization_fy_NL.ts
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">It paad bestiet net.</translation>
+        <translation>It paad bestiet net.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">It paad is net te lêzen.</translation>
+        <translation>It paad is net te lêzen.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">It paad is gjin Unix-domeinsocket.</translation>
+        <translation>It paad is gjin Unix-domeinsocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Miskien ûnjildich SSH_AUTH_SOCK-oerskriuwing</translation>
+        <translation>Miskien ûnjildich SSH_AUTH_SOCK-oerskriuwing</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">De SSH_AUTH_SOCK-oerskriuwing-wearde kin ûnjildich wêze.
+        <translation>De SSH_AUTH_SOCK-oerskriuwing-wearde kin ûnjildich wêze.
 
 %1
 

--- a/localization/localization_gl.ts
+++ b/localization/localization_gl.ts
@@ -387,22 +387,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">A ruta non existe.</translation>
+        <translation>A ruta non existe.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">A ruta non é lexible.</translation>
+        <translation>A ruta non é lexible.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">A ruta non é un socket de dominio Unix.</translation>
+        <translation>A ruta non é un socket de dominio Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Posíbel substitución inválida de SSH_AUTH_SOCK</translation>
+        <translation>Posíbel substitución inválida de SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -411,7 +411,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">O valor da substitución de SSH_AUTH_SOCK pode ser inválido.
+        <translation>O valor da substitución de SSH_AUTH_SOCK pode ser inválido.
 
 %1
 

--- a/localization/localization_hi.ts
+++ b/localization/localization_hi.ts
@@ -446,22 +446,22 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">पथ मौजूद नहीं है।</translation>
+        <translation>पथ मौजूद नहीं है।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">पथ पठनीय नहीं है।</translation>
+        <translation>पथ पठनीय नहीं है।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">पथ एक Unix डोमेन सॉकेट नहीं है।</translation>
+        <translation>पथ एक Unix डोमेन सॉकेट नहीं है।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">संभावित रूप से अमान्य SSH_AUTH_SOCK ओवरराइड</translation>
+        <translation>संभावित रूप से अमान्य SSH_AUTH_SOCK ओवरराइड</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ URL
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ओवरराइड मान अमान्य हो सकता है।
+        <translation>SSH_AUTH_SOCK ओवरराइड मान अमान्य हो सकता है।
 
 %1
 

--- a/localization/localization_hr.ts
+++ b/localization/localization_hr.ts
@@ -433,7 +433,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Potencijalno neispravno nadjačavanje SSH_AUTH_SOCK</translation>
+        <translation>Potencijalno neispravno nadjačavanje SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Vrijednost nadjačavanja SSH_AUTH_SOCK može biti neispravna.
+        <translation>Vrijednost nadjačavanja SSH_AUTH_SOCK može biti neispravna.
 
 %1
 

--- a/localization/localization_hu.ts
+++ b/localization/localization_hu.ts
@@ -439,22 +439,22 @@ e-mail</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Az elérési út nem létezik.</translation>
+        <translation>Az elérési út nem létezik.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Az elérési út nem olvasható.</translation>
+        <translation>Az elérési út nem olvasható.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Az elérési út nem Unix-domainsocket.</translation>
+        <translation>Az elérési út nem Unix-domainsocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Lehet, hogy érvénytelen SSH_AUTH_SOCK felülírás</translation>
+        <translation>Lehet, hogy érvénytelen SSH_AUTH_SOCK felülírás</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -463,7 +463,7 @@ e-mail</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Az SSH_AUTH_SOCK felülírási értéke érvénytelen lehet.
+        <translation>Az SSH_AUTH_SOCK felülírási értéke érvénytelen lehet.
 
 %1
 

--- a/localization/localization_id.ts
+++ b/localization/localization_id.ts
@@ -446,22 +446,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Jalur tidak ada.</translation>
+        <translation>Jalur tidak ada.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Jalur tidak dapat dibaca.</translation>
+        <translation>Jalur tidak dapat dibaca.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Jalur bukan soket domain Unix.</translation>
+        <translation>Jalur bukan soket domain Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Timpa SSH_AUTH_SOCK yang berpotensi tidak valid</translation>
+        <translation>Timpa SSH_AUTH_SOCK yang berpotensi tidak valid</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Nilai timpa SSH_AUTH_SOCK mungkin tidak valid.
+        <translation>Nilai timpa SSH_AUTH_SOCK mungkin tidak valid.
 
 %1
 

--- a/localization/localization_ja.ts
+++ b/localization/localization_ja.ts
@@ -418,22 +418,22 @@ url
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">パスが存在しません。</translation>
+        <translation>パスが存在しません。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">パスが読み取れません。</translation>
+        <translation>パスが読み取れません。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">パスが Unix ドメインソケットではありません。</translation>
+        <translation>パスが Unix ドメインソケットではありません。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">無効な可能性のある SSH_AUTH_SOCK の上書き</translation>
+        <translation>無効な可能性のある SSH_AUTH_SOCK の上書き</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ url
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK の上書き値が無効な可能性があります。
+        <translation>SSH_AUTH_SOCK の上書き値が無効な可能性があります。
 
 %1
 

--- a/localization/localization_ko.ts
+++ b/localization/localization_ko.ts
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">경로가 존재하지 않습니다.</translation>
+        <translation>경로가 존재하지 않습니다.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">경로를 읽을 수 없습니다.</translation>
+        <translation>경로를 읽을 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">경로가 Unix 도메인 소켓이 아닙니다.</translation>
+        <translation>경로가 Unix 도메인 소켓이 아닙니다.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">잠재적으로 잘못된 SSH_AUTH_SOCK 재정의</translation>
+        <translation>잠재적으로 잘못된 SSH_AUTH_SOCK 재정의</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 재정의 값이 잘못되었을 수 있습니다.
+        <translation>SSH_AUTH_SOCK 재정의 값이 잘못되었을 수 있습니다.
 
 %1
 

--- a/localization/localization_lb_LU.ts
+++ b/localization/localization_lb_LU.ts
@@ -387,22 +387,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">De Pfad existéiert net.</translation>
+        <translation>De Pfad existéiert net.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">De Pfad ass net liessbar.</translation>
+        <translation>De Pfad ass net liessbar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">De Pfad ass kee Unix-Domänensocket.</translation>
+        <translation>De Pfad ass kee Unix-Domänensocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Méiglicherweis onëllegeg SSH_AUTH_SOCK-Iwwerschreiwung</translation>
+        <translation>Méiglicherweis onëllegeg SSH_AUTH_SOCK-Iwwerschreiwung</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -411,7 +411,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">D'SSH_AUTH_SOCK-Iwwerschreiwung ka onëllegeg sinn.
+        <translation>D'SSH_AUTH_SOCK-Iwwerschreiwung ka onëllegeg sinn.
 
 %1
 

--- a/localization/localization_lt.ts
+++ b/localization/localization_lt.ts
@@ -446,22 +446,22 @@ el. paštas</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Kelias neegzistuoja.</translation>
+        <translation>Kelias neegzistuoja.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Kelias nėra skaitomas.</translation>
+        <translation>Kelias nėra skaitomas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Kelias nėra Unix domeno lizdas.</translation>
+        <translation>Kelias nėra Unix domeno lizdas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Galimas neteisingas SSH_AUTH_SOCK perrašymas</translation>
+        <translation>Galimas neteisingas SSH_AUTH_SOCK perrašymas</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ el. paštas</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK perrašymo vertė gali būti neteisinga.
+        <translation>SSH_AUTH_SOCK perrašymo vertė gali būti neteisinga.
 
 %1
 

--- a/localization/localization_lv.ts
+++ b/localization/localization_lv.ts
@@ -446,22 +446,22 @@ e-pasts</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Ceļš neeksistē.</translation>
+        <translation>Ceļš neeksistē.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Ceļš nav nolasāms.</translation>
+        <translation>Ceļš nav nolasāms.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Ceļš nav Unix domēna ligzda.</translation>
+        <translation>Ceļš nav Unix domēna ligzda.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Iespējams nederīga SSH_AUTH_SOCK pārrakstīšana</translation>
+        <translation>Iespējams nederīga SSH_AUTH_SOCK pārrakstīšana</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ e-pasts</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK pārrakstīšanas vērtība var būt nederīga.
+        <translation>SSH_AUTH_SOCK pārrakstīšanas vērtība var būt nederīga.
 
 %1
 

--- a/localization/localization_nl_BE.ts
+++ b/localization/localization_nl_BE.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK overschrijven:</translation>
+        <translation>SSH_AUTH_SOCK overschrijven:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Optioneel pad om SSH_AUTH_SOCK te overschrijven. Laat leeg om automatisch te detecteren via gpgconf (issue #543).</translation>
+        <translation>Optioneel pad om SSH_AUTH_SOCK te overschrijven. Laat leeg om automatisch te detecteren via gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatisch detecteren via gpgconf)</translation>
+        <translation>(automatisch detecteren via gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Het pad bestaat niet.</translation>
+        <translation>Het pad bestaat niet.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Het pad is niet leesbaar.</translation>
+        <translation>Het pad is niet leesbaar.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Het pad is geen Unix-domeinsocket.</translation>
+        <translation>Het pad is geen Unix-domeinsocket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Mogelijk ongeldige SSH_AUTH_SOCK-overschrijving</translation>
+        <translation>Mogelijk ongeldige SSH_AUTH_SOCK-overschrijving</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">De SSH_AUTH_SOCK-overschrijvingswaarde is mogelijk ongeldig.
+        <translation>De SSH_AUTH_SOCK-overschrijvingswaarde is mogelijk ongeldig.
 
 %1
 

--- a/localization/localization_pa_IN.ts
+++ b/localization/localization_pa_IN.ts
@@ -306,17 +306,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ਓਵਰਰਾਈਡ:</translation>
+        <translation>SSH_AUTH_SOCK ਓਵਰਰਾਈਡ:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ਨੂੰ ਓਵਰਰਾਈਡ ਕਰਨ ਲਈ ਵਿਕਲਪਿਕ ਮਾਰਗ। gpgconf ਰਾਹੀਂ ਆਟੋ-ਪਰੋਬ ਲਈ ਖਾਲੀ ਛੱਡੋ (issue #543)।</translation>
+        <translation>SSH_AUTH_SOCK ਨੂੰ ਓਵਰਰਾਈਡ ਕਰਨ ਲਈ ਵਿਕਲਪਿਕ ਮਾਰਗ। gpgconf ਰਾਹੀਂ ਆਟੋ-ਪਰੋਬ ਲਈ ਖਾਲੀ ਛੱਡੋ (issue #543)।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(gpgconf ਰਾਹੀਂ ਆਟੋ-ਪਰੋਬ)</translation>
+        <translation>(gpgconf ਰਾਹੀਂ ਆਟੋ-ਪਰੋਬ)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -446,22 +446,22 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">ਮਾਰਗ ਮੌਜੂਦ ਨਹੀਂ ਹੈ।</translation>
+        <translation>ਮਾਰਗ ਮੌਜੂਦ ਨਹੀਂ ਹੈ।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">ਮਾਰਗ ਪੜ੍ਹਨਯੋਗ ਨਹੀਂ ਹੈ।</translation>
+        <translation>ਮਾਰਗ ਪੜ੍ਹਨਯੋਗ ਨਹੀਂ ਹੈ।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">ਮਾਰਗ ਇਕ Unix ਡੋਮੇਨ ਸਾਕਟ ਨਹੀਂ ਹੈ।</translation>
+        <translation>ਮਾਰਗ ਇਕ Unix ਡੋਮੇਨ ਸਾਕਟ ਨਹੀਂ ਹੈ।</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">ਸੰਭਾਵਿਤ ਅਵੈਧ SSH_AUTH_SOCK ਓਵਰਰਾਈਡ</translation>
+        <translation>ਸੰਭਾਵਿਤ ਅਵੈਧ SSH_AUTH_SOCK ਓਵਰਰਾਈਡ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ URL
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ਓਵਰਰਾਈਡ ਮੁੱਲ ਅਵੈਧ ਹੋ ਸਕਦਾ ਹੈ।
+        <translation>SSH_AUTH_SOCK ਓਵਰਰਾਈਡ ਮੁੱਲ ਅਵੈਧ ਹੋ ਸਕਦਾ ਹੈ।
 
 %1
 

--- a/localization/localization_ro.ts
+++ b/localization/localization_ro.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Suprascriere SSH_AUTH_SOCK:</translation>
+        <translation>Suprascriere SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Cale opțională pentru suprascrierea SSH_AUTH_SOCK. Lăsați gol pentru detectare automată prin gpgconf (problema #543).</translation>
+        <translation>Cale opțională pentru suprascrierea SSH_AUTH_SOCK. Lăsați gol pentru detectare automată prin gpgconf (problema #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detectare automată prin gpgconf)</translation>
+        <translation>(detectare automată prin gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Calea nu există.</translation>
+        <translation>Calea nu există.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Calea nu este citibilă.</translation>
+        <translation>Calea nu este citibilă.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Calea nu este un socket de domeniu Unix.</translation>
+        <translation>Calea nu este un socket de domeniu Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Suprascriere SSH_AUTH_SOCK potențial invalidă</translation>
+        <translation>Suprascriere SSH_AUTH_SOCK potențial invalidă</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Valoarea de suprascriere SSH_AUTH_SOCK poate fi invalidă.
+        <translation>Valoarea de suprascriere SSH_AUTH_SOCK poate fi invalidă.
 
 %1
 

--- a/localization/localization_si.ts
+++ b/localization/localization_si.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK අභිබවා යෑම:</translation>
+        <translation>SSH_AUTH_SOCK අභිබවා යෑම:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">SSH_AUTH_SOCK අභිබවා යෑම සඳහා විකල්ප මාර්ගය. gpgconf මගින් ස්වයංක්‍රීය විමර්ශනය සඳහා හිස්ව තබන්න (ගැටළුව #543).</translation>
+        <translation>SSH_AUTH_SOCK අභිබවා යෑම සඳහා විකල්ප මාර්ගය. gpgconf මගින් ස්වයංක්‍රීය විමර්ශනය සඳහා හිස්ව තබන්න (ගැටළුව #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(gpgconf මගින් ස්වයංක්‍රීය විමර්ශනය)</translation>
+        <translation>(gpgconf මගින් ස්වයංක්‍රීය විමර්ශනය)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">මාර්ගය නොපවතී.</translation>
+        <translation>මාර්ගය නොපවතී.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">මාර්ගය කියවිය නොහැක.</translation>
+        <translation>මාර්ගය කියවිය නොහැක.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">මාර්ගය Unix වසම් සොකට් එකක් නොවේ.</translation>
+        <translation>මාර්ගය Unix වසම් සොකට් එකක් නොවේ.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">විභව වලංගු නොවන SSH_AUTH_SOCK අභිබවා යෑම</translation>
+        <translation>විභව වලංගු නොවන SSH_AUTH_SOCK අභිබවා යෑම</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK අභිබවා යෑමේ අගය වලංගු නොවිය හැක.
+        <translation>SSH_AUTH_SOCK අභිබවා යෑමේ අගය වලංගු නොවිය හැක.
 
 %1
 

--- a/localization/localization_sq.ts
+++ b/localization/localization_sq.ts
@@ -266,17 +266,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Mbivendosje SSH_AUTH_SOCK:</translation>
+        <translation>Mbivendosje SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Shteg opsional për të mbivendosur SSH_AUTH_SOCK. Lëreni bosh për detektim automatik përmes gpgconf (problemi #543).</translation>
+        <translation>Shteg opsional për të mbivendosur SSH_AUTH_SOCK. Lëreni bosh për detektim automatik përmes gpgconf (problemi #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(detektim automatik përmes gpgconf)</translation>
+        <translation>(detektim automatik përmes gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -387,22 +387,22 @@
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Shtegu nuk ekziston.</translation>
+        <translation>Shtegu nuk ekziston.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Shtegu nuk është i lexueshëm.</translation>
+        <translation>Shtegu nuk është i lexueshëm.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Shtegu nuk është një socket i domenit të Unix.</translation>
+        <translation>Shtegu nuk është një socket i domenit të Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Mbivendosje e mundshme e pavlefshme e SSH_AUTH_SOCK</translation>
+        <translation>Mbivendosje e mundshme e pavlefshme e SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -411,7 +411,7 @@
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Vlera e mbivendosjes së SSH_AUTH_SOCK mund të jetë e pavlefshme.
+        <translation>Vlera e mbivendosjes së SSH_AUTH_SOCK mund të jetë e pavlefshme.
 
 %1
 

--- a/localization/localization_sr_Cyrl.ts
+++ b/localization/localization_sr_Cyrl.ts
@@ -152,17 +152,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK надјачавање:</translation>
+        <translation>SSH_AUTH_SOCK надјачавање:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Опциона путања за надјачавање SSH_AUTH_SOCK. Оставите празно за аутоматско откривање путем gpgconf (проблем #543).</translation>
+        <translation>Опциона путања за надјачавање SSH_AUTH_SOCK. Оставите празно за аутоматско откривање путем gpgconf (проблем #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(аутоматско откривање путем gpgconf)</translation>
+        <translation>(аутоматско откривање путем gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -402,22 +402,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Путања не постоји.</translation>
+        <translation>Путања не постоји.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Путања није читљива.</translation>
+        <translation>Путања није читљива.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Путања није Unix доменска утичница.</translation>
+        <translation>Путања није Unix доменска утичница.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Потенцијално неисправно SSH_AUTH_SOCK надјачавање</translation>
+        <translation>Потенцијално неисправно SSH_AUTH_SOCK надјачавање</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -426,7 +426,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Вриједност SSH_AUTH_SOCK надјачавања може бити неисправна.
+        <translation>Вриједност SSH_AUTH_SOCK надјачавања може бити неисправна.
 
 %1
 

--- a/localization/localization_sr_RS.ts
+++ b/localization/localization_sr_RS.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK nadjačavanje:</translation>
+        <translation>SSH_AUTH_SOCK nadjačavanje:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Opcionalna putanja za nadjačavanje SSH_AUTH_SOCK. Ostavite prazno za automatsko otkrivanje putem gpgconf (problem #543).</translation>
+        <translation>Opcionalna putanja za nadjačavanje SSH_AUTH_SOCK. Ostavite prazno za automatsko otkrivanje putem gpgconf (problem #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(automatsko otkrivanje putem gpgconf)</translation>
+        <translation>(automatsko otkrivanje putem gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Putanja ne postoji.</translation>
+        <translation>Putanja ne postoji.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Putanja nije čitljiva.</translation>
+        <translation>Putanja nije čitljiva.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Putanja nije Unix domen soket.</translation>
+        <translation>Putanja nije Unix domen soket.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Potencijalno neispravno SSH_AUTH_SOCK nadjačavanje</translation>
+        <translation>Potencijalno neispravno SSH_AUTH_SOCK nadjačavanje</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Vrijednost SSH_AUTH_SOCK nadjačavanja može biti neispravna.
+        <translation>Vrijednost SSH_AUTH_SOCK nadjačavanja može biti neispravna.
 
 %1
 

--- a/localization/localization_sw.ts
+++ b/localization/localization_sw.ts
@@ -306,17 +306,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">Ubadilishaji wa SSH_AUTH_SOCK:</translation>
+        <translation>Ubadilishaji wa SSH_AUTH_SOCK:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">Njia ya hiari ya kubadilisha SSH_AUTH_SOCK. Acha tupu kwa utafutaji otomatiki kupitia gpgconf (issue #543).</translation>
+        <translation>Njia ya hiari ya kubadilisha SSH_AUTH_SOCK. Acha tupu kwa utafutaji otomatiki kupitia gpgconf (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(utafutaji otomatiki kupitia gpgconf)</translation>
+        <translation>(utafutaji otomatiki kupitia gpgconf)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -446,22 +446,22 @@ barua pepe</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Njia haipo.</translation>
+        <translation>Njia haipo.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Njia haisomiki.</translation>
+        <translation>Njia haisomiki.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Njia si tundiko la kikoa cha Unix.</translation>
+        <translation>Njia si tundiko la kikoa cha Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Ubadilishaji wa SSH_AUTH_SOCK unaowezekana kuwa batili</translation>
+        <translation>Ubadilishaji wa SSH_AUTH_SOCK unaowezekana kuwa batili</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ barua pepe</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Thamani ya ubadilishaji wa SSH_AUTH_SOCK inaweza kuwa batili.
+        <translation>Thamani ya ubadilishaji wa SSH_AUTH_SOCK inaweza kuwa batili.
 
 %1
 

--- a/localization/localization_ta.ts
+++ b/localization/localization_ta.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK மேலெழுதுதல்:</translation>
+        <translation>SSH_AUTH_SOCK மேலெழுதுதல்:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ஐ மேலெழுத விருப்பப் பாதை. gpgconf மூலம் தானியங்கு ஆய்வுக்கு காலியாக விடவும் (issue #543).</translation>
+        <translation>SSH_AUTH_SOCK ஐ மேலெழுத விருப்பப் பாதை. gpgconf மூலம் தானியங்கு ஆய்வுக்கு காலியாக விடவும் (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(gpgconf மூலம் தானியங்கு ஆய்வு)</translation>
+        <translation>(gpgconf மூலம் தானியங்கு ஆய்வு)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">பாதை இல்லை.</translation>
+        <translation>பாதை இல்லை.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">பாதை படிக்க முடியாதது.</translation>
+        <translation>பாதை படிக்க முடியாதது.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">பாதை Unix domain socket அல்ல.</translation>
+        <translation>பாதை Unix domain socket அல்ல.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">சாத்தியமான தவறான SSH_AUTH_SOCK மேலெழுதுதல்</translation>
+        <translation>சாத்தியமான தவறான SSH_AUTH_SOCK மேலெழுதுதல்</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK மேலெழுதுதல் மதிப்பு தவறாக இருக்கலாம்.
+        <translation>SSH_AUTH_SOCK மேலெழுதுதல் மதிப்பு தவறாக இருக்கலாம்.
 
 %1
 

--- a/localization/localization_te.ts
+++ b/localization/localization_te.ts
@@ -306,17 +306,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ఓవర్రైడ్:</translation>
+        <translation>SSH_AUTH_SOCK ఓవర్రైడ్:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ను ఓవర్రైడ్ చేయడానికి ఐచ్ఛిక మార్గం. gpgconf ద్వారా స్వయంచాలక పరిశోధన కోసం ఖాళీగా వదలండి (issue #543).</translation>
+        <translation>SSH_AUTH_SOCK ను ఓవర్రైడ్ చేయడానికి ఐచ్ఛిక మార్గం. gpgconf ద్వారా స్వయంచాలక పరిశోధన కోసం ఖాళీగా వదలండి (issue #543).</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(gpgconf ద్వారా స్వయంచాలక పరిశోధన)</translation>
+        <translation>(gpgconf ద్వారా స్వయంచాలక పరిశోధన)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -446,22 +446,22 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">మార్గం లేదు.</translation>
+        <translation>మార్గం లేదు.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">మార్గం చదవడం సాధ్యం కాదు.</translation>
+        <translation>మార్గం చదవడం సాధ్యం కాదు.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">మార్గం యూనిక్స్ డొమైన్ సాకెట్ కాదు.</translation>
+        <translation>మార్గం యూనిక్స్ డొమైన్ సాకెట్ కాదు.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">సంభావ్యంగా చెల్లని SSH_AUTH_SOCK ఓవర్రైడ్</translation>
+        <translation>సంభావ్యంగా చెల్లని SSH_AUTH_SOCK ఓవర్రైడ్</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ URL
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK ఓవర్రైడ్ విలువ చెల్లనిది కావచ్చు.
+        <translation>SSH_AUTH_SOCK ఓవర్రైడ్ విలువ చెల్లనిది కావచ్చు.
 
 %1
 

--- a/localization/localization_uk.ts
+++ b/localization/localization_uk.ts
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">Шлях не існує.</translation>
+        <translation>Шлях не існує.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">Шлях не читається.</translation>
+        <translation>Шлях не читається.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">Шлях не є доменним сокетом Unix.</translation>
+        <translation>Шлях не є доменним сокетом Unix.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">Можливо недійсне перевизначення SSH_AUTH_SOCK</translation>
+        <translation>Можливо недійсне перевизначення SSH_AUTH_SOCK</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">Значення перевизначення SSH_AUTH_SOCK може бути недійсним.
+        <translation>Значення перевизначення SSH_AUTH_SOCK може бути недійсним.
 
 %1
 

--- a/localization/localization_ur.ts
+++ b/localization/localization_ur.ts
@@ -306,17 +306,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK اوور رائیڈ:</translation>
+        <translation>SSH_AUTH_SOCK اوور رائیڈ:</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">SSH_AUTH_SOCK کو اوور رائیڈ کرنے کے لیے اختیاری راستہ۔ gpgconf کے ذریعے خودکار پڑتال کے لیے خالی چھوڑ دیں (issue #543)۔</translation>
+        <translation>SSH_AUTH_SOCK کو اوور رائیڈ کرنے کے لیے اختیاری راستہ۔ gpgconf کے ذریعے خودکار پڑتال کے لیے خالی چھوڑ دیں (issue #543)۔</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">(gpgconf کے ذریعے خودکار پڑتال)</translation>
+        <translation>(gpgconf کے ذریعے خودکار پڑتال)</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="921"/>
@@ -446,22 +446,22 @@ URL
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">راستہ موجود نہیں ہے۔</translation>
+        <translation>راستہ موجود نہیں ہے۔</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">راستہ پڑھنے کے قابل نہیں ہے۔</translation>
+        <translation>راستہ پڑھنے کے قابل نہیں ہے۔</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">راستہ یونکس ڈومین ساکٹ نہیں ہے۔</translation>
+        <translation>راستہ یونکس ڈومین ساکٹ نہیں ہے۔</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">ممکنہ طور پر غلط SSH_AUTH_SOCK اوور رائیڈ</translation>
+        <translation>ممکنہ طور پر غلط SSH_AUTH_SOCK اوور رائیڈ</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -470,7 +470,7 @@ URL
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK اوور رائیڈ کی قدر غلط ہو سکتی ہے۔
+        <translation>SSH_AUTH_SOCK اوور رائیڈ کی قدر غلط ہو سکتی ہے۔
 
 %1
 

--- a/localization/localization_zh_CN.ts
+++ b/localization/localization_zh_CN.ts
@@ -399,22 +399,22 @@ email</source>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">路径不存在。</translation>
+        <translation>路径不存在。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">路径不可读。</translation>
+        <translation>路径不可读。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">路径不是 Unix 域套接字。</translation>
+        <translation>路径不是 Unix 域套接字。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 覆盖值可能无效</translation>
+        <translation>可能无效的 SSH_AUTH_SOCK 覆盖</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -423,7 +423,7 @@ email</source>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 覆盖值可能无效。
+        <translation>SSH_AUTH_SOCK 覆盖值可能无效。
 
 %1
 

--- a/localization/localization_zh_Hant.ts
+++ b/localization/localization_zh_Hant.ts
@@ -156,17 +156,17 @@
     <message>
         <location filename="../src/configdialog.ui" line="888"/>
         <source>SSH_AUTH_SOCK override:</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 覆寫：</translation>
+        <translation>SSH_AUTH_SOCK 覆寫：</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation type="unfinished">覆寫 SSH_AUTH_SOCK 的可選路徑。留空透過 gpgconf 自動偵測 (issue #543)。</translation>
+        <translation>覆寫 SSH_AUTH_SOCK 的可選路徑。留空透過 gpgconf 自動偵測 (issue #543)。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
         <source>(auto-probe via gpgconf)</source>
-        <translation type="unfinished">（透過 gpgconf 自動偵測）</translation>
+        <translation>（透過 gpgconf 自動偵測）</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="973"/>
@@ -418,22 +418,22 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation type="unfinished">路徑不存在。</translation>
+        <translation>路徑不存在。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
         <source>The path is not readable.</source>
-        <translation type="unfinished">路徑無法讀取。</translation>
+        <translation>路徑無法讀取。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="272"/>
         <source>The path is not a Unix domain socket.</source>
-        <translation type="unfinished">路徑不是 Unix 網域 socket。</translation>
+        <translation>路徑不是 Unix 網域 socket。</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="278"/>
         <source>Potentially invalid SSH_AUTH_SOCK override</source>
-        <translation type="unfinished">可能無效的 SSH_AUTH_SOCK 覆寫</translation>
+        <translation>可能無效的 SSH_AUTH_SOCK 覆寫</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="279"/>
@@ -442,7 +442,7 @@ email</translation>
 %1
 
 The value will still be saved as entered.</source>
-        <translation type="unfinished">SSH_AUTH_SOCK 覆寫值可能無效。
+        <translation>SSH_AUTH_SOCK 覆寫值可能無效。
 
 %1
 


### PR DESCRIPTION
## Summary

Reviewed every translation in the 31 locales sitting between 95% and 99.9% finished — all of them had non-empty `<translation type="unfinished">` entries from earlier rounds (mostly the SSH_AUTH_SOCK + override-warn strings from #1438/#1439).

Each translation:
- preserves placeholders (`%1`) and source punctuation
- matches established locale terminology (e.g. zh_CN/zh_Hant `覆盖`/`覆寫`, sr_Cyrl/sr_RS `надјачавање`/`nadjačavanje`, ja `上書き`)
- reads naturally as a UI label / message body

Promoted to "finished" by stripping `type="unfinished"`.

### One terminology fix on the way

- **zh_CN** "Potentially invalid SSH_AUTH_SOCK override" was rendered `SSH_AUTH_SOCK 覆盖值可能无效` (= "SSH_AUTH_SOCK override value may be invalid") — awkward as a dialog title. Re-ordered to `可能无效的 SSH_AUTH_SOCK 覆盖`, matching the natural Chinese pattern and the existing zh_Hant rendering.

### Locales touched (31, all now 312/312 finished)

`cy, es_UY, et, fi, fr_BE, fr_LU, fy_NL, gl, hi, hr, hu, id, ja, ko, lb_LU, lt, lv, nl_BE, pa_IN, ro, si, sq, sr_Cyrl, sr_RS, sw, ta, te, uk, ur, zh_CN, zh_Hant`

### Out of scope (per request)

`he`, `en_US`, `ru` — sitting at 13.4% / 63.1% / 69.2% with hundreds of pre-existing untranslated entries.

## Test plan

- [x] `lrelease6` on every touched .ts: 312 finished + 0 unfinished, no errors
- [x] Spot-checked translations: placeholders preserved, no broken HTML, terminology matches existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Completed translations in 25+ languages for configuration dialog validation messages and SSH authentication settings, improving support for Welsh, Spanish, Estonian, Finnish, French, Dutch, Korean, Japanese, Chinese, and many other languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1460)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->