### PR TITLE
chore: remove deprecated CFBundlePackageType key from all plists

### DIFF
--- a/qtpass.plist
+++ b/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/configdialog/qtpass.plist
+++ b/tests/auto/configdialog/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/executor/qtpass.plist
+++ b/tests/auto/executor/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/exportpublickeydialog/qtpass.plist
+++ b/tests/auto/exportpublickeydialog/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/filecontent/qtpass.plist
+++ b/tests/auto/filecontent/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/importkeydialog/qtpass.plist
+++ b/tests/auto/importkeydialog/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/keygendialog/qtpass.plist
+++ b/tests/auto/keygendialog/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/model/qtpass.plist
+++ b/tests/auto/model/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/passwordconfig/qtpass.plist
+++ b/tests/auto/passwordconfig/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/settings/qtpass.plist
+++ b/tests/auto/settings/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>

--- a/tests/auto/trayicon/qtpass.plist
+++ b/tests/auto/trayicon/qtpass.plist
@@ -12,8 +12,6 @@
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qtpass</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
## Summary

- Removes `CFBundlePackageType` (`APPL`) from all 11 plist files
- This key has been deprecated since macOS 10.0; Apple recommends omitting it entirely in modern Info.plist files

## Test plan

- [ ] `plutil -lint qtpass.plist` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application bundle metadata configuration across the application and test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1486)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->