### PR TITLE
fix: remove duplicate NSPrincipalClass key from plist files

### DIFF
--- a/qtpass.plist
+++ b/qtpass.plist
@@ -25,8 +25,6 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>

--- a/tests/auto/executor/qtpass.plist
+++ b/tests/auto/executor/qtpass.plist
@@ -25,8 +25,6 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>

--- a/tests/auto/filecontent/qtpass.plist
+++ b/tests/auto/filecontent/qtpass.plist
@@ -25,8 +25,6 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>

--- a/tests/auto/model/qtpass.plist
+++ b/tests/auto/model/qtpass.plist
@@ -25,8 +25,6 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>

--- a/tests/auto/passwordconfig/qtpass.plist
+++ b/tests/auto/passwordconfig/qtpass.plist
@@ -25,8 +25,6 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>

--- a/tests/auto/settings/qtpass.plist
+++ b/tests/auto/settings/qtpass.plist
@@ -25,8 +25,6 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Summary

- Removes duplicate `NSPrincipalClass` key from `qtpass.plist` and 5 test plist files
- Duplicate keys in plist files cause undefined behavior on macOS (only one value is recognized)
- Affected files: `qtpass.plist`, `tests/auto/executor/`, `filecontent/`, `model/`, `passwordconfig/`, `settings/`

## Test plan

- [ ] Verify plist files parse correctly on macOS (`plutil -lint qtpass.plist`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added high-resolution display support for macOS (Retina displays).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1485)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->