### PR TITLE
test(storemodel): regression tests for path-traversal rejection in dropMimeData

### DIFF
--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -31,6 +31,9 @@ private Q_SLOTS:
   void canDropFileOnDir();
   void canDropFileOnFile();
   void canDropDirOnFile();
+  void dropMimeDataRejectsSourceOutsideStore();
+  void dropMimeDataRejectsAbsoluteOutsideSource();
+  void dropMimeDataRejectsSymlinkEscape();
   void lessThan();
   void lessThanDirsFirst();
   void supportedDropActions();
@@ -454,6 +457,65 @@ void tst_storemodel::canDropDirOnFile() {
                            fx.folderPath);
   QVERIFY(
       !fx.sm.canDropMimeData(mime.get(), Qt::MoveAction, 0, 0, fx.fileProxy()));
+}
+
+// ---------------------------------------------------------------------------
+// dropMimeData() path-traversal rejection (security regression for #1464)
+//
+// canDropMimeData is a UI policy layer (kind/column/MIME-type constraints)
+// and intentionally does not touch the filesystem. The store-boundary check
+// lives one layer down in executeDropAction. These tests exercise that
+// layer with crafted mime data whose source path escapes the store and
+// verify the drop is refused (returns false) without ever reaching Pass::Move
+// or Pass::Copy.
+// ---------------------------------------------------------------------------
+
+void tst_storemodel::dropMimeDataRejectsSourceOutsideStore() {
+  DropFixture fx;
+  // The fs model rooted at the store has no concept of /etc/passwd as a
+  // child; crafting that path into the mime payload simulates a malicious
+  // (or buggy) source that doesn't go through StoreModel::mimeData().
+  auto mime = makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File,
+                           QStringLiteral("/etc/passwd"));
+  QVERIFY2(
+      !fx.sm.dropMimeData(mime.get(), Qt::MoveAction, 0, 0, fx.folderProxy()),
+      "drop with src=/etc/passwd must be refused");
+}
+
+void tst_storemodel::dropMimeDataRejectsAbsoluteOutsideSource() {
+  DropFixture fx;
+  // Use a path inside QTemporaryDir's parent (system tempdir) but outside
+  // the store to exercise the canonical-path check on a path that exists
+  // on disk, not just one that the filesystem can't resolve.
+  QTemporaryDir outside;
+  QVERIFY2(outside.isValid(), "outside temp dir should be valid");
+  auto mime = makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File,
+                           outside.path() + "/elsewhere.gpg");
+  QVERIFY2(
+      !fx.sm.dropMimeData(mime.get(), Qt::CopyAction, 0, 0, fx.folderProxy()),
+      "drop with src in a sibling tempdir must be refused");
+}
+
+void tst_storemodel::dropMimeDataRejectsSymlinkEscape() {
+#ifdef Q_OS_WIN
+  QSKIP("symlink creation requires elevation on Windows");
+#else
+  DropFixture fx;
+  // A symlink physically inside the store that resolves outside —
+  // canonical-path resolution catches this even though the path string
+  // starts with the store root.
+  QTemporaryDir outside;
+  QVERIFY2(outside.isValid(), "outside temp dir should be valid");
+  const QString linkPath = fx.tempDir.path() + "/escape";
+  QVERIFY2(QFile::link(outside.path(), linkPath),
+           "QFile::link should create symlink in store");
+
+  auto mime =
+      makeMimeData(dragAndDropInfoPasswordStore::ItemKind::File, linkPath);
+  QVERIFY2(
+      !fx.sm.dropMimeData(mime.get(), Qt::MoveAction, 0, 0, fx.folderProxy()),
+      "drop with src=<symlink-out-of-store> must be refused");
+#endif
 }
 
 QTEST_MAIN(tst_storemodel)


### PR DESCRIPTION
## Summary

#1464 added a canonical-path check in \`StoreModel::executeDropAction\` that refuses any drop whose source or destination resolves outside the password store. That patch shipped with unit tests on the \`Util::isPathInStore\` helper but the integration into the drop flow was only manually verified.

These three regression tests close that gap.

## Tests

| Case | What it crafts | What it asserts |
|---|---|---|
| \`dropMimeDataRejectsSourceOutsideStore\` | mime payload with \`info.path = /etc/passwd\` | \`dropMimeData()\` returns false; never reaches \`Pass::Move\` |
| \`dropMimeDataRejectsAbsoluteOutsideSource\` | source in a sibling \`QTemporaryDir\` (real, existing fs path) | same — exercises canonicalisation on an existing path |
| \`dropMimeDataRejectsSymlinkEscape\` | symlink inside the store pointing at a sibling \`QTemporaryDir\` | \`canonicalFilePath()\` follows the link; rejected. Unix-only. |

\`canDropMimeData\` is a UI-policy layer (kind / column / MIME-type) that intentionally doesn't touch the filesystem — these tests pass through \`canDropMimeData\` and verify the deeper \`executeDropAction\` check is the one doing the work.

## Negative verification

To prove the tests aren't tautologically passing, I temporarily defanged the guard with \`if (false && (...))\` in \`storemodel.cpp\`. With that change all 3 tests **fail**:

\`\`\`
FAIL!  : dropMimeDataRejectsSourceOutsideStore() ... (drop with src=/etc/passwd must be refused)
FAIL!  : dropMimeDataRejectsAbsoluteOutsideSource() ... (drop with src in a sibling tempdir must be refused)
FAIL!  : dropMimeDataRejectsSymlinkEscape() ... (drop with src=<symlink-out-of-store> must be refused)
\`\`\`

Restoring the guard, all pass and the existing \`qWarning("executeDropAction: rejecting drop that escapes the store ...")\` fires for each.

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/model/tst_model\` — 33/33 pass (was 30, +3)
- [x] Verified the tests actually exercise the security boundary (see negative verification above)
- [x] clang-format applied

## Scope

Test-only — no production-code changes. Source-traversal protection only; destination-traversal would require constructing a manipulated \`QModelIndex\` outside the proxy, which has no realistic attack surface in the current UI (the destination always comes from a tree-view click). Skipping happy-path \`dropMimeData\` tests for now: those would need a Pass-singleton stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to improve coverage of drag-and-drop data source validation scenarios, ensuring proper handling of various source configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1466)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->