### PR TITLE
refactor(test/mainwindow): use QDir::filePath() for .gpg-id path construction

### DIFF
--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -65,7 +65,8 @@ void tst_mainwindow::initTestCase() {
   QVERIFY2(m_storeDir.isValid(), "temp store dir must be created");
 
   // Minimal valid pass store: just a .gpg-id file
-  QFile gpgId(QDir::cleanPath(QDir(m_storeDir.path()).filePath(QStringLiteral(".gpg-id"))));
+  QFile gpgId(QDir::cleanPath(
+      QDir(m_storeDir.path()).filePath(QStringLiteral(".gpg-id"))));
   QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.write("0000000000000000\n");
   gpgId.close();

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -65,7 +65,7 @@ void tst_mainwindow::initTestCase() {
   QVERIFY2(m_storeDir.isValid(), "temp store dir must be created");
 
   // Minimal valid pass store: just a .gpg-id file
-  QFile gpgId(QDir(m_storeDir.path()).filePath(QStringLiteral(".gpg-id")));
+  QFile gpgId(QDir::cleanPath(QDir(m_storeDir.path()).filePath(QStringLiteral(".gpg-id"))));
   QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.write("0000000000000000\n");
   gpgId.close();

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -65,7 +65,7 @@ void tst_mainwindow::initTestCase() {
   QVERIFY2(m_storeDir.isValid(), "temp store dir must be created");
 
   // Minimal valid pass store: just a .gpg-id file
-  QFile gpgId(QDir::cleanPath(m_storeDir.path() + QStringLiteral("/.gpg-id")));
+  QFile gpgId(QDir(m_storeDir.path()).filePath(QStringLiteral(".gpg-id")));
   QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.write("0000000000000000\n");
   gpgId.close();


### PR DESCRIPTION
## Summary

- Replace `QDir::cleanPath(m_storeDir.path() + "/.gpg-id")` with `QDir(m_storeDir.path()).filePath(".gpg-id")` — more idiomatic Qt path construction that handles separator normalisation intrinsically, without manual string concatenation.

## Skipped findings

- **Rename `tst_mainwindow` → `tst_MainWindow`**: every other test class in the project uses `tst_<lowercase>` (`tst_storemodel`, `tst_gpgkeystate`, `tst_configdialog`, …). The rename would be inconsistent with the established convention.
- **Add `normalHtml != errorHtml` styling assertion**: `flashText` calls `setTextColor(Qt::red)` then `setText(text)`. For plain text, `setText()` delegates to `setPlainText()` which resets the document with default formatting, discarding the char format set by `setTextColor()`. Both calls produce identical `toHtml()` output, so the assertion would always fail.

## Test plan

- [x] All 14 tests pass locally with `--platform offscreen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test handling of store file paths to be more robust across environments.
  * Made minimal test store creation more reliable, reducing flaky behavior in main-window tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->