### PR TITLE
test(configdialog): widget tests for the public useX setting-loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tests/auto/exportpublickeydialog/tst_exportpublickeydialog
 tests/auto/importkeydialog/tst_importkeydialog
 tests/auto/keygendialog/tst_keygendialog
 tests/auto/trayicon/tst_trayicon
+tests/auto/configdialog/tst_configdialog
 tests/auto/locale/tst_locale
 tests/auto/locale/.qm/
 tests/auto/locale/qmake_qmake_qm_files.qrc

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon locale
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/configdialog/configdialog.pro
+++ b/tests/auto/configdialog/configdialog.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_configdialog.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += configdialog.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/configdialog/qtpass.plist
+++ b/tests/auto/configdialog/qtpass.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+</dict>
+</plist>

--- a/tests/auto/configdialog/tst_configdialog.cpp
+++ b/tests/auto/configdialog/tst_configdialog.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <QApplication>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QtTest>
+
+#include "../../../src/configdialog.h"
+
+/**
+ * @class tst_configdialog
+ * @brief Widget tests for ConfigDialog's `useX(bool)` setting-loaders.
+ *
+ * ConfigDialog is the main Settings dialog and is fed by QtPassSettings on
+ * construction. Most of its public-facing behaviour lives in a family of
+ * `useX(bool)` methods that read settings into checkbox state; those are
+ * pure widget-state setters and testable in isolation by passing nullptr
+ * as the parent MainWindow.
+ *
+ * Coverage avoided here (needs a real MainWindow / Pass singleton):
+ * - genKey() — tunnels to mainWindow->generateKeyPair()
+ * - on_pushButtonGenerateKey_clicked() — calls into KeygenDialog
+ * - setProfiles() / profile-table flows — interact with QtPassSettings
+ *   profile map
+ * - Settings persistence (on_accepted) — already covered by the
+ *   tst_util sshAuthSockOverrideStatus tests in #1469
+ */
+class tst_configdialog : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void constructionDoesNotCrash();
+  void useSelectionTogglesCheckbox();
+  void useAutoclearTogglesCheckbox();
+  void useAutoclearPanelTogglesCheckbox();
+  void useGitTogglesCheckbox();
+  void useOtpTogglesCheckbox();
+  void useGrepSearchTogglesCheckbox();
+  void usePwgenTogglesCheckbox();
+  void useTemplateTogglesCheckbox();
+};
+
+/**
+ * @brief Construct ConfigDialog with a nullptr MainWindow and return — the
+ *        constructor doesn't dereference its parent.
+ */
+void tst_configdialog::constructionDoesNotCrash() {
+  ConfigDialog dialog(nullptr);
+  // Reaching this line means the constructor's setting-load + widget-
+  // wiring path completed without a segfault.
+  Q_UNUSED(dialog.isModal());
+}
+
+/**
+ * @brief useSelection toggles the X11 primary-selection checkbox.
+ */
+void tst_configdialog::useSelectionTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb = dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxSelection"));
+  QVERIFY2(cb != nullptr, "checkBoxSelection widget must exist");
+
+  dialog.useSelection(true);
+  QVERIFY(cb->isChecked());
+  dialog.useSelection(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief useAutoclear toggles the clipboard auto-clear checkbox.
+ */
+void tst_configdialog::useAutoclearTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb = dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxAutoclear"));
+  QVERIFY2(cb != nullptr, "checkBoxAutoclear widget must exist");
+
+  dialog.useAutoclear(true);
+  QVERIFY(cb->isChecked());
+  dialog.useAutoclear(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief useAutoclearPanel toggles the panel auto-clear checkbox.
+ */
+void tst_configdialog::useAutoclearPanelTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb =
+      dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxAutoclearPanel"));
+  QVERIFY2(cb != nullptr, "checkBoxAutoclearPanel widget must exist");
+
+  dialog.useAutoclearPanel(true);
+  QVERIFY(cb->isChecked());
+  dialog.useAutoclearPanel(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief useGit toggles the "use git" checkbox.
+ */
+void tst_configdialog::useGitTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb = dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxUseGit"));
+  QVERIFY2(cb != nullptr, "checkBoxUseGit widget must exist");
+
+  dialog.useGit(true);
+  QVERIFY(cb->isChecked());
+  dialog.useGit(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief useOtp toggles the "use OTP extension" checkbox.
+ */
+void tst_configdialog::useOtpTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb = dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxUseOtp"));
+  QVERIFY2(cb != nullptr, "checkBoxUseOtp widget must exist");
+
+  dialog.useOtp(true);
+  QVERIFY(cb->isChecked());
+  dialog.useOtp(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief useGrepSearch toggles the "content search" checkbox.
+ */
+void tst_configdialog::useGrepSearchTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb =
+      dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxUseGrepSearch"));
+  QVERIFY2(cb != nullptr, "checkBoxUseGrepSearch widget must exist");
+
+  dialog.useGrepSearch(true);
+  QVERIFY(cb->isChecked());
+  dialog.useGrepSearch(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief usePwgen toggles the pwgen-generator checkbox — but only if a
+ *        pwgen path is configured. With an empty pwgenPath, usePwgen(true)
+ *        is intentionally clamped to false (you can't use a tool that
+ *        isn't there).
+ */
+void tst_configdialog::usePwgenTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb = dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxUsePwgen"));
+  auto *pwgenPath = dialog.findChild<QLineEdit *>(QStringLiteral("pwgenPath"));
+  QVERIFY2(cb != nullptr, "checkBoxUsePwgen widget must exist");
+  QVERIFY2(pwgenPath != nullptr, "pwgenPath widget must exist");
+
+  // First verify the empty-path branch: even usePwgen(true) leaves the
+  // checkbox unchecked when pwgenPath is empty.
+  pwgenPath->setText(QString());
+  dialog.usePwgen(true);
+  QVERIFY2(!cb->isChecked(),
+           "usePwgen(true) with empty pwgenPath must stay unchecked");
+
+  // Now with a non-empty path the value flows through.
+  pwgenPath->setText(QStringLiteral("/usr/bin/pwgen"));
+  dialog.usePwgen(true);
+  QVERIFY(cb->isChecked());
+  dialog.usePwgen(false);
+  QVERIFY(!cb->isChecked());
+}
+
+/**
+ * @brief useTemplate toggles the password-template checkbox.
+ */
+void tst_configdialog::useTemplateTogglesCheckbox() {
+  ConfigDialog dialog(nullptr);
+  auto *cb =
+      dialog.findChild<QCheckBox *>(QStringLiteral("checkBoxUseTemplate"));
+  QVERIFY2(cb != nullptr, "checkBoxUseTemplate widget must exist");
+
+  dialog.useTemplate(true);
+  QVERIFY(cb->isChecked());
+  dialog.useTemplate(false);
+  QVERIFY(!cb->isChecked());
+}
+
+QTEST_MAIN(tst_configdialog)
+#include "tst_configdialog.moc"

--- a/tests/auto/configdialog/tst_configdialog.cpp
+++ b/tests/auto/configdialog/tst_configdialog.cpp
@@ -60,9 +60,11 @@ void tst_configdialog::useSelectionTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxSelection widget must exist");
 
   dialog.useSelection(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(),
+           "useSelection(true) should check checkBoxSelection");
   dialog.useSelection(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(),
+           "useSelection(false) should uncheck checkBoxSelection");
 }
 
 /**
@@ -74,9 +76,11 @@ void tst_configdialog::useAutoclearTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxAutoclear widget must exist");
 
   dialog.useAutoclear(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(),
+           "useAutoclear(true) should check checkBoxAutoclear");
   dialog.useAutoclear(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(),
+           "useAutoclear(false) should uncheck checkBoxAutoclear");
 }
 
 /**
@@ -89,9 +93,11 @@ void tst_configdialog::useAutoclearPanelTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxAutoclearPanel widget must exist");
 
   dialog.useAutoclearPanel(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(),
+           "useAutoclearPanel(true) should check checkBoxAutoclearPanel");
   dialog.useAutoclearPanel(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(),
+           "useAutoclearPanel(false) should uncheck checkBoxAutoclearPanel");
 }
 
 /**
@@ -103,9 +109,9 @@ void tst_configdialog::useGitTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxUseGit widget must exist");
 
   dialog.useGit(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(), "useGit(true) should check checkBoxUseGit");
   dialog.useGit(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(), "useGit(false) should uncheck checkBoxUseGit");
 }
 
 /**
@@ -117,9 +123,9 @@ void tst_configdialog::useOtpTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxUseOtp widget must exist");
 
   dialog.useOtp(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(), "useOtp(true) should check checkBoxUseOtp");
   dialog.useOtp(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(), "useOtp(false) should uncheck checkBoxUseOtp");
 }
 
 /**
@@ -132,9 +138,11 @@ void tst_configdialog::useGrepSearchTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxUseGrepSearch widget must exist");
 
   dialog.useGrepSearch(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(),
+           "useGrepSearch(true) should check checkBoxUseGrepSearch");
   dialog.useGrepSearch(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(),
+           "useGrepSearch(false) should uncheck checkBoxUseGrepSearch");
 }
 
 /**
@@ -160,9 +168,11 @@ void tst_configdialog::usePwgenTogglesCheckbox() {
   // Now with a non-empty path the value flows through.
   pwgenPath->setText(QStringLiteral("/usr/bin/pwgen"));
   dialog.usePwgen(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(),
+           "usePwgen(true) with a configured pwgenPath should check "
+           "checkBoxUsePwgen");
   dialog.usePwgen(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(), "usePwgen(false) should uncheck checkBoxUsePwgen");
 }
 
 /**
@@ -175,9 +185,11 @@ void tst_configdialog::useTemplateTogglesCheckbox() {
   QVERIFY2(cb != nullptr, "checkBoxUseTemplate widget must exist");
 
   dialog.useTemplate(true);
-  QVERIFY(cb->isChecked());
+  QVERIFY2(cb->isChecked(),
+           "useTemplate(true) should check checkBoxUseTemplate");
   dialog.useTemplate(false);
-  QVERIFY(!cb->isChecked());
+  QVERIFY2(!cb->isChecked(),
+           "useTemplate(false) should uncheck checkBoxUseTemplate");
 }
 
 QTEST_MAIN(tst_configdialog)


### PR DESCRIPTION
## Summary

\`ConfigDialog\` (1311 lines, 61 methods) had **zero** test coverage. Most of its public-facing surface is a family of small \"load setting into UI\" methods (\`useSelection\`, \`useAutoclear\`, \`useGit\`, \`useOtp\`, \`useGrepSearch\`, \`usePwgen\`, \`useTemplate\`, \`useAutoclearPanel\`) plus the constructor — all reachable in isolation with a \`nullptr\` MainWindow parent (the constructor stores the parent pointer but never dereferences it during construction).

This is the third dialog-per-subdir test (after \`keygendialog/\` #1476 and \`trayicon/\` #1477) — same scaffold pattern.

## Tests

| Case | What it asserts |
|---|---|
| \`constructionDoesNotCrash\` | Constructor's setting-load / widget-wiring path completes. |
| \`useSelectionTogglesCheckbox\` | \`useSelection(bool)\` flows to \`checkBoxSelection\`. |
| \`useAutoclearTogglesCheckbox\` | \`useAutoclear(bool)\` → \`checkBoxAutoclear\`. |
| \`useAutoclearPanelTogglesCheckbox\` | \`useAutoclearPanel(bool)\` → \`checkBoxAutoclearPanel\`. |
| \`useGitTogglesCheckbox\` | \`useGit(bool)\` → \`checkBoxUseGit\`. |
| \`useOtpTogglesCheckbox\` | \`useOtp(bool)\` → \`checkBoxUseOtp\`. |
| \`useGrepSearchTogglesCheckbox\` | \`useGrepSearch(bool)\` → \`checkBoxUseGrepSearch\`. |
| \`useTemplateTogglesCheckbox\` | \`useTemplate(bool)\` → \`checkBoxUseTemplate\`. |
| \`usePwgenTogglesCheckbox\` | Covers both branches: \`usePwgen(true)\` is **clamped to false** when \`pwgenPath\` is empty (you can't use a tool that isn't configured); flows through normally when \`pwgenPath\` is set. |

## Out of scope

Need a real MainWindow / Pass singleton:
- \`genKey()\` — tunnels to \`mainWindow->generateKeyPair()\`
- \`on_pushButtonGenerateKey_clicked()\` — drives \`KeygenDialog\`
- \`setProfiles()\` / profile-table flows
- Settings persistence (\`on_accepted\` is already covered indirectly via \`tst_util::sshAuthSockOverrideStatus\` from #1469)

Privately-scoped helpers (\`setGitPath()\`, \`usePass()\`, \`setGroupBoxState()\`) also can't be tested from outside without a friend declaration; left alone.

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`tests/auto/configdialog/tst_configdialog\` — 11/11 (incl. init/cleanup)
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new automated test suite validating configuration dialog toggles and behavior.
* **Build**
  * Updated test project configuration to include the new test subdirectory and build inputs.
* **Platform**
  * Added a macOS app metadata template to support running tests on macOS.
* **Chores**
  * Updated ignore rules to exclude generated/auto test artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1481)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->