### PR TITLE
fix(security): chmod 0600 on .gpg-id after write

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -269,6 +269,12 @@ void ImitatePass::writeGpgIdFile(const QString &gpgIdFile,
     }
   }
   gpgId.close();
+  // Lock the file to owner-only access. The .gpg-id leaks which keys the
+  // store is encrypted to; while the typical ~/.password-store is 0700,
+  // users may relocate the store onto NFS/SMB/USB where the parent dir
+  // perms are more lax. On platforms where setPermissions is a no-op
+  // (Windows), this is silently best-effort.
+  QFile::setPermissions(gpgIdFile, QFile::ReadOwner | QFile::WriteOwner);
   if (!secret_selected) {
     emit critical(
         tr("Check selected users!"),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1523,6 +1523,10 @@ void MainWindow::addFolder() {
       }
     }
     gpgId.close();
+    // Lock to owner-only access; see ImitatePass::writeGpgIdFile for
+    // rationale (NFS / USB / unusual umask scenarios). Best-effort on
+    // platforms where setPermissions is a no-op.
+    QFile::setPermissions(gpgIdFile, QFile::ReadOwner | QFile::WriteOwner);
   }
 }
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -2310,14 +2310,17 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
 
   ::umask(oldUmask);
 
-  QVERIFY2(QFile::exists(gpgIdFile), "gpg id file must exist after writeGpgIdFile");
+  QVERIFY2(QFile::exists(gpgIdFile),
+           "gpg id file must exist after writeGpgIdFile");
   const QFile::Permissions perms = QFile(gpgIdFile).permissions();
   QVERIFY2(perms.testFlag(QFile::ReadOwner), "expected ReadOwner to be set");
   QVERIFY2(perms.testFlag(QFile::WriteOwner), "expected WriteOwner to be set");
   QVERIFY2(!perms.testFlag(QFile::ReadGroup), "expected ReadGroup to be unset");
-  QVERIFY2(!perms.testFlag(QFile::WriteGroup), "expected WriteGroup to be unset");
+  QVERIFY2(!perms.testFlag(QFile::WriteGroup),
+           "expected WriteGroup to be unset");
   QVERIFY2(!perms.testFlag(QFile::ReadOther), "expected ReadOther to be unset");
-  QVERIFY2(!perms.testFlag(QFile::WriteOther), "expected WriteOther to be unset");
+  QVERIFY2(!perms.testFlag(QFile::WriteOther),
+           "expected WriteOther to be unset");
   QVERIFY2(!perms.testFlag(QFile::ExeOwner), "expected ExeOwner to be unset");
   QVERIFY2(!perms.testFlag(QFile::ExeGroup), "expected ExeGroup to be unset");
   QVERIFY2(!perms.testFlag(QFile::ExeOther), "expected ExeOther to be unset");

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -2312,12 +2312,12 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
 
   QVERIFY(QFile::exists(gpgIdFile));
   const QFile::Permissions perms = QFile(gpgIdFile).permissions();
-  QVERIFY(perms.testFlag(QFile::ReadOwner));
-  QVERIFY(perms.testFlag(QFile::WriteOwner));
-  QVERIFY(!perms.testFlag(QFile::ReadGroup));
-  QVERIFY(!perms.testFlag(QFile::WriteGroup));
-  QVERIFY(!perms.testFlag(QFile::ReadOther));
-  QVERIFY(!perms.testFlag(QFile::WriteOther));
+  QVERIFY2(perms.testFlag(QFile::ReadOwner), "expected ReadOwner to be set");
+  QVERIFY2(perms.testFlag(QFile::WriteOwner), "expected WriteOwner to be set");
+  QVERIFY2(!perms.testFlag(QFile::ReadGroup), "expected ReadGroup to be unset");
+  QVERIFY2(!perms.testFlag(QFile::WriteGroup), "expected WriteGroup to be unset");
+  QVERIFY2(!perms.testFlag(QFile::ReadOther), "expected ReadOther to be unset");
+  QVERIFY2(!perms.testFlag(QFile::WriteOther), "expected WriteOther to be unset");
 #endif
 }
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -2318,6 +2318,9 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
   QVERIFY2(!perms.testFlag(QFile::WriteGroup), "expected WriteGroup to be unset");
   QVERIFY2(!perms.testFlag(QFile::ReadOther), "expected ReadOther to be unset");
   QVERIFY2(!perms.testFlag(QFile::WriteOther), "expected WriteOther to be unset");
+  QVERIFY2(!perms.testFlag(QFile::ExeOwner), "expected ExeOwner to be unset");
+  QVERIFY2(!perms.testFlag(QFile::ExeGroup), "expected ExeGroup to be unset");
+  QVERIFY2(!perms.testFlag(QFile::ExeOther), "expected ExeOther to be unset");
 #endif
 }
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -10,6 +10,9 @@
 #include <QTemporaryDir>
 #include <QUuid>
 #include <QtTest>
+#ifndef Q_OS_WIN
+#include <sys/stat.h>
+#endif
 
 #include "../../../src/enums.h"
 #include "../../../src/filecontent.h"
@@ -221,6 +224,8 @@ private Q_SLOTS:
   void isPathInStoreRejectsSymlinkEscape();
   void isPathInStoreAllowsNewChild();
   void isPathInStoreRejectsEmptyArgs();
+  // .gpg-id permission hardening (security)
+  void writeGpgIdFileSetsOwnerOnlyPerms();
 };
 
 /**
@@ -2274,6 +2279,46 @@ void tst_util::isPathInStoreRejectsEmptyArgs() {
   // Non-existent root.
   QVERIFY(!Util::isPathInStore(QStringLiteral("/no/such/dir"),
                                QStringLiteral("/no/such/dir/foo")));
+}
+
+/**
+ * @brief writeGpgIdFile should lock the produced .gpg-id to owner-only
+ *        permissions, regardless of the process umask. On Windows
+ *        setPermissions is best-effort and Qt's Unix-permission bits don't
+ *        round-trip, so the assertion is Unix-only.
+ */
+void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
+#ifdef Q_OS_WIN
+  QSKIP("Unix permission bits don't round-trip through Qt on Windows");
+#else
+  QTemporaryDir tempDir;
+  QVERIFY(tempDir.isValid());
+  const QString gpgIdFile = tempDir.path() + "/.gpg-id";
+
+  // Force a permissive umask so we know the close() would have produced
+  // 0644 in the absence of our setPermissions call.
+  const mode_t oldUmask = ::umask(0022);
+
+  UserInfo user;
+  user.key_id = QStringLiteral("ABCDEF1234567890");
+  user.enabled = true;
+  user.have_secret = true;
+  QList<UserInfo> users{user};
+
+  ImitatePass pass;
+  pass.writeGpgIdFile(gpgIdFile, users);
+
+  ::umask(oldUmask);
+
+  QVERIFY(QFile::exists(gpgIdFile));
+  const QFile::Permissions perms = QFile(gpgIdFile).permissions();
+  QVERIFY(perms.testFlag(QFile::ReadOwner));
+  QVERIFY(perms.testFlag(QFile::WriteOwner));
+  QVERIFY(!perms.testFlag(QFile::ReadGroup));
+  QVERIFY(!perms.testFlag(QFile::WriteGroup));
+  QVERIFY(!perms.testFlag(QFile::ReadOther));
+  QVERIFY(!perms.testFlag(QFile::WriteOther));
+#endif
 }
 
 QTEST_MAIN(tst_util)

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -2292,7 +2292,7 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
   QSKIP("Unix permission bits don't round-trip through Qt on Windows");
 #else
   QTemporaryDir tempDir;
-  QVERIFY(tempDir.isValid());
+  QVERIFY2(tempDir.isValid(), "tempDir should be valid after creation");
   const QString gpgIdFile = tempDir.path() + "/.gpg-id";
 
   // Force a permissive umask so we know the close() would have produced
@@ -2310,7 +2310,7 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
 
   ::umask(oldUmask);
 
-  QVERIFY(QFile::exists(gpgIdFile));
+  QVERIFY2(QFile::exists(gpgIdFile), "gpg id file must exist after writeGpgIdFile");
   const QFile::Permissions perms = QFile(gpgIdFile).permissions();
   QVERIFY2(perms.testFlag(QFile::ReadOwner), "expected ReadOwner to be set");
   QVERIFY2(perms.testFlag(QFile::WriteOwner), "expected WriteOwner to be set");


### PR DESCRIPTION
## Summary

`.gpg-id` lists the GPG key IDs (often full fingerprints) that a password store sub-tree is encrypted to. Default-umask creation leaves it world-readable (0644 with the typical 0022 umask).

While `~/.password-store` itself is normally `0700` and protects the file in practice, users who relocate the store onto NFS / SMB / USB / a FS with a more permissive parent mode lose that protection. The file leaks both **who can decrypt the store** and (for full fingerprints) **the long-term identity of the recipients**.

## Change

Apply `QFile::setPermissions(ReadOwner | WriteOwner)` (= 0600 on Unix; best-effort no-op on Windows) immediately after the `close()` call. Two write sites:

- `ImitatePass::writeGpgIdFile` — recipient edits via the Users dialog
- `MainWindow::addFolder` — when "Add a .gpg-id when creating a new folder" is enabled in settings

## Tests

- `tst_util::writeGpgIdFileSetsOwnerOnlyPerms` — forces `umask 0022`, runs `ImitatePass::writeGpgIdFile`, asserts `QFile::permissions` is `ReadOwner|WriteOwner` only. Unix-only (Qt's permission bits don't round-trip through Windows ACLs).

## Test plan

- [x] `qmake6 -r && make -j4` clean
- [x] `tests/auto/util/tst_util` — 114 passed (was 113, +1 new)
- [x] `doxygen Doxyfile` — zero warnings
- [x] `clang-format` applied
- [x] Manual: created a new folder with addGPGId enabled, verified `ls -la .gpg-id` shows `-rw-------`
- [x] Manual: edited recipients via Users dialog, same result

## Diff

3 files changed, 55 insertions (≈9 lines of production code + comments, the rest is the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Files created by the app (including when adding folders via the UI) are now explicitly set to owner-only read/write permissions after creation to reduce exposure on permissive filesystems.

* **Tests**
  * Added an automated, platform-aware test that verifies .gpg-id files are created with owner-only permissions; the test is skipped on unsupported platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1465)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->