### PR TITLE
refactor: drop default arguments from virtual functions (google-default-arguments)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
-Checks: 'modernize-*,performance-*,bugprone-*,google-explicit-constructor,google-build-using-namespace,google-runtime-int,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-bugprone-throwing-static-initialization,-bugprone-easily-swappable-parameters'
+Checks: 'modernize-*,performance-*,bugprone-*,google-explicit-constructor,google-build-using-namespace,google-runtime-int,google-default-arguments,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-bugprone-throwing-static-initialization,-bugprone-easily-swappable-parameters'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^(?!.*qprogressindicator).*$'

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -192,8 +192,7 @@ protected:
    * @param readStderr Whether to capture stderr.
    */
   void executeWrapper(PROCESS id, const QString &app, const QStringList &args,
-                      QString input, bool readStdout = true,
-                      bool readStderr = true) override;
+                      QString input, bool readStdout, bool readStderr) override;
 
 public:
   /**
@@ -240,13 +239,13 @@ public:
    * @param newValue Password content to store.
    * @param overwrite true to overwrite an existing file.
    */
-  void Insert(QString file, QString newValue, bool overwrite = false) override;
+  void Insert(QString file, QString newValue, bool overwrite) override;
   /**
    * @brief Remove password.
    * @param file Path to the file or directory to remove.
    * @param isDir true if removing a directory.
    */
-  void Remove(QString file, bool isDir = false) override;
+  void Remove(QString file, bool isDir) override;
   /**
    * @brief Initialize store.
    * @param path Root path of the password store.
@@ -278,16 +277,14 @@ public:
    * @param dest Destination path.
    * @param force true to overwrite existing destination.
    */
-  void Move(const QString src, const QString dest,
-            const bool force = false) override;
+  void Move(const QString src, const QString dest, const bool force) override;
   /**
    * @brief Copy password file.
    * @param src Source path.
    * @param dest Destination path.
    * @param force true to overwrite existing destination.
    */
-  void Copy(const QString src, const QString dest,
-            const bool force = false) override;
+  void Copy(const QString src, const QString dest, const bool force) override;
   /**
    * @brief Search all password content by GPG-decrypting each .gpg file.
    *
@@ -298,7 +295,7 @@ public:
    * @param pattern Search pattern (QRegularExpression).
    * @param caseInsensitive true for case-insensitive search.
    */
-  void Grep(QString pattern, bool caseInsensitive = false) override;
+  void Grep(QString pattern, bool caseInsensitive) override;
 
 private:
   int m_grepSeq = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1549,7 +1549,7 @@ void MainWindow::renameFolder() {
   if (!confirmPathInStore(destDir)) {
     return;
   }
-  QtPassSettings::getPass()->Move(srcDir, destDir);
+  QtPassSettings::getPass()->Move(srcDir, destDir, false);
 }
 
 /**
@@ -1587,7 +1587,7 @@ void MainWindow::renamePassword() {
   if (!confirmPathInStore(newFile)) {
     return;
   }
-  QtPassSettings::getPass()->Move(file, newFile);
+  QtPassSettings::getPass()->Move(file, newFile, false);
 }
 
 /**

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -454,7 +454,7 @@ void Pass::GenerateGPGKeys(QString batch) {
   }
 
   executeWrapper(GPG_GENKEYS, gpgPath, {"--gen-key", "--no-tty", "--batch"},
-                 std::move(batch));
+                 std::move(batch), true, true);
 }
 
 /**

--- a/src/pass.h
+++ b/src/pass.h
@@ -135,7 +135,7 @@ public:
    * @param force Overwrite existing.
    */
   virtual void Move(const QString srcDir, const QString dest,
-                    const bool force = false) = 0;
+                    const bool force) = 0;
   /**
    * @brief Copy password file or directory.
    * @param srcDir Source path.
@@ -143,7 +143,7 @@ public:
    * @param force Overwrite existing.
    */
   virtual void Copy(const QString srcDir, const QString dest,
-                    const bool force = false) = 0;
+                    const bool force) = 0;
   /**
    * @brief Initialize new password store.
    * @param path Root of password store.
@@ -155,7 +155,7 @@ public:
    * @param pattern Search pattern (regular expression).
    * @param caseInsensitive true for case-insensitive search.
    */
-  virtual void Grep(QString pattern, bool caseInsensitive = false) = 0;
+  virtual void Grep(QString pattern, bool caseInsensitive) = 0;
 
   /**
    * @brief Generate random password.
@@ -266,7 +266,7 @@ protected:
    */
   virtual void executeWrapper(PROCESS id, const QString &app,
                               const QStringList &args, QString input,
-                              bool readStdout = true, bool readStderr = true);
+                              bool readStdout, bool readStderr);
 
 protected slots:
   /**

--- a/src/realpass.h
+++ b/src/realpass.h
@@ -76,13 +76,13 @@ public:
    * @param newValue Password content.
    * @param overwrite true to overwrite existing.
    */
-  void Insert(QString file, QString newValue, bool overwrite = false) override;
+  void Insert(QString file, QString newValue, bool overwrite) override;
   /**
    * @brief Remove password or directory.
    * @param file Path to remove.
    * @param isDir true if removing directory.
    */
-  void Remove(QString file, bool isDir = false) override;
+  void Remove(QString file, bool isDir) override;
   /**
    * @brief Initialize password store.
    * @param path Store root path.
@@ -98,22 +98,20 @@ public:
    * @param dest Destination path.
    * @param force Overwrite existing.
    */
-  void Move(const QString src, const QString dest,
-            const bool force = false) override;
+  void Move(const QString src, const QString dest, const bool force) override;
   /**
    * @brief Copy password file or directory.
    * @param src Source path.
    * @param dest Destination path.
    * @param force Overwrite existing.
    */
-  void Copy(const QString src, const QString dest,
-            const bool force = false) override;
+  void Copy(const QString src, const QString dest, const bool force) override;
   /**
    * @brief Search password content via 'pass grep'.
    * @param pattern Search pattern.
    * @param caseInsensitive true for case-insensitive search.
    */
-  void Grep(QString pattern, bool caseInsensitive = false) override;
+  void Grep(QString pattern, bool caseInsensitive) override;
 };
 
 #endif // SRC_REALPASS_H_

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -388,9 +388,9 @@ auto StoreModel::handleDirDrop(const QString &cleanedSrc,
   QString cleanedDestDir = QDir::cleanPath(destDir.absolutePath());
 
   if (action == Qt::MoveAction) {
-    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDestDir);
+    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDestDir, false);
   } else if (action == Qt::CopyAction) {
-    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDestDir);
+    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDestDir, false);
   }
   return true;
 }
@@ -409,9 +409,9 @@ auto StoreModel::handleFileToDirDrop(const QString &cleanedSrc,
                                      const QString &cleanedDest,
                                      Qt::DropAction action) -> bool {
   if (action == Qt::MoveAction) {
-    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDest);
+    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDest, false);
   } else if (action == Qt::CopyAction) {
-    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDest);
+    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDest, false);
   }
   return true;
 }

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -380,7 +380,7 @@ void tst_integration::imitatePass_insertAndGrep() {
   QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);
-  pass.Grep(QStringLiteral("token"));
+  pass.Grep(QStringLiteral("token"), false);
   QVERIFY2(waitForSignal(grepSpy, 20000), "finishedGrep not emitted");
 
   const auto results = grepSpy[0][0].value<GrepResults>();
@@ -439,7 +439,7 @@ void tst_integration::imitatePass_grepSkipsUndecryptableFiles() {
   c2.close();
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);
-  pass.Grep(QStringLiteral("token"));
+  pass.Grep(QStringLiteral("token"), false);
   QVERIFY2(waitForSignal(grepSpy, 20000), "finishedGrep not emitted");
 
   const auto results = grepSpy[0][0].value<GrepResults>();
@@ -473,7 +473,7 @@ void tst_integration::imitatePass_insertMoveAndShow() {
   QVERIFY2(QFile::exists(src), "source .gpg must exist before move");
 
   // Without git, Move is synchronous — no signal emitted.
-  pass.Move(src, dst);
+  pass.Move(src, dst, false);
   QVERIFY2(!QFile::exists(src), "source should be gone after move");
   QVERIFY2(QFile::exists(dst), "destination should exist after move");
 
@@ -498,7 +498,7 @@ void tst_integration::imitatePass_insertCopyAndShow() {
   const QString dst = storeDir.path() + "/copy.gpg";
 
   // Without git, Copy is synchronous — no finishedCopy signal emitted.
-  pass.Copy(src, dst);
+  pass.Copy(src, dst, false);
   QVERIFY2(QFile::exists(src), "source should still exist after copy");
   QVERIFY2(QFile::exists(dst), "destination should exist after copy");
 
@@ -748,7 +748,7 @@ void tst_integration::realPass_insertAndGrep() {
   QVERIFY2(waitForSignal(insertSpy, 20000), gpgInsertErrorMsg(insertErrorSpy));
 
   QSignalSpy grepSpy(&pass, &Pass::finishedGrep);
-  pass.Grep(QStringLiteral("url"));
+  pass.Grep(QStringLiteral("url"), false);
   QVERIFY2(waitForSignal(grepSpy, 30000), "RealPass finishedGrep not emitted");
 
   const auto results = grepSpy[0][0].value<GrepResults>();

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -2036,7 +2036,7 @@ void tst_util::grepImitatePassEmptyStoreEmitsEmpty() {
 
   TestPass pass;
   QSignalSpy spy(&pass, &Pass::finishedGrep);
-  pass.Grep(QStringLiteral("anything"));
+  pass.Grep(QStringLiteral("anything"), false);
   // Wait up to 3 s for the background thread to emit
   QVERIFY2(spy.wait(TEST_SIGNAL_TIMEOUT_MS),
            "Timed out waiting for Pass::finishedGrep signal");
@@ -2054,7 +2054,7 @@ void tst_util::grepImitatePassInvalidRegexEmitsEmpty() {
   TestPass pass;
   QSignalSpy spy(&pass, &Pass::finishedGrep);
   // An invalid regex (unmatched '[') must still emit an empty result
-  pass.Grep(QStringLiteral("[invalid"));
+  pass.Grep(QStringLiteral("[invalid"), false);
   QVERIFY2(spy.wait(TEST_SIGNAL_TIMEOUT_MS),
            "Timed out waiting for Pass::finishedGrep signal");
   QCOMPARE(spy.count(), 1);


### PR DESCRIPTION
## Summary

Closes the loop on the deferred clang-tidy finding from #1487. Defaults on \`virtual\` / \`override\` methods are a Google-style anti-pattern because the default value depends on which **static** type the call goes through:

\`\`\`cpp
// Base virtual with default
virtual void Move(QString src, QString dest, bool force = false) = 0;

// Override redeclares the default (or it would be a compile error)
void Move(QString src, QString dest, bool force = false) override;

Pass *base = new RealPass();
base->Move(a, b);          // uses BASE default
realpass_ptr->Move(a, b);  // uses RealPass default — may differ
\`\`\`

If subclasses ever drift, the default value silently differs by pointer type. Remove the trap.

## Changes

**\`src/pass.h\`** — remove defaults from 4 base virtuals:
- \`Move(..., bool force)\`
- \`Copy(..., bool force)\`
- \`Grep(..., bool caseInsensitive)\`
- \`executeWrapper(..., bool readStdout, bool readStderr)\`

**\`src/imitatepass.h\` / \`src/realpass.h\`** — strip the duplicated \`= false\` from every override declaration (\`Insert\`, \`Remove\`, \`Move\`, \`Copy\`, \`Grep\`, plus \`executeWrapper\` for ImitatePass).

**Callers updated** to pass values explicitly:
- \`src/storemodel.cpp\`: 4× \`Move\`/\`Copy\` in drag-drop handlers.
- \`src/mainwindow.cpp\`: 2× \`Move\` in \`renameFolder\` / \`renamePassword\`.
- \`src/pass.cpp\`: 1× \`executeWrapper\` in \`GenerateGPGKeys\`.
- \`tests/auto/util/tst_util.cpp\`: 2× \`Grep\`.
- \`tests/auto/integration/tst_integration.cpp\`: 3× \`Grep\`, 1× \`Move\`, 1× \`Copy\`.

**\`.clang-tidy\`** — add \`google-default-arguments\` now that the codebase is clean. Locks the status quo in.

## Test plan

- [x] \`qmake6 -r && make -j4\` clean
- [x] \`clang-tidy --checks='-*,google-default-arguments'\` on \`src/*.cpp\` → 0 findings
- [x] \`tests/auto/util/tst_util\` — 124/124
- [x] \`tests/auto/integration/tst_integration\` — 20/20
- [x] \`clang-format\` applied

## Note

This is a refactor with semantic-preservation guarantees: every explicit \`false\` / \`true, true\` matches the previous implicit default exactly. No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality by enforcing explicit parameter passing in internal methods, eliminating reliance on default values across password management operations and supporting utilities. Updated static analysis configuration to enforce consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1488)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->