### PR TITLE
fix: rename internal drag-drop MIME type to RFC 6838 form

### DIFF
--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -193,7 +193,7 @@ auto StoreModel::flags(const QModelIndex &index) const -> Qt::ItemFlags {
  */
 auto StoreModel::mimeTypes() const -> QStringList {
   QStringList types;
-  types << "application/vnd+qtpass.dragAndDropInfoPasswordStore";
+  types << "application/vnd.qtpass.dragAndDropInfoPasswordStore";
   return types;
 }
 
@@ -223,7 +223,7 @@ auto StoreModel::mimeData(const QModelIndexList &indexes) const -> QMimeData * {
   }
 
   auto *mimeData = new QMimeData();
-  mimeData->setData("application/vnd+qtpass.dragAndDropInfoPasswordStore",
+  mimeData->setData("application/vnd.qtpass.dragAndDropInfoPasswordStore",
                     encodedData);
   return mimeData;
 }
@@ -248,12 +248,12 @@ auto StoreModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
 #endif
 
   if (data == nullptr ||
-      !data->hasFormat("application/vnd+qtpass.dragAndDropInfoPasswordStore")) {
+      !data->hasFormat("application/vnd.qtpass.dragAndDropInfoPasswordStore")) {
     return false;
   }
 
   QByteArray encodedData =
-      data->data("application/vnd+qtpass.dragAndDropInfoPasswordStore");
+      data->data("application/vnd.qtpass.dragAndDropInfoPasswordStore");
   if (encodedData.isEmpty()) {
     return false;
   }
@@ -324,7 +324,7 @@ auto StoreModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
 auto StoreModel::parseDropData(const QMimeData *data,
                                dragAndDropInfoPasswordStore *outInfo) -> bool {
   QByteArray encodedData =
-      data->data("application/vnd+qtpass.dragAndDropInfoPasswordStore");
+      data->data("application/vnd.qtpass.dragAndDropInfoPasswordStore");
   if (encodedData.isEmpty()) {
     return false;
   }

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
 // SPDX-License-Identifier: GPL-3.0-or-later
+#include <memory>
+
 #include <QDataStream>
 #include <QDir>
 #include <QFileSystemModel>
 #include <QMimeData>
 #include <QtTest>
-
-#include <memory>
 
 #include "../../../src/storemodel.h"
 
@@ -102,7 +102,7 @@ void tst_storemodel::mimeTypes() {
   StoreModel sm;
   QStringList types = sm.mimeTypes();
   QVERIFY(
-      types.contains("application/vnd+qtpass.dragAndDropInfoPasswordStore"));
+      types.contains("application/vnd.qtpass.dragAndDropInfoPasswordStore"));
 }
 
 void tst_storemodel::lessThan() {
@@ -220,7 +220,7 @@ void tst_storemodel::mimeData() {
   QMimeData *data = sm.mimeData(QModelIndexList() << proxyIndex);
   QVERIFY(data != nullptr);
   QVERIFY(
-      data->hasFormat("application/vnd+qtpass.dragAndDropInfoPasswordStore"));
+      data->hasFormat("application/vnd.qtpass.dragAndDropInfoPasswordStore"));
   delete data;
 }
 
@@ -298,7 +298,7 @@ auto makeMimeData(dragAndDropInfoPasswordStore::ItemKind kind,
   stream << info;
 
   auto mime = std::make_unique<QMimeData>();
-  mime->setData("application/vnd+qtpass.dragAndDropInfoPasswordStore", encoded);
+  mime->setData("application/vnd.qtpass.dragAndDropInfoPasswordStore", encoded);
   return mime;
 }
 
@@ -404,7 +404,7 @@ void tst_storemodel::canDropWrongMimeType() {
 void tst_storemodel::canDropEmptyEncodedData() {
   DropFixture fx;
   QMimeData mime;
-  mime.setData("application/vnd+qtpass.dragAndDropInfoPasswordStore",
+  mime.setData("application/vnd.qtpass.dragAndDropInfoPasswordStore",
                QByteArray());
   QVERIFY(
       !fx.sm.canDropMimeData(&mime, Qt::MoveAction, 0, 0, fx.folderProxy()));

--- a/tests/auto/model/tst_storemodel.cpp
+++ b/tests/auto/model/tst_storemodel.cpp
@@ -101,8 +101,10 @@ void tst_storemodel::flagsWithInvalidIndex() {
 void tst_storemodel::mimeTypes() {
   StoreModel sm;
   QStringList types = sm.mimeTypes();
-  QVERIFY(
-      types.contains("application/vnd.qtpass.dragAndDropInfoPasswordStore"));
+  QVERIFY2(
+      types.contains("application/vnd.qtpass.dragAndDropInfoPasswordStore"),
+      "mimeTypes() should advertise "
+      "application/vnd.qtpass.dragAndDropInfoPasswordStore");
 }
 
 void tst_storemodel::lessThan() {
@@ -218,9 +220,11 @@ void tst_storemodel::mimeData() {
   QModelIndex sourceIndex = fsm.index(tempDir.path() + "/testfile.gpg");
   QModelIndex proxyIndex = sm.mapFromSource(sourceIndex);
   QMimeData *data = sm.mimeData(QModelIndexList() << proxyIndex);
-  QVERIFY(data != nullptr);
-  QVERIFY(
-      data->hasFormat("application/vnd.qtpass.dragAndDropInfoPasswordStore"));
+  QVERIFY2(data != nullptr, "mimeData() should return a non-null QMimeData");
+  QVERIFY2(
+      data->hasFormat("application/vnd.qtpass.dragAndDropInfoPasswordStore"),
+      "mimeData() should carry "
+      "application/vnd.qtpass.dragAndDropInfoPasswordStore");
   delete data;
 }
 


### PR DESCRIPTION
## Summary

CodeRabbit flagged that the internal drag-drop MIME identifier
\`application/vnd+qtpass.dragAndDropInfoPasswordStore\` is malformed per RFC 6838:

- \`+\` is reserved for **structured-syntax suffixes** (e.g. \`application/atom+xml\`)
- the **vendor-tree separator is \`.\`** — the right form is \`application/vnd.qtpass.dragAndDropInfoPasswordStore\`

## Scope

Internal-only identifier — drag/drop happens between QtPass widgets in the same process. No external compatibility concern.

9 occurrences renamed in lockstep:

- \`src/storemodel.cpp\`: \`mimeTypes()\`, \`mimeData()\`, \`canDropMimeData()\` ×2, \`parseDropData()\`
- \`tests/auto/model/tst_storemodel.cpp\`: 4 assertions + the \`makeMimeData\` helper

Also moved \`<memory>\` to live with the C++ stdlib headers above the Qt headers, matching the stdlib-then-Qt-then-project convention.

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/model/tst_model\` — 33/33

## Other CodeRabbit nits in tst_util.cpp (re-evaluated, still skipped)

- \`DF9\` → \`DF_9\` rename — only file-scope constant with a number suffix; no other example to be consistent with
- Hoist \`ASSUMED_MAX_KEY_ID_LENGTH\` to file scope — used in exactly one test
- \`ScopedUmask\` RAII guard — Qt Test doesn't throw on assertion failures

Same rationale as #1467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the drag-and-drop MIME format so password store items are correctly recognized and transferred, restoring reliable drag-and-drop behavior across the app.

* **Tests**
  * Updated automated tests to validate the corrected drag-and-drop format and ensure consistent behavior going forward.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1468)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->