### PR TITLE
test(integration): grep skips files that gpg can't decrypt

### DIFF
--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -13,6 +13,8 @@
  *   - pass otp extension (optional – OTP tests skipped when absent)
  */
 
+#include <algorithm>
+
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -399,7 +401,8 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   ImitatePass pass;
   INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
-  QVERIFY(QDir(storeDir.path()).mkpath("work"));
+  QVERIFY2(QDir(storeDir.path()).mkpath("work"),
+           ("failed to create work directory at " + storeDir.path()).toUtf8());
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -426,7 +429,8 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   c1.close();
   QFile c2(corrupt2);
   QVERIFY2(c2.open(QIODevice::WriteOnly), "should create corrupt.gpg");
-  c2.write("\xFF\xFE\x00\x01 binary junk\n", 24);
+  QByteArray corruptData("\xFF\xFE\x00\x01 binary junk\n", 17);
+  c2.write(corruptData);
   c2.close();
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -425,12 +425,14 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   const QString corrupt2 = storeDir.path() + "/corrupt.gpg";
   QFile c1(corrupt1);
   QVERIFY2(c1.open(QIODevice::WriteOnly), "should create garbage-token.gpg");
-  c1.write("not a real gpg payload but contains the token word\n");
+  qint64 bytesWritten1 = c1.write("not a real gpg payload but contains the token word\n");
+  QVERIFY2(bytesWritten1 == 55, "failed to write test payload to c1");
   c1.close();
   QFile c2(corrupt2);
   QVERIFY2(c2.open(QIODevice::WriteOnly), "should create corrupt.gpg");
   QByteArray corruptData("\xFF\xFE\x00\x01 binary junk\n", 17);
-  c2.write(corruptData);
+  qint64 bytesWritten2 = c2.write(corruptData);
+  QVERIFY2(bytesWritten2 == corruptData.size(), "failed to write test payload to c2");
   c2.close();
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -208,6 +208,7 @@ private Q_SLOTS:
   // ImitatePass backend
   void imitatePass_insertAndShow();
   void imitatePass_insertAndGrep();
+  void imitatePass_grepSkipsUndecryptableFiles();
   void imitatePass_insertMoveAndShow();
   void imitatePass_insertCopyAndShow();
   void imitatePass_insertAndRemove();
@@ -382,6 +383,70 @@ void tst_integration::imitatePass_insertAndGrep() {
 
   const auto results = grepSpy[0][0].value<GrepResults>();
   QVERIFY2(results.size() == 2, "grep should find both entries");
+}
+
+// Verifies the env-aware Executor failure path used by
+// ImitatePass::grepMatchFile(): when gpg returns non-zero on a corrupt /
+// foreign .gpg file inside the store, grepScanStore must drop that file's
+// results and keep walking — not abort the whole scan or surface garbage.
+//
+// Plants two legitimate entries, then drops two non-gpg payloads with a
+// .gpg extension into the store (one with the "token" substring and one
+// without, both undecryptable). Grep for "token" must come back with
+// exactly the two legitimate matches.
+void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
+  QTemporaryDir storeDir;
+  ImitatePass pass;
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
+
+  QVERIFY(QDir(storeDir.path()).mkpath("work"));
+
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("work/github"),
+              QStringLiteral("s3cr3t\ntoken: abc123\n"), false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  insertSpy.clear();
+  insertErrorSpy.clear();
+  pass.Insert(QStringLiteral("work/gitlab"),
+              QStringLiteral("another\ntoken: xyz789\n"), false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  // Plant two .gpg files that aren't valid gpg ciphertext at all. Their
+  // file name contains "token" — but since gpg --decrypt will fail with
+  // non-zero exit on the garbage payload, grepMatchFile must throw away
+  // the would-be plaintext (including the embedded "token" substring)
+  // and grepScanStore must continue past the failure.
+  const QString corrupt1 = storeDir.path() + "/work/garbage-token.gpg";
+  const QString corrupt2 = storeDir.path() + "/corrupt.gpg";
+  QFile c1(corrupt1);
+  QVERIFY2(c1.open(QIODevice::WriteOnly), "should create garbage-token.gpg");
+  c1.write("not a real gpg payload but contains the token word\n");
+  c1.close();
+  QFile c2(corrupt2);
+  QVERIFY2(c2.open(QIODevice::WriteOnly), "should create corrupt.gpg");
+  c2.write("\xFF\xFE\x00\x01 binary junk\n", 24);
+  c2.close();
+
+  QSignalSpy grepSpy(&pass, &Pass::finishedGrep);
+  pass.Grep(QStringLiteral("token"));
+  QVERIFY2(waitForSignal(grepSpy, 20000), "finishedGrep not emitted");
+
+  const auto results = grepSpy[0][0].value<GrepResults>();
+  // The two real entries must be present; neither of the corrupt files
+  // may contribute a match even though one contains "token" in its raw
+  // bytes — gpg failed to decrypt them, so grepMatchFile returned empty.
+  QVERIFY2(
+      results.size() == 2,
+      qPrintable(
+          QStringLiteral("expected 2 matches, got %1").arg(results.size())));
+  QStringList paths;
+  for (const auto &pair : results)
+    paths << pair.first;
+  std::sort(paths.begin(), paths.end());
+  QCOMPARE(paths, (QStringList{QStringLiteral("work/github"),
+                               QStringLiteral("work/gitlab")}));
 }
 
 void tst_integration::imitatePass_insertMoveAndShow() {

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -425,8 +425,9 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   const QString corrupt2 = storeDir.path() + "/corrupt.gpg";
   QFile c1(corrupt1);
   QVERIFY2(c1.open(QIODevice::WriteOnly), "should create garbage-token.gpg");
-  qint64 bytesWritten1 = c1.write("not a real gpg payload but contains the token word\n");
-  QVERIFY2(bytesWritten1 == 55, "failed to write test payload to c1");
+  const char *payload1 = "not a real gpg payload but contains the token word\n";
+  qint64 bytesWritten1 = c1.write(payload1);
+  QVERIFY2(bytesWritten1 == static_cast<qint64>(strlen(payload1)), "failed to write test payload to c1");
   c1.close();
   QFile c2(corrupt2);
   QVERIFY2(c2.open(QIODevice::WriteOnly), "should create corrupt.gpg");


### PR DESCRIPTION
## Summary

End-to-end coverage for the env-aware \`Executor::executeBlocking\` call in \`ImitatePass::grepMatchFile\` (imitatepass.cpp:1055). The function feeds each \`.gpg\` file in the store to \`gpg --decrypt\` via the env-aware Executor overload; when gpg exits non-zero (or stdout is empty), the match list for that file is discarded and \`grepScanStore\` continues to the next file.

The existing **unit** test \`grepMatchFileFailedDecryptReturnsEmpty\` (tst_util) covers the single-file branch by pointing at a non-existent gpg binary. This new **integration** test exercises the multi-file scan with real gpg + a real keyring:

1. Insert two legitimate entries (\`work/github\`, \`work/gitlab\`) both containing the \"token\" substring.
2. Plant two \`.gpg\` files that aren't valid gpg ciphertext at all:
   - \`work/garbage-token.gpg\` — plain text \"...contains the token word\"
   - \`corrupt.gpg\` — binary junk
3. Run \`Grep(\"token\")\`.
4. Assert exactly the two legitimate entries are returned; neither corrupt file leaks a match (even though one has \"token\" in its raw plaintext bytes, gpg fails to decrypt it and \`grepMatchFile\` returns empty).

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/integration/tst_integration\` — 20/20 (was 19, +1)
- [x] \`clang-format\` applied

## Notes

This is a behavioural / smoke test of the full env-aware grep path, not a guard-isolation test — \`grepMatchFile\` is naturally robust to empty plaintext via its empty-line skip in the match loop, so even with the \`rc != 0\` early-return defanged the integration test still passes. The dedicated unit test covers the guard branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test ensuring grep/search ignores corrupt or undecryptable encrypted password files and returns only genuine matched entries, reducing false positives and improving search reliability when damaged or tampered files are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1471)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->