### PR TITLE
test: cover SSH_AUTH_SOCK override soft-validation via Util helper

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -11,7 +11,6 @@
 #include <QClipboard>
 #include <QDir>
 #include <QFileDialog>
-#include <QFileInfo>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSystemTrayIcon>
@@ -19,10 +18,6 @@
 #include <utility>
 #ifdef Q_OS_WIN
 #include <windows.h>
-#endif
-
-#ifdef Q_OS_UNIX
-#include <sys/stat.h>
 #endif
 
 #ifdef QT_DEBUG
@@ -258,21 +253,19 @@ void ConfigDialog::on_accepted() {
   const QString sshAuthSockOverride = ui->sshAuthSockOverride->text().trimmed();
   if (!sshAuthSockOverride.isEmpty()) {
     QString reason;
-    QFileInfo fi(sshAuthSockOverride);
-    if (!fi.exists()) {
+    switch (Util::sshAuthSockOverrideStatus(sshAuthSockOverride)) {
+    case Util::SshAuthSockOverrideStatus::Valid:
+      break;
+    case Util::SshAuthSockOverrideStatus::DoesNotExist:
       reason = tr("The path does not exist.");
-    } else if (!fi.isReadable()) {
+      break;
+    case Util::SshAuthSockOverrideStatus::NotReadable:
       reason = tr("The path is not readable.");
+      break;
+    case Util::SshAuthSockOverrideStatus::NotUnixDomainSocket:
+      reason = tr("The path is not a Unix domain socket.");
+      break;
     }
-#ifdef Q_OS_UNIX
-    if (reason.isEmpty()) {
-      struct stat st;
-      if (::stat(sshAuthSockOverride.toLocal8Bit().constData(), &st) != 0 ||
-          !S_ISSOCK(st.st_mode)) {
-        reason = tr("The path is not a Unix domain socket.");
-      }
-    }
-#endif
     if (!reason.isEmpty()) {
       QMessageBox::warning(
           this, tr("Potentially invalid SSH_AUTH_SOCK override"),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,6 +27,7 @@
 #ifdef Q_OS_WIN
 #include <windows.h>
 #else
+#include <sys/stat.h>
 #include <sys/time.h>
 #endif
 #include "qtpasssettings.h"
@@ -283,6 +284,29 @@ auto Util::isPathInStore(const QString &storeRoot, const QString &candidate)
   }
   return resolved == rootCanon ||
          resolved.startsWith(rootCanon + QLatin1Char('/'));
+}
+
+auto Util::sshAuthSockOverrideStatus(const QString &path)
+    -> SshAuthSockOverrideStatus {
+  const QFileInfo fi(path);
+  if (!fi.exists()) {
+    return SshAuthSockOverrideStatus::DoesNotExist;
+  }
+  if (!fi.isReadable()) {
+    return SshAuthSockOverrideStatus::NotReadable;
+  }
+#ifdef Q_OS_UNIX
+  // S_ISSOCK isn't exposed by QFileInfo; go through stat(2). On Windows
+  // ssh-agent uses a named pipe (\\.\pipe\openssh-ssh-agent.<sid>) and the
+  // socket check would always fail, so skip it there — exists + readable is
+  // the best we can do.
+  struct stat st{};
+  if (::stat(path.toLocal8Bit().constData(), &st) != 0 ||
+      !S_ISSOCK(st.st_mode)) {
+    return SshAuthSockOverrideStatus::NotUnixDomainSocket;
+  }
+#endif
+  return SshAuthSockOverrideStatus::Valid;
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -20,6 +20,34 @@ class StoreModel;
 class Util {
 public:
   /**
+   * @brief Classify a non-empty SSH_AUTH_SOCK override path supplied by the
+   *        user.
+   *
+   * Empty / unset input is handled by the caller (no warning when the field
+   * is blank). For a non-empty path, this returns one of:
+   *
+   * - `Valid` — exists, readable, and on Unix is a Unix domain socket.
+   * - `DoesNotExist` — `QFileInfo::exists()` returned false.
+   * - `NotReadable` — exists but `QFileInfo::isReadable()` returned false.
+   * - `NotUnixDomainSocket` — Unix-only: `stat()` says it's not `S_ISSOCK`.
+   *
+   * On Windows the socket check is skipped — ssh-agent uses a named pipe.
+   */
+  enum class SshAuthSockOverrideStatus {
+    Valid,
+    DoesNotExist,
+    NotReadable,
+    NotUnixDomainSocket,
+  };
+  /**
+   * @brief Validate an SSH_AUTH_SOCK override path. Caller is expected to
+   *        skip validation when the input is empty / whitespace-only.
+   * @param path Non-empty candidate path.
+   * @return Classification per SshAuthSockOverrideStatus.
+   */
+  static auto sshAuthSockOverrideStatus(const QString &path)
+      -> SshAuthSockOverrideStatus;
+  /**
    * @brief Locate an executable by searching the process PATH and (on Windows)
    * falling back to WSL.
    * @param binary Executable name or relative path to locate (e.g., "gpg" or

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -11,7 +11,12 @@
 #include <QUuid>
 #include <QtTest>
 #ifndef Q_OS_WIN
+#include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cstring>
 #endif
 
 #include "../../../src/enums.h"
@@ -226,6 +231,11 @@ private Q_SLOTS:
   void isPathInStoreRejectsEmptyArgs();
   // .gpg-id permission hardening (security)
   void writeGpgIdFileSetsOwnerOnlyPerms();
+  // SSH_AUTH_SOCK override soft-validation (Settings dialog warning)
+  void sshAuthSockOverrideStatusDoesNotExist();
+  void sshAuthSockOverrideStatusRegularFileRejected();
+  void sshAuthSockOverrideStatusNotReadable();
+  void sshAuthSockOverrideStatusValid();
 };
 
 /**
@@ -2324,6 +2334,116 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
   QVERIFY2(!perms.testFlag(QFile::ExeOwner), "expected ExeOwner to be unset");
   QVERIFY2(!perms.testFlag(QFile::ExeGroup), "expected ExeGroup to be unset");
   QVERIFY2(!perms.testFlag(QFile::ExeOther), "expected ExeOther to be unset");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Util::sshAuthSockOverrideStatus tests
+//
+// Backs the Settings dialog soft-warning logic added in #1439. The dialog
+// shows a non-blocking warning when the user-typed override path is bogus
+// (missing, unreadable, or not a Unix domain socket) but still saves the
+// value as entered. These tests drive the pure validation function directly
+// so we don't need a Qt event loop / QMessageBox spy.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief A non-existent path is classified DoesNotExist.
+ */
+void tst_util::sshAuthSockOverrideStatusDoesNotExist() {
+  QTemporaryDir tmp;
+  QVERIFY2(tmp.isValid(), "tmp dir should be valid");
+  QCOMPARE(Util::sshAuthSockOverrideStatus(tmp.path() + "/no-such-socket"),
+           Util::SshAuthSockOverrideStatus::DoesNotExist);
+}
+
+/**
+ * @brief A regular file that exists but isn't a Unix domain socket is
+ *        rejected on Unix. Skipped on Windows where the socket check is a
+ *        no-op (ssh-agent uses a named pipe there).
+ */
+void tst_util::sshAuthSockOverrideStatusRegularFileRejected() {
+#ifdef Q_OS_WIN
+  QSKIP("socket-type check is Unix-only");
+#else
+  QTemporaryDir tmp;
+  QVERIFY2(tmp.isValid(), "tmp dir should be valid");
+  const QString filePath = tmp.path() + "/regular-file";
+  QFile f(filePath);
+  QVERIFY2(f.open(QIODevice::WriteOnly), "should be able to create a file");
+  f.close();
+  QCOMPARE(Util::sshAuthSockOverrideStatus(filePath),
+           Util::SshAuthSockOverrideStatus::NotUnixDomainSocket);
+#endif
+}
+
+/**
+ * @brief A file that exists but has no read permission is classified
+ *        NotReadable. Skipped on Windows because Qt's permission bits
+ *        don't round-trip the same way.
+ */
+void tst_util::sshAuthSockOverrideStatusNotReadable() {
+#ifdef Q_OS_WIN
+  QSKIP("Unix permission bits don't round-trip on Windows");
+#else
+  // Root user on Linux ignores read-mode bits, so the test would
+  // falsely return Valid. Skip in that case.
+  if (::geteuid() == 0) {
+    QSKIP("root sees all files as readable; skip");
+  }
+  QTemporaryDir tmp;
+  QVERIFY2(tmp.isValid(), "tmp dir should be valid");
+  const QString filePath = tmp.path() + "/unreadable";
+  QFile f(filePath);
+  QVERIFY2(f.open(QIODevice::WriteOnly), "should be able to create a file");
+  f.close();
+  QVERIFY2(QFile::setPermissions(filePath, QFile::Permissions{}),
+           "should be able to chmod 0 on the file");
+  QCOMPARE(Util::sshAuthSockOverrideStatus(filePath),
+           Util::SshAuthSockOverrideStatus::NotReadable);
+  // Restore something so QTemporaryDir can clean up.
+  QFile::setPermissions(filePath, QFile::ReadOwner | QFile::WriteOwner);
+#endif
+}
+
+/**
+ * @brief A real Unix domain socket (bind(2)) is classified Valid.
+ *        Unix-only.
+ */
+void tst_util::sshAuthSockOverrideStatusValid() {
+#ifdef Q_OS_WIN
+  QSKIP("socket creation API differs on Windows");
+#else
+  QTemporaryDir tmp;
+  QVERIFY2(tmp.isValid(), "tmp dir should be valid");
+  const QString sockPath = tmp.path() + "/agent.sock";
+  const QByteArray sockBytes = sockPath.toLocal8Bit();
+
+  // sun_path is typically 108 bytes on Linux; QTemporaryDir gives us a
+  // short /tmp/qttest_XXXXXX prefix, so this should fit easily.
+  QVERIFY2(sockBytes.size() < static_cast<int>(sizeof(sockaddr_un{}.sun_path)),
+           "socket path too long for sockaddr_un");
+
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  QVERIFY2(fd >= 0, "socket(AF_UNIX) failed");
+
+  sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::memcpy(addr.sun_path, sockBytes.constData(),
+              static_cast<size_t>(sockBytes.size()));
+
+  const int br = ::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+  if (br != 0) {
+    ::close(fd);
+    QFAIL("bind(AF_UNIX) failed");
+  }
+
+  QCOMPARE(Util::sshAuthSockOverrideStatus(sockPath),
+           Util::SshAuthSockOverrideStatus::Valid);
+
+  ::close(fd);
+  // QTemporaryDir will rm -rf the directory on destruction, removing the
+  // socket file along with it.
 #endif
 }
 


### PR DESCRIPTION
## Summary

The Settings dialog warning logic added in #1439 (\`ConfigDialog::on_accepted\` SSH_AUTH_SOCK override soft-check) had **zero unit tests**. Adding tests directly on the dialog needs a Qt event loop and a \`QMessageBox\` spy, which is heavyweight and brittle. Instead: extract the validation rules into a pure helper, switch the dialog to use it, then test the helper directly.

## Production changes (mechanical, no semantic diff)

- **\`Util::sshAuthSockOverrideStatus(QString)\`** — new public helper returning an enum:
  - \`Valid\` — exists, readable, and on Unix is a Unix domain socket
  - \`DoesNotExist\`
  - \`NotReadable\`
  - \`NotUnixDomainSocket\` (Unix-only check)
- **\`ConfigDialog::on_accepted\`** — three inline \`if/else\` branches replaced by a \`switch\` over the enum. Translation strings stay in ConfigDialog (Util has no \`tr()\` callers).
- Dropped now-unused \`#include <QFileInfo>\` and \`#include <sys/stat.h>\` from \`configdialog.cpp\`.

## Tests

| Case | What it sets up |
|---|---|
| \`sshAuthSockOverrideStatusDoesNotExist\` | path that doesn't exist |
| \`sshAuthSockOverrideStatusRegularFileRejected\` | regular file in a tempdir (Unix only) |
| \`sshAuthSockOverrideStatusNotReadable\` | \`chmod 0\` on a file (Unix only; skipped under root since euid 0 ignores mode bits) |
| \`sshAuthSockOverrideStatusValid\` | \`socket(AF_UNIX)\` + \`bind\` a real Unix domain socket and assert \`Valid\` |

POSIX \`socket(2)\`/\`bind(2)\` rather than \`QLocalServer\` to avoid pulling \`QtNetwork\` into the util test target. Unix-only tests SKIP on Windows where the production code also skips the socket check.

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/util/tst_util\` — 124/124 (was 120, +4)
- [x] Doxygen — no new warnings
- [x] \`clang-format\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH_AUTH_SOCK override validation now provides detailed error feedback for missing paths, unreadable files, and invalid socket types on Unix systems.

* **Tests**
  * Added comprehensive test coverage for SSH_AUTH_SOCK override validation, including non-existent paths, regular files, permission issues, and valid Unix domain sockets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1469)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->