### PR TITLE
i18n(et,pl): four reviewer-flagged fixes

### DIFF
--- a/localization/localization_et.ts
+++ b/localization/localization_et.ts
@@ -161,7 +161,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="891"/>
         <source>Optional path to override SSH_AUTH_SOCK. Leave empty to auto-probe via gpgconf (issue #543).</source>
-        <translation>Valikuline asukoht SSH_AUTH_SOCK sürjutamiseks. Automaatseks tuvastamiseks gpgconf kaudu (veateade #543) jäta tühjaks.</translation>
+        <translation>Valikuline asukoht SSH_AUTH_SOCK alistamiseks. Automaatseks tuvastamiseks gpgconf kaudu (veateade #543) jäta tühjaks.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="898"/>
@@ -418,7 +418,7 @@ email</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="263"/>
         <source>The path does not exist.</source>
-        <translation>Aaukohta pole olemas.</translation>
+        <translation>Asukohta pole olemas.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="265"/>
@@ -512,7 +512,7 @@ Väärtus salvestatakse ikkagi sisestatud kujul.</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="1019"/>
         <source>Failed to create password-store at: %1</source>
-        <translation>salasõnahoidla loomine ei õnnestunus asukohas: %1</translation>
+        <translation>salasõnahoidla loomine ei õnnestunud asukohas: %1</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="1050"/>

--- a/localization/localization_pl.ts
+++ b/localization/localization_pl.ts
@@ -1269,7 +1269,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="1015"/>
         <source>That name would resolve outside the password store. Please choose a different name.</source>
-        <translation>Ta nazwa nie będzie rozpoznawana w bazie haseł. Wybierz inną nazwę.</translation>
+        <translation>Ta nazwa będzie rozwiązywana poza magazynem haseł. Wybierz inną nazwę.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1058"/>


### PR DESCRIPTION
## Summary

Four still-valid reviewer findings against current main.

| Locale | Source | Old | New |
|---|---|---|---|
| \`et\` | \"Optional path to override SSH_AUTH_SOCK...\" | \"...SSH_AUTH_SOCK **sürjutamiseks**...\" | \"...SSH_AUTH_SOCK **alistamiseks**...\" |
| \`et\` | \"The path does not exist.\" | \"**Aaukohta** pole olemas.\" | \"**Asukohta** pole olemas.\" |
| \`et\` | \"Failed to create password-store at: %1\" | \"...ei **õnnestunus** asukohas: %1\" | \"...ei **õnnestunud** asukohas: %1\" |
| \`pl\` | \"That name would resolve outside the password store. Please choose a different name.\" | \"Ta nazwa **nie będzie rozpoznawana w bazie haseł**. ...\" | \"Ta nazwa **będzie rozwiązywana poza magazynem haseł**. ...\" |

### Why

- **et / sürjutamiseks**: nonstandard word. The Estonian term used everywhere else in the file for \"override\" is \`alistam-\` (line 159 \`SSH_AUTH_SOCK alistamine:\`, lines 436/445 for the warning strings).
- **et / Aaukohta**: typo for \`Asukohta\` (\"location\"). One extra \"a\".
- **et / õnnestunus**: typo. Estonian past-tense ending is \`-d\` (\`õnnestunud\`), not \`-s\`.
- **pl**: the previous rendering \"will not be recognised in the password store\" loses the path-traversal meaning — the warning is about the name **resolving outside** the store, not about recognisability. Reworded to convey that.

## Test plan

- [x] \`lrelease6\` on \`localization_et.ts\` — 314 finished, 0 unfinished
- [x] \`lrelease6\` on \`localization_pl.ts\` — 314 finished, 0 unfinished

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Estonian UI translation typos in SSH authentication, file path error, and password-store creation messages.
  * Updated Polish translation for password store path resolution messaging for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1474)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->