### PR TITLE
chore: clang-format two over-long QVERIFY2 lines in tst_integration.cpp

### DIFF
--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -427,13 +427,15 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   QVERIFY2(c1.open(QIODevice::WriteOnly), "should create garbage-token.gpg");
   const char *payload1 = "not a real gpg payload but contains the token word\n";
   qint64 bytesWritten1 = c1.write(payload1);
-  QVERIFY2(bytesWritten1 == static_cast<qint64>(strlen(payload1)), "failed to write test payload to c1");
+  QVERIFY2(bytesWritten1 == static_cast<qint64>(strlen(payload1)),
+           "failed to write test payload to c1");
   c1.close();
   QFile c2(corrupt2);
   QVERIFY2(c2.open(QIODevice::WriteOnly), "should create corrupt.gpg");
   QByteArray corruptData("\xFF\xFE\x00\x01 binary junk\n", 17);
   qint64 bytesWritten2 = c2.write(corruptData);
-  QVERIFY2(bytesWritten2 == corruptData.size(), "failed to write test payload to c2");
+  QVERIFY2(bytesWritten2 == corruptData.size(),
+           "failed to write test payload to c2");
   c2.close();
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);


### PR DESCRIPTION
## Summary

CI super-linter started rejecting unrelated PRs because clang-format runs over the whole tree and two lines in \`tst_integration.cpp\` exceed the 80-col limit:

\`\`\`
/github/workspace/tests/auto/integration/tst_integration.cpp:430:67: error: code should be clang-formatted [-Wclang-format-violations]
  QVERIFY2(bytesWritten1 == static_cast<qint64>(strlen(payload1)), \"failed to write test payload to c1\");
                                                                  ^
/github/workspace/tests/auto/integration/tst_integration.cpp:436:48: error: code should be clang-formatted [-Wclang-format-violations]
  QVERIFY2(bytesWritten2 == corruptData.size(), \"failed to write test payload to c2\");
                                               ^
\`\`\`

Those came from CodeRabbit's auto-fix on #1471 that captured the \`QFile::write()\` return value and asserted it equals the payload size. The change was good, the formatting just slipped past.

Reformat both calls — break after the condition, matches the QVERIFY2 style applied elsewhere.

## Test plan

- [x] \`clang-format\` re-runs cleanly on the file
- [x] \`tests/auto/integration/tst_integration imitatePass_grepSkipsUndecryptableFiles\` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test code formatting in integration tests.

---

**Note:** This release contains no user-visible changes. Updates are limited to internal test code formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1475)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->