### PR TITLE
fx: remove stale debug msg

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -107,7 +107,6 @@ void TrayIcon::iconActivated(QSystemTrayIcon::ActivationReason reason) {
     showHideParent();
     break;
   case QSystemTrayIcon::MiddleClick:
-    showMessage("test", "test msg", 1000);
     break;
   default: {
   }


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary debug message that appeared when interacting with the tray icon during window visibility toggling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1473)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->