### PR TITLE
test(mainwindow): add MainWindow widget test suite

### DIFF
--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/mainwindow/mainwindow.pro
+++ b/tests/auto/mainwindow/mainwindow.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_mainwindow.cpp
+
+LIBS += -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += ../../../src/mainwindow.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/mainwindow/qtpass.plist
+++ b/tests/auto/mainwindow/qtpass.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @brief Widget tests for MainWindow.
+ *
+ * These tests exercise the public surface of MainWindow in isolation.
+ * Each test gets a fresh window instance; a single QTemporaryDir serves as
+ * the pass store for the whole run.
+ *
+ * Coverage deferred here (requires live GPG / pass / git operations):
+ * - addPassword / addFolder / renameFolder / renamePassword — invoke Pass
+ * - on_treeView_clicked / doubleClicked — need a populated store model
+ * - onGrepFinished — depends on a running grep
+ * - generateKeyPair — spawns gpg key generation
+ */
+
+#include <QApplication>
+#include <QFile>
+#include <QScopedPointer>
+#include <QStatusBar>
+#include <QTemporaryDir>
+#include <QTextBrowser>
+#include <QTextEdit>
+#include <QTreeView>
+#include <QtTest>
+
+#include "../../../src/mainwindow.h"
+#include "../../../src/qtpasssettings.h"
+#include "../../../src/util.h"
+
+class tst_mainwindow : public QObject {
+  Q_OBJECT
+
+  QTemporaryDir m_storeDir;
+  QScopedPointer<MainWindow> m_window;
+
+private Q_SLOTS:
+  void initTestCase();
+  void init();
+  void cleanup();
+  void cleanupTestCase();
+
+  void constructionDoesNotCrash();
+  void getKeygenDialogInitiallyNull();
+  void cleanKeygenDialogWithNullIsHarmless();
+  void setUiElementsEnabledDisablesTreeView();
+  void setUiElementsEnabledEnablesTreeView();
+  void flashTextSetsContent();
+  void flashTextErrorDoesNotCrash();
+  void flashTextHtmlRenderedInBrowser();
+  void showStatusMessageAppearsInStatusBar();
+  void deselectDoesNotCrash();
+  void onProcessOutputAppendsToPanel();
+  void onProcessOutputSkippedWhenPanelHidden();
+};
+
+void tst_mainwindow::initTestCase() {
+  QVERIFY2(m_storeDir.isValid(), "temp store dir must be created");
+
+  // Minimal valid pass store: just a .gpg-id file
+  QFile gpgId(m_storeDir.path() + QStringLiteral("/.gpg-id"));
+  QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
+  gpgId.write("0000000000000000\n");
+  gpgId.close();
+
+  // Point QtPassSettings at the temp store and use gpg (not pass) mode so
+  // configIsValid() only requires the .gpg-id file + a gpg binary.
+  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setUsePass(false);
+
+  // Verify gpg is reachable; initExecutables() will set the path, but we
+  // check early so the QSKIP fires before any MainWindow is constructed.
+  QString gpg = Util::findBinaryInPath(QStringLiteral("gpg2"));
+  if (gpg.isEmpty())
+    gpg = Util::findBinaryInPath(QStringLiteral("gpg"));
+  if (gpg.isEmpty())
+    QSKIP("gpg not available — skipping MainWindow construction tests");
+}
+
+void tst_mainwindow::init() {
+  // Re-apply store settings in case a previous test modified them.
+  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setUsePass(false);
+  QtPassSettings::setShowProcessOutput(true);
+  m_window.reset(new MainWindow);
+}
+
+void tst_mainwindow::cleanup() { m_window.reset(); }
+
+void tst_mainwindow::cleanupTestCase() {
+  // Restore a clean state so the user's live config is not left pointing
+  // at our temp store (which will be deleted when m_storeDir goes out of
+  // scope).
+  QtPassSettings::setPassStore(QString());
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Constructor completes without crashing when a valid store exists.
+ */
+void tst_mainwindow::constructionDoesNotCrash() {
+  // init() already constructed the window; reaching this line is the test.
+  QVERIFY2(m_window != nullptr, "MainWindow must have been constructed");
+}
+
+/**
+ * @brief getKeygenDialog() returns nullptr before any keygen is started.
+ */
+void tst_mainwindow::getKeygenDialogInitiallyNull() {
+  QCOMPARE(m_window->getKeygenDialog(), nullptr);
+}
+
+/**
+ * @brief cleanKeygenDialog() is a no-op (and harmless) when no dialog exists.
+ */
+void tst_mainwindow::cleanKeygenDialogWithNullIsHarmless() {
+  QCOMPARE(m_window->getKeygenDialog(), nullptr);
+  m_window->cleanKeygenDialog();
+  QCOMPARE(m_window->getKeygenDialog(), nullptr);
+}
+
+/**
+ * @brief setUiElementsEnabled(false) disables the tree view and search field.
+ */
+void tst_mainwindow::setUiElementsEnabledDisablesTreeView() {
+  auto *treeView = m_window->findChild<QTreeView *>(QStringLiteral("treeView"));
+  QVERIFY2(treeView != nullptr, "treeView widget must exist");
+
+  m_window->setUiElementsEnabled(false);
+  QVERIFY2(!treeView->isEnabled(), "treeView must be disabled");
+}
+
+/**
+ * @brief setUiElementsEnabled(true) re-enables the tree view.
+ */
+void tst_mainwindow::setUiElementsEnabledEnablesTreeView() {
+  auto *treeView = m_window->findChild<QTreeView *>(QStringLiteral("treeView"));
+  QVERIFY2(treeView != nullptr, "treeView widget must exist");
+
+  m_window->setUiElementsEnabled(false);
+  m_window->setUiElementsEnabled(true);
+  QVERIFY2(treeView->isEnabled(), "treeView must be re-enabled");
+}
+
+/**
+ * @brief flashText() sets the text browser content.
+ */
+void tst_mainwindow::flashTextSetsContent() {
+  auto *browser =
+      m_window->findChild<QTextBrowser *>(QStringLiteral("textBrowser"));
+  QVERIFY2(browser != nullptr, "textBrowser must exist");
+
+  m_window->flashText(QStringLiteral("hello mainwindow test"), false);
+  QVERIFY2(
+      browser->toPlainText().contains(QStringLiteral("hello mainwindow test")),
+      "textBrowser must contain the flashed text");
+}
+
+/**
+ * @brief flashText() with isError=true does not crash.
+ */
+void tst_mainwindow::flashTextErrorDoesNotCrash() {
+  auto *browser =
+      m_window->findChild<QTextBrowser *>(QStringLiteral("textBrowser"));
+  QVERIFY2(browser != nullptr, "textBrowser must exist");
+
+  m_window->flashText(QStringLiteral("error text"), true);
+  QVERIFY2(browser->toPlainText().contains(QStringLiteral("error text")),
+           "textBrowser must contain the error text");
+}
+
+/**
+ * @brief flashText() with isHtml=true renders HTML into the browser.
+ */
+void tst_mainwindow::flashTextHtmlRenderedInBrowser() {
+  auto *browser =
+      m_window->findChild<QTextBrowser *>(QStringLiteral("textBrowser"));
+  QVERIFY2(browser != nullptr, "textBrowser must exist");
+
+  m_window->flashText(QStringLiteral("<b>bold</b>"), false, true);
+  // toHtml() includes the full document wrapper; the source fragment must
+  // survive the round-trip.
+  QVERIFY2(browser->toHtml().contains(QStringLiteral("bold")),
+           "HTML content must appear in textBrowser");
+}
+
+/**
+ * @brief showStatusMessage() writes to the status bar.
+ */
+void tst_mainwindow::showStatusMessageAppearsInStatusBar() {
+  m_window->showStatusMessage(QStringLiteral("status test"), 60000);
+  QCOMPARE(m_window->statusBar()->currentMessage(),
+           QStringLiteral("status test"));
+}
+
+/**
+ * @brief deselect() does not crash when nothing is selected.
+ */
+void tst_mainwindow::deselectDoesNotCrash() {
+  m_window->deselect();
+  // No assertion needed — reaching this line means no crash / assert fired.
+}
+
+/**
+ * @brief onProcessOutput() appends text to the process output panel when the
+ *        panel is visible.
+ */
+void tst_mainwindow::onProcessOutputAppendsToPanel() {
+  auto *outputEdit =
+      m_window->findChild<QTextEdit *>(QStringLiteral("processOutputEdit"));
+  QVERIFY2(outputEdit != nullptr, "processOutputEdit must exist");
+
+  m_window->onProcessOutput(QStringLiteral("process output line"), false);
+  QVERIFY2(
+      outputEdit->toPlainText().contains(QStringLiteral("process output line")),
+      "processOutputEdit must contain the appended line");
+}
+
+/**
+ * @brief onProcessOutput() does nothing when the panel is hidden
+ *        (isShowProcessOutput == false).
+ */
+void tst_mainwindow::onProcessOutputSkippedWhenPanelHidden() {
+  QtPassSettings::setShowProcessOutput(false);
+
+  auto *outputEdit =
+      m_window->findChild<QTextEdit *>(QStringLiteral("processOutputEdit"));
+  QVERIFY2(outputEdit != nullptr, "processOutputEdit must exist");
+
+  const QString before = outputEdit->toPlainText();
+  m_window->onProcessOutput(QStringLiteral("should not appear"), false);
+  QCOMPARE(outputEdit->toPlainText(), before);
+}
+
+QTEST_MAIN(tst_mainwindow)
+#include "tst_mainwindow.moc"

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -35,6 +35,10 @@ class tst_mainwindow : public QObject {
   QTemporaryDir m_storeDir;
   QScopedPointer<MainWindow> m_window;
   QString m_gpgPath;
+  QString m_savedPassStore;
+  bool m_savedUsePass;
+  bool m_savedShowProcessOutput;
+  QString m_savedGpgExecutable;
 
 private Q_SLOTS:
   void initTestCase();
@@ -64,6 +68,12 @@ void tst_mainwindow::initTestCase() {
   QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.write("0000000000000000\n");
   gpgId.close();
+
+  // Save original settings before modifying them
+  m_savedPassStore = QtPassSettings::getPassStore();
+  m_savedUsePass = QtPassSettings::isUsePass();
+  m_savedShowProcessOutput = QtPassSettings::isShowProcessOutput();
+  m_savedGpgExecutable = QtPassSettings::getGpgExecutable();
 
   // Point QtPassSettings at the temp store and use gpg (not pass) mode so
   // configIsValid() only requires the .gpg-id file + a gpg binary.
@@ -100,10 +110,13 @@ void tst_mainwindow::init() {
 void tst_mainwindow::cleanup() { m_window.reset(); }
 
 void tst_mainwindow::cleanupTestCase() {
-  // Restore a clean state so the user's live config is not left pointing
+  // Restore all saved settings so the user's live config is not left pointing
   // at our temp store (which will be deleted when m_storeDir goes out of
   // scope).
-  QtPassSettings::setPassStore(QString());
+  QtPassSettings::setPassStore(m_savedPassStore);
+  QtPassSettings::setUsePass(m_savedUsePass);
+  QtPassSettings::setShowProcessOutput(m_savedShowProcessOutput);
+  QtPassSettings::setGpgExecutable(m_savedGpgExecutable);
 }
 
 // ---------------------------------------------------------------------------
@@ -192,9 +205,13 @@ void tst_mainwindow::flashTextHtmlRenderedInBrowser() {
 
   m_window->flashText(QStringLiteral("<b>bold</b>"), false, true);
   // toHtml() includes the full document wrapper; the source fragment must
-  // survive the round-trip.
-  QVERIFY2(browser->toHtml().contains(QStringLiteral("bold")),
-           "HTML content must appear in textBrowser");
+  // survive the round-trip and be rendered (not escaped).
+  QVERIFY2(browser->toHtml().contains(QStringLiteral("<b>bold</b>")),
+           "flashText with isHtml=true must render <b>bold</b> tags in "
+           "browser->toHtml(), not escape them");
+  QVERIFY2(!browser->toHtml().contains(QStringLiteral("&lt;b&gt;bold&lt;/b&gt;")),
+           "flashText with isHtml=true must NOT produce escaped "
+           "&lt;b&gt;bold&lt;/b&gt; in browser->toHtml()");
 }
 
 /**

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -34,6 +34,7 @@ class tst_mainwindow : public QObject {
 
   QTemporaryDir m_storeDir;
   QScopedPointer<MainWindow> m_window;
+  QString m_gpgPath;
 
 private Q_SLOTS:
   void initTestCase();
@@ -69,13 +70,18 @@ void tst_mainwindow::initTestCase() {
   QtPassSettings::setPassStore(m_storeDir.path());
   QtPassSettings::setUsePass(false);
 
-  // Verify gpg is reachable; initExecutables() will set the path, but we
-  // check early so the QSKIP fires before any MainWindow is constructed.
-  QString gpg = Util::findBinaryInPath(QStringLiteral("gpg2"));
-  if (gpg.isEmpty())
-    gpg = Util::findBinaryInPath(QStringLiteral("gpg"));
-  if (gpg.isEmpty())
+  // Verify gpg is reachable. We also pre-set the executable path so that
+  // QtPass::init() → initExecutables() finds it even when only "gpg" (not
+  // "gpg2") exists in PATH (e.g. Ubuntu CI where gpg2 is not a separate
+  // binary). Without this, initExecutables() leaves the path empty,
+  // configIsValid() returns false, and config() opens a blocking modal
+  // dialog that times out the test after 300 s.
+  m_gpgPath = Util::findBinaryInPath(QStringLiteral("gpg2"));
+  if (m_gpgPath.isEmpty())
+    m_gpgPath = Util::findBinaryInPath(QStringLiteral("gpg"));
+  if (m_gpgPath.isEmpty())
     QSKIP("gpg not available — skipping MainWindow construction tests");
+  QtPassSettings::setGpgExecutable(m_gpgPath);
 }
 
 void tst_mainwindow::init() {
@@ -83,6 +89,11 @@ void tst_mainwindow::init() {
   QtPassSettings::setPassStore(m_storeDir.path());
   QtPassSettings::setUsePass(false);
   QtPassSettings::setShowProcessOutput(true);
+  // Re-apply gpg path: initExecutables() inside the constructor overwrites
+  // the setting to findBinaryInPath("gpg2"), which is empty on systems where
+  // only "gpg" exists. Setting it here ensures configIsValid() sees a valid
+  // executable and does not fall back to the blocking config() dialog.
+  QtPassSettings::setGpgExecutable(m_gpgPath);
   m_window.reset(new MainWindow);
 }
 

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <QApplication>
+#include <QDir>
 #include <QFile>
 #include <QScopedPointer>
 #include <QStatusBar>
@@ -64,7 +65,7 @@ void tst_mainwindow::initTestCase() {
   QVERIFY2(m_storeDir.isValid(), "temp store dir must be created");
 
   // Minimal valid pass store: just a .gpg-id file
-  QFile gpgId(m_storeDir.path() + QStringLiteral("/.gpg-id"));
+  QFile gpgId(QDir::cleanPath(m_storeDir.path() + QStringLiteral("/.gpg-id")));
   QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.write("0000000000000000\n");
   gpgId.close();
@@ -77,7 +78,7 @@ void tst_mainwindow::initTestCase() {
 
   // Point QtPassSettings at the temp store and use gpg (not pass) mode so
   // configIsValid() only requires the .gpg-id file + a gpg binary.
-  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setPassStore(QDir::cleanPath(m_storeDir.path()));
   QtPassSettings::setUsePass(false);
 
   // Verify gpg is reachable. We also pre-set the executable path so that
@@ -96,7 +97,7 @@ void tst_mainwindow::initTestCase() {
 
 void tst_mainwindow::init() {
   // Re-apply store settings in case a previous test modified them.
-  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setPassStore(QDir::cleanPath(m_storeDir.path()));
   QtPassSettings::setUsePass(false);
   QtPassSettings::setShowProcessOutput(true);
   // Re-apply gpg path: initExecutables() inside the constructor overwrites
@@ -204,14 +205,14 @@ void tst_mainwindow::flashTextHtmlRenderedInBrowser() {
   QVERIFY2(browser != nullptr, "textBrowser must exist");
 
   m_window->flashText(QStringLiteral("<b>bold</b>"), false, true);
-  // toHtml() includes the full document wrapper; the source fragment must
-  // survive the round-trip and be rendered (not escaped).
-  QVERIFY2(browser->toHtml().contains(QStringLiteral("<b>bold</b>")),
-           "flashText with isHtml=true must render <b>bold</b> tags in "
-           "browser->toHtml(), not escape them");
-  QVERIFY2(!browser->toHtml().contains(QStringLiteral("&lt;b&gt;bold&lt;/b&gt;")),
-           "flashText with isHtml=true must NOT produce escaped "
-           "&lt;b&gt;bold&lt;/b&gt; in browser->toHtml()");
+  // Qt's rich text engine converts <b> to font-weight CSS internally, so
+  // toHtml() never emits literal <b> tags. Verify the text content appears
+  // and that the HTML was rendered (not escaped as &lt;b&gt;).
+  QVERIFY2(browser->toHtml().contains(QStringLiteral("bold")),
+           "flashText with isHtml=true must set content in textBrowser");
+  QVERIFY2(
+      !browser->toHtml().contains(QStringLiteral("&lt;b&gt;bold&lt;/b&gt;")),
+      "flashText with isHtml=true must not escape HTML tags");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `tests/auto/mainwindow/` with 14 Qt Test cases covering the public API of `MainWindow`
- Tests construction, `setUiElementsEnabled`, `flashText` (plain / error / HTML), `showStatusMessage`, `deselect`, `onProcessOutput` (visible and hidden panel), and `getKeygenDialog` / `cleanKeygenDialog`
- Uses a `QTemporaryDir` with a `.gpg-id` file as a minimal valid pass store; auto-skips the entire suite if no `gpg` binary is found, so the test never blocks on CI environments without GPG
- Wires the suite into `tests/auto/auto.pro`

## Test plan

- [x] All 14 tests pass locally: `Totals: 14 passed, 0 failed, 0 skipped`
- [x] `clang-format --style=file --dry-run -Werror` passes on `tst_mainwindow.cpp`
- [ ] CI green

## Notes

`constructionDoesNotCrash` emits a harmless Qt warning:
> `No matching signal for on_clearOutputButton_clicked()`

This is a pre-existing condition — `m_clearOutputButton` is created programmatically and connected explicitly (mainwindow.cpp:347); `connectSlotsByName` simply can't auto-wire it. The connection works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive MainWindow tests covering construction, dialogs, UI enable/disable, status messages, process output handling, and cleanup.

* **Chores**
  * Included new test project configuration so main-window test targets are built and run in automated tests.

* **Packaging**
  * Added a macOS application metadata template (bundle display name, executable, icon, version placeholders).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->