### PR TITLE
test: bump tests/tests.pri to c++17, drop legacy make_unique workaround

### DIFF
--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -297,10 +297,7 @@ auto makeMimeData(dragAndDropInfoPasswordStore::ItemKind kind,
   QDataStream stream(&encoded, QIODevice::WriteOnly);
   stream << info;
 
-  // std::unique_ptr<T>(new T) rather than std::make_unique<T>() because
-  // tests/tests.pri pins the test build to c++11 (see Qt 5.15 CI), and
-  // make_unique is c++14.
-  std::unique_ptr<QMimeData> mime(new QMimeData);
+  auto mime = std::make_unique<QMimeData>();
   mime->setData("application/vnd+qtpass.dragAndDropInfoPasswordStore", encoded);
   return mime;
 }

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -1,5 +1,5 @@
 !include(../qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 
-CONFIG += testcase qt warn_on depend_includepath testcase no_testcase_installs c++11
+CONFIG += testcase qt warn_on depend_includepath testcase no_testcase_installs c++17
 QT += testlib widgets
 


### PR DESCRIPTION
## Summary

CodeRabbit flagged the comment in \`tst_storemodel.cpp\` claiming
\"make_unique is c++14, tests are pinned to c++11\" as outdated. On investigation:

- \`src/src.pro\` already requires c++17 (project enforces it per CLAUDE.md and uses \`std::as_const\` broadly), so any test that \`#include\`s a src/ header transitively needs the same standard.
- The compile commands produced by \`qmake\` for tests don't actually contain a \`-std=\` flag — gcc 13+ defaults to c++17 anyway, which is why clang-tidy's \`modernize-make-unique\` was firing on this very workaround.

## Changes

- \`tests/tests.pri\`: \`c++11\` → \`c++17\`, matching \`src/src.pro\` and matching reality.
- \`tst_storemodel.cpp\`: replace the \`std::unique_ptr<T>(new T)\` / 3-line comment dance with a plain \`std::make_unique<QMimeData>()\`.

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/model/tst_model\` — 33/33
- [x] \`tests/auto/util/tst_util\` — 120/120

## Other CodeRabbit nits (deliberately skipped)

- \`DF9\` → \`DF_9\` rename — it's the only file-scope constant with a number suffix in tst_util.cpp; no other example to be consistent with.
- Move \`ASSUMED_MAX_KEY_ID_LENGTH\` from function scope to file scope — used in exactly one test; function-scope keeps the magic-number context next to its sole use.
- \`ScopedUmask\` RAII guard — already discussed on #1465; Qt Test doesn't throw, the umask is restored on the very next line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to compile with C++17 standard.
  * Modernized test helper code to use contemporary C++ practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1467)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->