### PR TITLE
chore: NSHighResolutionCapable as a real plist boolean, not <string>True</string>

### DIFF
--- a/qtpass.plist
+++ b/qtpass.plist
@@ -28,6 +28,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/configdialog/qtpass.plist
+++ b/tests/auto/configdialog/qtpass.plist
@@ -26,6 +26,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/executor/qtpass.plist
+++ b/tests/auto/executor/qtpass.plist
@@ -28,6 +28,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/exportpublickeydialog/qtpass.plist
+++ b/tests/auto/exportpublickeydialog/qtpass.plist
@@ -26,6 +26,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/filecontent/qtpass.plist
+++ b/tests/auto/filecontent/qtpass.plist
@@ -28,6 +28,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/importkeydialog/qtpass.plist
+++ b/tests/auto/importkeydialog/qtpass.plist
@@ -26,6 +26,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/keygendialog/qtpass.plist
+++ b/tests/auto/keygendialog/qtpass.plist
@@ -26,6 +26,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/model/qtpass.plist
+++ b/tests/auto/model/qtpass.plist
@@ -28,6 +28,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/passwordconfig/qtpass.plist
+++ b/tests/auto/passwordconfig/qtpass.plist
@@ -28,6 +28,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/settings/qtpass.plist
+++ b/tests/auto/settings/qtpass.plist
@@ -28,6 +28,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>

--- a/tests/auto/trayicon/qtpass.plist
+++ b/tests/auto/trayicon/qtpass.plist
@@ -26,6 +26,6 @@ This program is free software: you can redistribute it and/or modify it under th
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

CodeRabbit's recurring nit on every new test subdir we add (most recently #1481): the \`NSHighResolutionCapable\` key in our \`qtpass.plist\` files is stored as \`<string>True</string>\` instead of the boolean \`<true/>\` form Apple's plist DTD expects. Sweep the project to fix it once so future per-subdir-PRs don't keep flagging it.

## Files

11 plists touched (+1/-1 each):

- \`qtpass.plist\` (root) — canonical, three symlinks point at it:
  - \`main/qtpass.plist\` -> \`../qtpass.plist\`
  - \`tests/auto/ui/qtpass.plist\` -> \`../../../qtpass.plist\`
  - \`tests/auto/util/qtpass.plist\` -> \`../../../qtpass.plist\`
- 10 free-standing copies under \`tests/auto/\`: \`configdialog\`, \`executor\`, \`exportpublickeydialog\`, \`filecontent\`, \`importkeydialog\`, \`keygendialog\`, \`model\`, \`passwordconfig\`, \`settings\`, \`trayicon\`.

## What this affects

These plists template the macOS \`.app\` bundle's \`Info.plist\`. No Linux/Windows impact, no test-runtime impact. Just correctness per Apple's DTD.

## Out of scope

The duplicate \`<key>NSPrincipalClass</key>\` entry in \`qtpass.plist\` (lines 26-29) is a different pre-existing issue. Left alone.

## Test plan

- [x] \`make -j4\` clean
- [x] \`tests/auto/configdialog/tst_configdialog\` — 11/11 (smoke that the test plist still parses)
- [x] No \`<string>True</string>\` left in any plist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated macOS application configuration settings to use proper boolean formatting across configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1483)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->