### PR TITLE
test(trayicon): widget tests for TrayIcon's parent-window plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ tests/auto/integration/tst_integration
 tests/auto/exportpublickeydialog/tst_exportpublickeydialog
 tests/auto/importkeydialog/tst_importkeydialog
 tests/auto/keygendialog/tst_keygendialog
+tests/auto/trayicon/tst_trayicon
 tests/auto/locale/tst_locale
 tests/auto/locale/.qm/
 tests/auto/locale/qmake_qmake_qm_files.qrc

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog locale
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon locale
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/trayicon/qtpass.plist
+++ b/tests/auto/trayicon/qtpass.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+</dict>
+</plist>

--- a/tests/auto/trayicon/trayicon.pro
+++ b/tests/auto/trayicon/trayicon.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_trayicon.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += trayicon.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/trayicon/tst_trayicon.cpp
+++ b/tests/auto/trayicon/tst_trayicon.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <QApplication>
+#include <QMainWindow>
+#include <QSystemTrayIcon>
+#include <QtTest>
+
+#include "../../../src/trayicon.h"
+
+/**
+ * @class tst_trayicon
+ * @brief Widget tests for TrayIcon.
+ *
+ * TrayIcon wraps QSystemTrayIcon and routes activation events back to the
+ * parent QMainWindow. The QSystemTrayIcon side only initialises when the
+ * runtime platform reports `isSystemTrayAvailable()` — on a headless CI
+ * (offscreen platform) that's typically false, so the menu/icon code path
+ * is largely unreachable in unit tests.
+ *
+ * What IS reachable, regardless of tray availability:
+ * - The parent pointer is always stored.
+ * - `showHideParent()` operates on the parent QMainWindow directly.
+ * - `iconActivated()` dispatches on the reason enum and only calls
+ *   showHideParent for Trigger / DoubleClick. The other branches must be
+ *   no-ops.
+ *
+ * That's what these tests cover.
+ */
+class tst_trayicon : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void constructionStoresParent();
+  void showHideParentTogglesVisibility();
+  void iconActivatedTriggerTogglesVisibility();
+  void iconActivatedDoubleClickTogglesVisibility();
+  void iconActivatedMiddleClickIsNoOp();
+  void iconActivatedUnknownReasonIsNoOp();
+  void getIsAllocatedMatchesPlatformTrayAvailability();
+};
+
+/**
+ * @brief Constructor stores the parent pointer and returns without
+ *        crashing regardless of tray availability.
+ */
+void tst_trayicon::constructionStoresParent() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+  // No public accessor for parentwin; the showHideParent test below
+  // verifies the pointer was wired correctly. Here we just assert
+  // the constructor returned and getIsAllocated() returns a bool.
+  // The compiler enforces the bool return type, so this is really a
+  // "doesn't crash" smoke check.
+  Q_UNUSED(tray.getIsAllocated());
+}
+
+/**
+ * @brief showHideParent() toggles the parent window's visibility.
+ */
+void tst_trayicon::showHideParentTogglesVisibility() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+
+  parent.show();
+  // Spin the event loop once so the window-manager show-event lands.
+  QTRY_VERIFY2(parent.isVisible(), "parent must be visible after show()");
+
+  tray.showHideParent();
+  QTRY_VERIFY2(!parent.isVisible(),
+               "showHideParent should hide a visible parent");
+
+  tray.showHideParent();
+  QTRY_VERIFY2(parent.isVisible(),
+               "showHideParent should re-show a hidden parent");
+}
+
+/**
+ * @brief A Trigger activation toggles parent visibility (single-click /
+ *        keyboard activate on platforms that map them to Trigger).
+ */
+void tst_trayicon::iconActivatedTriggerTogglesVisibility() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+  parent.show();
+  QTRY_VERIFY(parent.isVisible());
+
+  tray.iconActivated(QSystemTrayIcon::Trigger);
+  QTRY_VERIFY2(!parent.isVisible(), "Trigger should toggle visibility");
+}
+
+/**
+ * @brief A DoubleClick activation toggles parent visibility (Windows
+ *        users typically reach the tray via double-click).
+ */
+void tst_trayicon::iconActivatedDoubleClickTogglesVisibility() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+  parent.show();
+  QTRY_VERIFY(parent.isVisible());
+
+  tray.iconActivated(QSystemTrayIcon::DoubleClick);
+  QTRY_VERIFY2(!parent.isVisible(), "DoubleClick should toggle visibility");
+}
+
+/**
+ * @brief A MiddleClick activation does nothing — the switch case is
+ *        explicitly handled and falls through without changing state.
+ */
+void tst_trayicon::iconActivatedMiddleClickIsNoOp() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+  parent.show();
+  QTRY_VERIFY(parent.isVisible());
+
+  tray.iconActivated(QSystemTrayIcon::MiddleClick);
+  // Give any pending toggle a chance to land. The assertion is "still
+  // visible after a short spin", which exercises the no-op contract.
+  QTest::qWait(50);
+  QVERIFY2(parent.isVisible(), "MiddleClick must not change parent visibility");
+}
+
+/**
+ * @brief Unknown / Context reasons fall to the default branch which is
+ *        also a no-op.
+ */
+void tst_trayicon::iconActivatedUnknownReasonIsNoOp() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+  parent.show();
+  QTRY_VERIFY(parent.isVisible());
+
+  tray.iconActivated(QSystemTrayIcon::Unknown);
+  QTest::qWait(50);
+  QVERIFY2(parent.isVisible(),
+           "Unknown reason must not change parent visibility");
+
+  tray.iconActivated(QSystemTrayIcon::Context);
+  QTest::qWait(50);
+  QVERIFY2(parent.isVisible(),
+           "Context reason must not change parent visibility");
+}
+
+/**
+ * @brief getIsAllocated mirrors the runtime
+ *        QSystemTrayIcon::isSystemTrayAvailable() check — true when the
+ *        platform supports a tray, false on headless / offscreen.
+ */
+void tst_trayicon::getIsAllocatedMatchesPlatformTrayAvailability() {
+  QMainWindow parent;
+  TrayIcon tray(&parent);
+  QCOMPARE(tray.getIsAllocated(), QSystemTrayIcon::isSystemTrayAvailable());
+}
+
+QTEST_MAIN(tst_trayicon)
+#include "tst_trayicon.moc"

--- a/tests/auto/trayicon/tst_trayicon.cpp
+++ b/tests/auto/trayicon/tst_trayicon.cpp
@@ -82,7 +82,7 @@ void tst_trayicon::iconActivatedTriggerTogglesVisibility() {
   QMainWindow parent;
   TrayIcon tray(&parent);
   parent.show();
-  QTRY_VERIFY(parent.isVisible());
+  QTRY_VERIFY2(parent.isVisible(), "parent must be visible after show()");
 
   tray.iconActivated(QSystemTrayIcon::Trigger);
   QTRY_VERIFY2(!parent.isVisible(), "Trigger should toggle visibility");
@@ -96,7 +96,7 @@ void tst_trayicon::iconActivatedDoubleClickTogglesVisibility() {
   QMainWindow parent;
   TrayIcon tray(&parent);
   parent.show();
-  QTRY_VERIFY(parent.isVisible());
+  QTRY_VERIFY2(parent.isVisible(), "parent must be visible after show()");
 
   tray.iconActivated(QSystemTrayIcon::DoubleClick);
   QTRY_VERIFY2(!parent.isVisible(), "DoubleClick should toggle visibility");
@@ -110,7 +110,7 @@ void tst_trayicon::iconActivatedMiddleClickIsNoOp() {
   QMainWindow parent;
   TrayIcon tray(&parent);
   parent.show();
-  QTRY_VERIFY(parent.isVisible());
+  QTRY_VERIFY2(parent.isVisible(), "parent must be visible after show()");
 
   tray.iconActivated(QSystemTrayIcon::MiddleClick);
   // Give any pending toggle a chance to land. The assertion is "still
@@ -127,7 +127,7 @@ void tst_trayicon::iconActivatedUnknownReasonIsNoOp() {
   QMainWindow parent;
   TrayIcon tray(&parent);
   parent.show();
-  QTRY_VERIFY(parent.isVisible());
+  QTRY_VERIFY2(parent.isVisible(), "parent must be visible after show()");
 
   tray.iconActivated(QSystemTrayIcon::Unknown);
   QTest::qWait(50);


### PR DESCRIPTION
## Summary

\`TrayIcon\` had **zero** test coverage. This is the second new dialog/widget test subdir post-security-review (after #1476 KeygenDialog) — same scaffold, same dir-per-class pattern as \`importkeydialog/\` and \`keygendialog/\`.

## What's testable here

\`TrayIcon\` wraps \`QSystemTrayIcon\` and routes activation events back to its parent \`QMainWindow\`. Most of the \`QSystemTrayIcon\` side only initialises when the platform reports \`isSystemTrayAvailable()\` — on a headless CI (offscreen platform) that's typically false, so the menu / icon setup path is largely unreachable in unit tests.

What IS reachable regardless of tray availability:
- the parent pointer (set in the constructor body before the \`isSystemTrayAvailable()\` check)
- \`showHideParent()\` (operates on the parent directly)
- \`iconActivated()\` dispatches on the enum and only calls \`showHideParent\` for \`Trigger\` / \`DoubleClick\` — other branches must be no-ops

## Tests

| Case | What it asserts |
|---|---|
| \`constructionStoresParent\` | Construction with a parent doesn't crash; \`getIsAllocated()\` returns a bool. |
| \`showHideParentTogglesVisibility\` | \`showHideParent()\` round-trips shown → hidden → shown. |
| \`iconActivatedTriggerTogglesVisibility\` | \`Trigger\` reason toggles parent (single-click / keyboard activation). |
| \`iconActivatedDoubleClickTogglesVisibility\` | \`DoubleClick\` reason toggles parent (Windows users typically reach the tray this way). |
| \`iconActivatedMiddleClickIsNoOp\` | Explicit middle-click branch leaves parent visibility alone. |
| \`iconActivatedUnknownReasonIsNoOp\` | Default branch also a no-op (\`Unknown\` + \`Context\` both checked). |
| \`getIsAllocatedMatchesPlatformTrayAvailability\` | \`getIsAllocated()\` mirrors \`QSystemTrayIcon::isSystemTrayAvailable()\`. |

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/trayicon/tst_trayicon\` — 7/7 pass on Linux with system tray available
- [x] clang-format applied

### Noise

Test output shows \`QSystemTrayIcon::setVisible: No Icon set\` warnings on platforms where the tray is available. The icon comes from \`:/artwork/icon.png\` (a qrc resource) which isn't linked into the test binary. Production has the qrc embedded. The warnings are informational, don't fail any test, and would suppress to nothing on headless CI where \`isSystemTrayAvailable()\` is false. Not addressing in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new TrayIcon unit test suite covering construction, tray activation behaviors, and parent window visibility toggling.
* **Chores**
  * Registered several new automated test modules with the test runner.
  * Added a macOS test bundle template for tray icon tests.
  * Updated ignore rules to exclude the new test executable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1477)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->