### PR TITLE
test(keygendialog): widget tests for the GPG keygen dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ tests/auto/gpgkeystate/tst_gpgkeystate
 tests/auto/integration/tst_integration
 tests/auto/exportpublickeydialog/tst_exportpublickeydialog
 tests/auto/importkeydialog/tst_importkeydialog
+tests/auto/keygendialog/tst_keygendialog
 tests/auto/locale/tst_locale
 tests/auto/locale/.qm/
 tests/auto/locale/qmake_qmake_qm_files.qrc

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog locale
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog locale
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -427,13 +427,15 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   QVERIFY2(c1.open(QIODevice::WriteOnly), "should create garbage-token.gpg");
   const char *payload1 = "not a real gpg payload but contains the token word\n";
   qint64 bytesWritten1 = c1.write(payload1);
-  QVERIFY2(bytesWritten1 == static_cast<qint64>(strlen(payload1)), "failed to write test payload to c1");
+  QVERIFY2(bytesWritten1 == static_cast<qint64>(strlen(payload1)),
+           "failed to write test payload to c1");
   c1.close();
   QFile c2(corrupt2);
   QVERIFY2(c2.open(QIODevice::WriteOnly), "should create corrupt.gpg");
   QByteArray corruptData("\xFF\xFE\x00\x01 binary junk\n", 17);
   qint64 bytesWritten2 = c2.write(corruptData);
-  QVERIFY2(bytesWritten2 == corruptData.size(), "failed to write test payload to c2");
+  QVERIFY2(bytesWritten2 == corruptData.size(),
+           "failed to write test payload to c2");
   c2.close();
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);

--- a/tests/auto/keygendialog/keygendialog.pro
+++ b/tests/auto/keygendialog/keygendialog.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_keygendialog.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += keygendialog.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/keygendialog/qtpass.plist
+++ b/tests/auto/keygendialog/qtpass.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+</dict>
+</plist>

--- a/tests/auto/keygendialog/tst_keygendialog.cpp
+++ b/tests/auto/keygendialog/tst_keygendialog.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <QApplication>
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QtTest>
+
+#include "../../../src/keygendialog.h"
+
+/**
+ * @class tst_keygendialog
+ * @brief Widget-level tests for KeygenDialog.
+ *
+ * KeygenDialog is the modal that fronts GPG key-pair generation. These tests
+ * cover construction and the input-driven UI state transitions; they don't
+ * drive a full key generation (that needs a real gpg + several seconds of
+ * entropy gathering).
+ *
+ * The dialog is normally parented to a ConfigDialog; tests pass nullptr to
+ * sidestep ConfigDialog construction entirely. The protected `done()` slot
+ * isn't exercised here for the same reason (it dispatches into
+ * dialog->genKey(), which dereferences the ConfigDialog parent).
+ */
+class tst_keygendialog : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void constructionLoadsNonEmptyTemplate();
+  void expertCheckboxTogglesTemplateEditor();
+  void nameTextUpdatesNameRealLine();
+  void emailTextUpdatesNameEmailLine();
+  void matchingPassphrasesEnableButtonBox();
+  void mismatchedPassphrasesDisableButtonBox();
+};
+
+/**
+ * @brief The default GPG batch template gets loaded into the editor on
+ *        construction, regardless of whether ed25519 is supported.
+ */
+void tst_keygendialog::constructionLoadsNonEmptyTemplate() {
+  KeygenDialog dialog(nullptr);
+  auto *editor =
+      dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
+  QVERIFY2(editor != nullptr, "plainTextEdit widget must exist");
+  const QString tpl = editor->toPlainText();
+  QVERIFY2(!tpl.isEmpty(), "default key template must be loaded");
+  // Both the ed25519 and RSA fallback templates contain Name-Real and
+  // Name-Email placeholders we rely on in the other tests.
+  QVERIFY2(tpl.contains(QStringLiteral("Name-Real:")),
+           "template must contain a Name-Real: line");
+  QVERIFY2(tpl.contains(QStringLiteral("Name-Email:")),
+           "template must contain a Name-Email: line");
+}
+
+/**
+ * @brief Toggling the "Expert" checkbox enables/disables direct editing of
+ *        the GPG batch template.
+ */
+void tst_keygendialog::expertCheckboxTogglesTemplateEditor() {
+  KeygenDialog dialog(nullptr);
+  auto *checkBox = dialog.findChild<QCheckBox *>(QStringLiteral("checkBox"));
+  auto *editor =
+      dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
+  QVERIFY(checkBox != nullptr);
+  QVERIFY(editor != nullptr);
+
+  // Default state: checkbox unchecked, editor read-only / disabled.
+  checkBox->setChecked(false);
+  QVERIFY2(editor->isReadOnly(), "editor should start read-only");
+  QVERIFY2(!editor->isEnabled(), "editor should start disabled");
+
+  checkBox->setChecked(true);
+  QVERIFY2(!editor->isReadOnly(), "expert mode should drop read-only");
+  QVERIFY2(editor->isEnabled(), "expert mode should enable editor");
+
+  checkBox->setChecked(false);
+  QVERIFY2(editor->isReadOnly(), "unchecking expert restores read-only");
+  QVERIFY2(!editor->isEnabled(), "unchecking expert disables editor");
+}
+
+/**
+ * @brief Typing in the Name field replaces the Name-Real: line in the
+ *        template.
+ */
+void tst_keygendialog::nameTextUpdatesNameRealLine() {
+  KeygenDialog dialog(nullptr);
+  auto *nameEdit = dialog.findChild<QLineEdit *>(QStringLiteral("name"));
+  auto *editor =
+      dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
+  QVERIFY(nameEdit != nullptr);
+  QVERIFY(editor != nullptr);
+
+  // The slot fires on textChanged(); setText() is enough to trigger it.
+  nameEdit->setText(QStringLiteral("QtPass Tester"));
+  QVERIFY2(editor->toPlainText().contains(
+               QStringLiteral("Name-Real: QtPass Tester")),
+           "template should reflect typed name");
+}
+
+/**
+ * @brief Typing in the Email field replaces the Name-Email: line.
+ */
+void tst_keygendialog::emailTextUpdatesNameEmailLine() {
+  KeygenDialog dialog(nullptr);
+  auto *emailEdit = dialog.findChild<QLineEdit *>(QStringLiteral("email"));
+  auto *editor =
+      dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
+  QVERIFY(emailEdit != nullptr);
+  QVERIFY(editor != nullptr);
+
+  emailEdit->setText(QStringLiteral("tester@qtpass.example"));
+  QVERIFY2(editor->toPlainText().contains(
+               QStringLiteral("Name-Email: tester@qtpass.example")),
+           "template should reflect typed email");
+}
+
+/**
+ * @brief Matching passphrases in both passphrase fields enable the
+ *        DialogButtonBox so OK can be clicked.
+ */
+void tst_keygendialog::matchingPassphrasesEnableButtonBox() {
+  KeygenDialog dialog(nullptr);
+  auto *pp1 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase1"));
+  auto *pp2 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase2"));
+  auto *buttonBox =
+      dialog.findChild<QDialogButtonBox *>(QStringLiteral("buttonBox"));
+  QVERIFY(pp1 != nullptr);
+  QVERIFY(pp2 != nullptr);
+  QVERIFY(buttonBox != nullptr);
+
+  pp1->setText(QStringLiteral("secret"));
+  pp2->setText(QStringLiteral("secret"));
+  QVERIFY2(buttonBox->isEnabled(), "matching passphrases enable OK");
+}
+
+/**
+ * @brief Mismatched passphrases disable the DialogButtonBox.
+ */
+void tst_keygendialog::mismatchedPassphrasesDisableButtonBox() {
+  KeygenDialog dialog(nullptr);
+  auto *pp1 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase1"));
+  auto *pp2 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase2"));
+  auto *buttonBox =
+      dialog.findChild<QDialogButtonBox *>(QStringLiteral("buttonBox"));
+  QVERIFY(pp1 != nullptr);
+  QVERIFY(pp2 != nullptr);
+  QVERIFY(buttonBox != nullptr);
+
+  pp1->setText(QStringLiteral("secret"));
+  pp2->setText(QStringLiteral("different"));
+  QVERIFY2(!buttonBox->isEnabled(), "mismatched passphrases disable OK");
+}
+
+QTEST_MAIN(tst_keygendialog)
+#include "tst_keygendialog.moc"

--- a/tests/auto/keygendialog/tst_keygendialog.cpp
+++ b/tests/auto/keygendialog/tst_keygendialog.cpp
@@ -64,8 +64,8 @@ void tst_keygendialog::expertCheckboxTogglesTemplateEditor() {
   auto *checkBox = dialog.findChild<QCheckBox *>(QStringLiteral("checkBox"));
   auto *editor =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
-  QVERIFY(checkBox != nullptr);
-  QVERIFY(editor != nullptr);
+  QVERIFY2(checkBox != nullptr, "checkBox != nullptr");
+  QVERIFY2(editor != nullptr, "editor != nullptr");
 
   // Default state: checkbox unchecked, editor read-only / disabled.
   checkBox->setChecked(false);
@@ -90,8 +90,8 @@ void tst_keygendialog::nameTextUpdatesNameRealLine() {
   auto *nameEdit = dialog.findChild<QLineEdit *>(QStringLiteral("name"));
   auto *editor =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
-  QVERIFY(nameEdit != nullptr);
-  QVERIFY(editor != nullptr);
+  QVERIFY2(nameEdit != nullptr, "nameEdit != nullptr");
+  QVERIFY2(editor != nullptr, "editor != nullptr");
 
   // The slot fires on textChanged(); setText() is enough to trigger it.
   nameEdit->setText(QStringLiteral("QtPass Tester"));
@@ -108,8 +108,8 @@ void tst_keygendialog::emailTextUpdatesNameEmailLine() {
   auto *emailEdit = dialog.findChild<QLineEdit *>(QStringLiteral("email"));
   auto *editor =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
-  QVERIFY(emailEdit != nullptr);
-  QVERIFY(editor != nullptr);
+  QVERIFY2(emailEdit != nullptr, "emailEdit != nullptr");
+  QVERIFY2(editor != nullptr, "editor != nullptr");
 
   emailEdit->setText(QStringLiteral("tester@qtpass.example"));
   QVERIFY2(editor->toPlainText().contains(
@@ -127,12 +127,12 @@ void tst_keygendialog::matchingPassphrasesEnableButtonBox() {
   auto *pp2 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase2"));
   auto *buttonBox =
       dialog.findChild<QDialogButtonBox *>(QStringLiteral("buttonBox"));
-  QVERIFY(pp1 != nullptr);
-  QVERIFY(pp2 != nullptr);
-  QVERIFY(buttonBox != nullptr);
+  QVERIFY2(pp1 != nullptr, "pp1 != nullptr");
+  QVERIFY2(pp2 != nullptr, "pp2 != nullptr");
+  QVERIFY2(buttonBox != nullptr, "buttonBox != nullptr");
 
-  pp1->setText(QStringLiteral("secret"));
-  pp2->setText(QStringLiteral("secret"));
+  pp1->setText(QStringLiteral("testkey123"));
+  pp2->setText(QStringLiteral("testkey123"));
   QVERIFY2(buttonBox->isEnabled(), "matching passphrases enable OK");
 }
 
@@ -145,12 +145,12 @@ void tst_keygendialog::mismatchedPassphrasesDisableButtonBox() {
   auto *pp2 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase2"));
   auto *buttonBox =
       dialog.findChild<QDialogButtonBox *>(QStringLiteral("buttonBox"));
-  QVERIFY(pp1 != nullptr);
-  QVERIFY(pp2 != nullptr);
-  QVERIFY(buttonBox != nullptr);
+  QVERIFY2(pp1 != nullptr, "pp1 != nullptr");
+  QVERIFY2(pp2 != nullptr, "pp2 != nullptr");
+  QVERIFY2(buttonBox != nullptr, "buttonBox != nullptr");
 
-  pp1->setText(QStringLiteral("secret"));
-  pp2->setText(QStringLiteral("different"));
+  pp1->setText(QStringLiteral("testkey123"));
+  pp2->setText(QStringLiteral("testkey456"));
   QVERIFY2(!buttonBox->isEnabled(), "mismatched passphrases disable OK");
 }
 

--- a/tests/auto/keygendialog/tst_keygendialog.cpp
+++ b/tests/auto/keygendialog/tst_keygendialog.cpp
@@ -64,8 +64,8 @@ void tst_keygendialog::expertCheckboxTogglesTemplateEditor() {
   auto *checkBox = dialog.findChild<QCheckBox *>(QStringLiteral("checkBox"));
   auto *editor =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
-  QVERIFY2(checkBox != nullptr, "checkBox != nullptr");
-  QVERIFY2(editor != nullptr, "editor != nullptr");
+  QVERIFY2(checkBox != nullptr, "checkBox widget must exist");
+  QVERIFY2(editor != nullptr, "plainTextEdit widget must exist");
 
   // Default state: checkbox unchecked, editor read-only / disabled.
   checkBox->setChecked(false);
@@ -90,8 +90,8 @@ void tst_keygendialog::nameTextUpdatesNameRealLine() {
   auto *nameEdit = dialog.findChild<QLineEdit *>(QStringLiteral("name"));
   auto *editor =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
-  QVERIFY2(nameEdit != nullptr, "nameEdit != nullptr");
-  QVERIFY2(editor != nullptr, "editor != nullptr");
+  QVERIFY2(nameEdit != nullptr, "name widget must exist");
+  QVERIFY2(editor != nullptr, "plainTextEdit widget must exist");
 
   // The slot fires on textChanged(); setText() is enough to trigger it.
   nameEdit->setText(QStringLiteral("QtPass Tester"));
@@ -108,8 +108,8 @@ void tst_keygendialog::emailTextUpdatesNameEmailLine() {
   auto *emailEdit = dialog.findChild<QLineEdit *>(QStringLiteral("email"));
   auto *editor =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("plainTextEdit"));
-  QVERIFY2(emailEdit != nullptr, "emailEdit != nullptr");
-  QVERIFY2(editor != nullptr, "editor != nullptr");
+  QVERIFY2(emailEdit != nullptr, "email widget must exist");
+  QVERIFY2(editor != nullptr, "plainTextEdit widget must exist");
 
   emailEdit->setText(QStringLiteral("tester@qtpass.example"));
   QVERIFY2(editor->toPlainText().contains(
@@ -127,9 +127,9 @@ void tst_keygendialog::matchingPassphrasesEnableButtonBox() {
   auto *pp2 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase2"));
   auto *buttonBox =
       dialog.findChild<QDialogButtonBox *>(QStringLiteral("buttonBox"));
-  QVERIFY2(pp1 != nullptr, "pp1 != nullptr");
-  QVERIFY2(pp2 != nullptr, "pp2 != nullptr");
-  QVERIFY2(buttonBox != nullptr, "buttonBox != nullptr");
+  QVERIFY2(pp1 != nullptr, "passphrase1 widget must exist");
+  QVERIFY2(pp2 != nullptr, "passphrase2 widget must exist");
+  QVERIFY2(buttonBox != nullptr, "buttonBox widget must exist");
 
   pp1->setText(QStringLiteral("testkey123"));
   pp2->setText(QStringLiteral("testkey123"));
@@ -145,9 +145,9 @@ void tst_keygendialog::mismatchedPassphrasesDisableButtonBox() {
   auto *pp2 = dialog.findChild<QLineEdit *>(QStringLiteral("passphrase2"));
   auto *buttonBox =
       dialog.findChild<QDialogButtonBox *>(QStringLiteral("buttonBox"));
-  QVERIFY2(pp1 != nullptr, "pp1 != nullptr");
-  QVERIFY2(pp2 != nullptr, "pp2 != nullptr");
-  QVERIFY2(buttonBox != nullptr, "buttonBox != nullptr");
+  QVERIFY2(pp1 != nullptr, "passphrase1 widget must exist");
+  QVERIFY2(pp2 != nullptr, "passphrase2 widget must exist");
+  QVERIFY2(buttonBox != nullptr, "buttonBox widget must exist");
 
   pp1->setText(QStringLiteral("testkey123"));
   pp2->setText(QStringLiteral("testkey456"));


### PR DESCRIPTION
## Summary

\`KeygenDialog\` (the modal that fronts GPG key-pair generation) had **zero** test coverage. Added six widget-level tests in a new \`tests/auto/keygendialog/\` subdirectory, modelled on the existing \`tests/auto/importkeydialog/\` pattern.

This is also our **first new dialog test subdir post-security-review** and sets the template for the rest of the untested-dialog backlog (ConfigDialog, UsersDialog, ProfileInit, TrayIcon, MainWindow).

## Tests

| Case | What it asserts |
|---|---|
| \`constructionLoadsNonEmptyTemplate\` | Dialog instantiates; \`plainTextEdit\` receives the default GPG batch template. Checks the \`Name-Real:\`/\`Name-Email:\` substrings that both the ed25519 and RSA fallback templates share. |
| \`expertCheckboxTogglesTemplateEditor\` | Toggling \"Expert\" flips \`plainTextEdit\` between read-only/disabled and editable/enabled. |
| \`nameTextUpdatesNameRealLine\` | Typing in the Name field replaces the \`Name-Real:\` line. |
| \`emailTextUpdatesNameEmailLine\` | Same for \`Name-Email:\`. |
| \`matchingPassphrasesEnableButtonBox\` | Identical text in both passphrase fields enables OK. |
| \`mismatchedPassphrasesDisableButtonBox\` | Differing passphrases disable OK. |

## Out of scope

- The protected \`done()\` slot — it dispatches into \`dialog->genKey()\` which dereferences the \`ConfigDialog\` parent (tests pass nullptr to sidestep that). Name-length / email-regex validation in \`done()\` would need either a ConfigDialog stub or a QMessageBox spy; both are heavier than this PR warrants.
- Full key generation — needs real gpg + entropy gathering (already exercised in \`tst_integration\`).

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/keygendialog/tst_keygendialog\` — 6/6 (8 incl. init/cleanup)
- [x] \`tests/auto/ui/tst_ui\` — 46/46 (no regression)
- [x] Doxygen — no new warnings
- [x] clang-format applied

Wired into \`tests/auto/auto.pro\` SUBDIRS and \`.gitignore\`. Followed the importkeydialog/ scaffolding pattern (matching \`.pro\`, \`qtpass.plist\` template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new automated test suite for the key generation dialog covering template loading, expert mode toggling, name/email syncing, and passphrase validation.
  * Minor refinements to an existing integration test to clarify failure messages.
  * Expanded automated test run configuration to include the new dialog tests.

* **Chores**
  * Updated ignore rules to exclude the new test executable and added macOS test bundle metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1476)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->