### PR TITLE
test: add UserInfo and ProfileInit unit test suites

### DIFF
--- a/src/profileinit.cpp
+++ b/src/profileinit.cpp
@@ -16,6 +16,9 @@
  * @return true if the path needs initialization.
  */
 auto ProfileInit::needsInit(const QString &path) -> bool {
+  if (path.isEmpty()) {
+    return false;
+  }
   QDir dir(path);
   if (!dir.exists()) {
     return false;

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow userinfo profileinit
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/profileinit/profileinit.pro
+++ b/tests/auto/profileinit/profileinit.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_profileinit.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += ../../../src/profileinit.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/profileinit/qtpass.plist
+++ b/tests/auto/profileinit/qtpass.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/auto/profileinit/tst_profileinit.cpp
+++ b/tests/auto/profileinit/tst_profileinit.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include "../../../src/profileinit.h"
+
+class tst_profileinit : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void needsInitFalseForNonexistentPath();
+  void needsInitFalseForEmptyPath();
+  void needsInitTrueForDirWithoutGpgId();
+  void needsInitFalseForDirWithGpgId();
+  void needsInitFalseAfterGpgIdAdded();
+};
+
+void tst_profileinit::needsInitFalseForNonexistentPath() {
+  QVERIFY(!ProfileInit::needsInit(QStringLiteral("/nonexistent/path/abc123")));
+}
+
+void tst_profileinit::needsInitFalseForEmptyPath() {
+  QVERIFY(!ProfileInit::needsInit(QString()));
+}
+
+void tst_profileinit::needsInitTrueForDirWithoutGpgId() {
+  QTemporaryDir dir;
+  QVERIFY(dir.isValid());
+  QVERIFY(ProfileInit::needsInit(dir.path()));
+}
+
+void tst_profileinit::needsInitFalseForDirWithGpgId() {
+  QTemporaryDir dir;
+  QVERIFY(dir.isValid());
+
+  QFile gpgId(QDir(dir.path()).filePath(QStringLiteral(".gpg-id")));
+  QVERIFY(gpgId.open(QIODevice::WriteOnly));
+  gpgId.close();
+
+  QVERIFY(!ProfileInit::needsInit(dir.path()));
+}
+
+void tst_profileinit::needsInitFalseAfterGpgIdAdded() {
+  QTemporaryDir dir;
+  QVERIFY(dir.isValid());
+
+  QVERIFY(ProfileInit::needsInit(dir.path()));
+
+  QFile gpgId(QDir(dir.path()).filePath(QStringLiteral(".gpg-id")));
+  QVERIFY(gpgId.open(QIODevice::WriteOnly));
+  gpgId.close();
+
+  QVERIFY(!ProfileInit::needsInit(dir.path()));
+}
+
+QTEST_APPLESS_MAIN(tst_profileinit)
+#include "tst_profileinit.moc"

--- a/tests/auto/profileinit/tst_profileinit.cpp
+++ b/tests/auto/profileinit/tst_profileinit.cpp
@@ -23,7 +23,8 @@ void tst_profileinit::needsInitFalseForNonexistentPath() {
   // Build a guaranteed-absent path inside the system temp tree.
   QTemporaryDir base;
   QVERIFY2(base.isValid(), "base temp dir must be created");
-  const QString absent = QDir(base.path()).filePath(QStringLiteral("nonexistent_subdir"));
+  const QString absent =
+      QDir(base.path()).filePath(QStringLiteral("nonexistent_subdir"));
   QVERIFY2(!ProfileInit::needsInit(absent),
            "needsInit must return false for a path that does not exist");
 }

--- a/tests/auto/profileinit/tst_profileinit.cpp
+++ b/tests/auto/profileinit/tst_profileinit.cpp
@@ -20,42 +20,52 @@ private Q_SLOTS:
 };
 
 void tst_profileinit::needsInitFalseForNonexistentPath() {
-  QVERIFY(!ProfileInit::needsInit(QStringLiteral("/nonexistent/path/abc123")));
+  // Build a guaranteed-absent path inside the system temp tree.
+  QTemporaryDir base;
+  QVERIFY2(base.isValid(), "base temp dir must be created");
+  const QString absent = QDir(base.path()).filePath(QStringLiteral("nonexistent_subdir"));
+  QVERIFY2(!ProfileInit::needsInit(absent),
+           "needsInit must return false for a path that does not exist");
 }
 
 void tst_profileinit::needsInitFalseForEmptyPath() {
-  QVERIFY(!ProfileInit::needsInit(QString()));
+  QVERIFY2(!ProfileInit::needsInit(QString()),
+           "needsInit must return false for an empty path");
 }
 
 void tst_profileinit::needsInitTrueForDirWithoutGpgId() {
   QTemporaryDir dir;
-  QVERIFY(dir.isValid());
-  QVERIFY(ProfileInit::needsInit(dir.path()));
+  QVERIFY2(dir.isValid(), "temp dir must be created");
+  QVERIFY2(ProfileInit::needsInit(dir.path()),
+           "needsInit must return true for a directory without .gpg-id");
 }
 
 void tst_profileinit::needsInitFalseForDirWithGpgId() {
   QTemporaryDir dir;
-  QVERIFY(dir.isValid());
+  QVERIFY2(dir.isValid(), "temp dir must be created");
 
   QFile gpgId(QDir(dir.path()).filePath(QStringLiteral(".gpg-id")));
-  QVERIFY(gpgId.open(QIODevice::WriteOnly));
+  QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.close();
 
-  QVERIFY(!ProfileInit::needsInit(dir.path()));
+  QVERIFY2(!ProfileInit::needsInit(dir.path()),
+           "needsInit must return false for a directory that has .gpg-id");
 }
 
 void tst_profileinit::needsInitFalseAfterGpgIdAdded() {
   QTemporaryDir dir;
-  QVERIFY(dir.isValid());
+  QVERIFY2(dir.isValid(), "temp dir must be created");
 
-  QVERIFY(ProfileInit::needsInit(dir.path()));
+  QVERIFY2(ProfileInit::needsInit(dir.path()),
+           "needsInit must return true before .gpg-id is created");
 
   QFile gpgId(QDir(dir.path()).filePath(QStringLiteral(".gpg-id")));
-  QVERIFY(gpgId.open(QIODevice::WriteOnly));
+  QVERIFY2(gpgId.open(QIODevice::WriteOnly), ".gpg-id must be writable");
   gpgId.close();
 
-  QVERIFY(!ProfileInit::needsInit(dir.path()));
+  QVERIFY2(!ProfileInit::needsInit(dir.path()),
+           "needsInit must return false after .gpg-id is created");
 }
 
-QTEST_APPLESS_MAIN(tst_profileinit)
+QTEST_MAIN(tst_profileinit)
 #include "tst_profileinit.moc"

--- a/tests/auto/userinfo/qtpass.plist
+++ b/tests/auto/userinfo/qtpass.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>QtPass @SHORT_VERSION@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleGetInfoString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.qtpass</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleSignature</key>
+	<string>@TYPEINFO@</string>
+	<key>NOTE</key>
+	<string>QtPass is a multi-platform GUI for pass</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2014-2026 IJhack
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/auto/userinfo/tst_userinfo.cpp
+++ b/tests/auto/userinfo/tst_userinfo.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QtTest>
+
+#include "../../../src/userinfo.h"
+
+class tst_userinfo : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void defaultValidityIsInvalid();
+  void fullyValidWithF();
+  void fullyValidWithU();
+  void fullyValidFalseForM();
+  void fullyValidFalseForOther();
+  void marginallyValidWithM();
+  void marginallyValidFalseForF();
+  void marginallyValidFalseForU();
+  void isValidWithF();
+  void isValidWithU();
+  void isValidWithM();
+  void isValidFalseForDash();
+  void isValidFalseForN();
+  void isValidFalseForUnknown();
+  void defaultFieldValues();
+};
+
+void tst_userinfo::defaultValidityIsInvalid() {
+  UserInfo u;
+  QVERIFY2(!u.isValid(), "default UserInfo must not be valid");
+}
+
+void tst_userinfo::fullyValidWithF() {
+  UserInfo u;
+  u.validity = 'f';
+  QVERIFY(u.fullyValid());
+}
+
+void tst_userinfo::fullyValidWithU() {
+  UserInfo u;
+  u.validity = 'u';
+  QVERIFY(u.fullyValid());
+}
+
+void tst_userinfo::fullyValidFalseForM() {
+  UserInfo u;
+  u.validity = 'm';
+  QVERIFY(!u.fullyValid());
+}
+
+void tst_userinfo::fullyValidFalseForOther() {
+  UserInfo u;
+  u.validity = '-';
+  QVERIFY(!u.fullyValid());
+}
+
+void tst_userinfo::marginallyValidWithM() {
+  UserInfo u;
+  u.validity = 'm';
+  QVERIFY(u.marginallyValid());
+}
+
+void tst_userinfo::marginallyValidFalseForF() {
+  UserInfo u;
+  u.validity = 'f';
+  QVERIFY(!u.marginallyValid());
+}
+
+void tst_userinfo::marginallyValidFalseForU() {
+  UserInfo u;
+  u.validity = 'u';
+  QVERIFY(!u.marginallyValid());
+}
+
+void tst_userinfo::isValidWithF() {
+  UserInfo u;
+  u.validity = 'f';
+  QVERIFY(u.isValid());
+}
+
+void tst_userinfo::isValidWithU() {
+  UserInfo u;
+  u.validity = 'u';
+  QVERIFY(u.isValid());
+}
+
+void tst_userinfo::isValidWithM() {
+  UserInfo u;
+  u.validity = 'm';
+  QVERIFY(u.isValid());
+}
+
+void tst_userinfo::isValidFalseForDash() {
+  UserInfo u;
+  u.validity = '-';
+  QVERIFY(!u.isValid());
+}
+
+void tst_userinfo::isValidFalseForN() {
+  UserInfo u;
+  u.validity = 'n'; // not valid per GPG
+  QVERIFY(!u.isValid());
+}
+
+void tst_userinfo::isValidFalseForUnknown() {
+  UserInfo u;
+  u.validity = '?';
+  QVERIFY(!u.isValid());
+}
+
+void tst_userinfo::defaultFieldValues() {
+  UserInfo u;
+  QCOMPARE(u.validity, '-');
+  QVERIFY(!u.have_secret);
+  QVERIFY(!u.enabled);
+  QVERIFY(u.name.isEmpty());
+  QVERIFY(u.key_id.isEmpty());
+  QVERIFY(!u.expiry.isValid());
+  QVERIFY(!u.created.isValid());
+}
+
+QTEST_APPLESS_MAIN(tst_userinfo)
+#include "tst_userinfo.moc"

--- a/tests/auto/userinfo/tst_userinfo.cpp
+++ b/tests/auto/userinfo/tst_userinfo.cpp
@@ -34,91 +34,96 @@ void tst_userinfo::defaultValidityIsInvalid() {
 void tst_userinfo::fullyValidWithF() {
   UserInfo u;
   u.validity = 'f';
-  QVERIFY(u.fullyValid());
+  QVERIFY2(u.fullyValid(), "fullyValid() must return true for validity='f'");
 }
 
 void tst_userinfo::fullyValidWithU() {
   UserInfo u;
   u.validity = 'u';
-  QVERIFY(u.fullyValid());
+  QVERIFY2(u.fullyValid(), "fullyValid() must return true for validity='u'");
 }
 
 void tst_userinfo::fullyValidFalseForM() {
   UserInfo u;
   u.validity = 'm';
-  QVERIFY(!u.fullyValid());
+  QVERIFY2(!u.fullyValid(),
+           "fullyValid() must return false for validity='m'");
 }
 
 void tst_userinfo::fullyValidFalseForOther() {
   UserInfo u;
   u.validity = '-';
-  QVERIFY(!u.fullyValid());
+  QVERIFY2(!u.fullyValid(),
+           "fullyValid() must return false for validity='-'");
 }
 
 void tst_userinfo::marginallyValidWithM() {
   UserInfo u;
   u.validity = 'm';
-  QVERIFY(u.marginallyValid());
+  QVERIFY2(u.marginallyValid(),
+           "marginallyValid() must return true for validity='m'");
 }
 
 void tst_userinfo::marginallyValidFalseForF() {
   UserInfo u;
   u.validity = 'f';
-  QVERIFY(!u.marginallyValid());
+  QVERIFY2(!u.marginallyValid(),
+           "marginallyValid() must return false for validity='f'");
 }
 
 void tst_userinfo::marginallyValidFalseForU() {
   UserInfo u;
   u.validity = 'u';
-  QVERIFY(!u.marginallyValid());
+  QVERIFY2(!u.marginallyValid(),
+           "marginallyValid() must return false for validity='u'");
 }
 
 void tst_userinfo::isValidWithF() {
   UserInfo u;
   u.validity = 'f';
-  QVERIFY(u.isValid());
+  QVERIFY2(u.isValid(), "isValid() must return true for validity='f'");
 }
 
 void tst_userinfo::isValidWithU() {
   UserInfo u;
   u.validity = 'u';
-  QVERIFY(u.isValid());
+  QVERIFY2(u.isValid(), "isValid() must return true for validity='u'");
 }
 
 void tst_userinfo::isValidWithM() {
   UserInfo u;
   u.validity = 'm';
-  QVERIFY(u.isValid());
+  QVERIFY2(u.isValid(), "isValid() must return true for validity='m'");
 }
 
 void tst_userinfo::isValidFalseForDash() {
   UserInfo u;
   u.validity = '-';
-  QVERIFY(!u.isValid());
+  QVERIFY2(!u.isValid(), "isValid() must return false for validity='-'");
 }
 
 void tst_userinfo::isValidFalseForN() {
   UserInfo u;
-  u.validity = 'n'; // not valid per GPG
-  QVERIFY(!u.isValid());
+  u.validity = 'n';
+  QVERIFY2(!u.isValid(), "isValid() must return false for validity='n'");
 }
 
 void tst_userinfo::isValidFalseForUnknown() {
   UserInfo u;
   u.validity = '?';
-  QVERIFY(!u.isValid());
+  QVERIFY2(!u.isValid(), "isValid() must return false for validity='?'");
 }
 
 void tst_userinfo::defaultFieldValues() {
   UserInfo u;
   QCOMPARE(u.validity, '-');
-  QVERIFY(!u.have_secret);
-  QVERIFY(!u.enabled);
-  QVERIFY(u.name.isEmpty());
-  QVERIFY(u.key_id.isEmpty());
-  QVERIFY(!u.expiry.isValid());
-  QVERIFY(!u.created.isValid());
+  QVERIFY2(!u.have_secret, "default have_secret must be false");
+  QVERIFY2(!u.enabled, "default enabled must be false");
+  QVERIFY2(u.name.isEmpty(), "default name must be empty");
+  QVERIFY2(u.key_id.isEmpty(), "default key_id must be empty");
+  QVERIFY2(!u.expiry.isValid(), "default expiry must be invalid");
+  QVERIFY2(!u.created.isValid(), "default created must be invalid");
 }
 
-QTEST_APPLESS_MAIN(tst_userinfo)
+QTEST_MAIN(tst_userinfo)
 #include "tst_userinfo.moc"

--- a/tests/auto/userinfo/tst_userinfo.cpp
+++ b/tests/auto/userinfo/tst_userinfo.cpp
@@ -46,15 +46,13 @@ void tst_userinfo::fullyValidWithU() {
 void tst_userinfo::fullyValidFalseForM() {
   UserInfo u;
   u.validity = 'm';
-  QVERIFY2(!u.fullyValid(),
-           "fullyValid() must return false for validity='m'");
+  QVERIFY2(!u.fullyValid(), "fullyValid() must return false for validity='m'");
 }
 
 void tst_userinfo::fullyValidFalseForOther() {
   UserInfo u;
   u.validity = '-';
-  QVERIFY2(!u.fullyValid(),
-           "fullyValid() must return false for validity='-'");
+  QVERIFY2(!u.fullyValid(), "fullyValid() must return false for validity='-'");
 }
 
 void tst_userinfo::marginallyValidWithM() {

--- a/tests/auto/userinfo/userinfo.pro
+++ b/tests/auto/userinfo/userinfo.pro
@@ -1,0 +1,12 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_userinfo.cpp
+
+HEADERS   += ../../../src/userinfo.h
+
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}


### PR DESCRIPTION
## Summary

- **`tst_userinfo`** (17 tests): covers `fullyValid()`, `marginallyValid()`, and `isValid()` across all GPG validity codes (`f`, `u`, `m`, `-`, `n`, `?`), plus default field values. Uses `QTEST_APPLESS_MAIN` — no display or event loop needed.

- **`tst_profileinit`** (7 tests): covers `ProfileInit::needsInit()` for non-existent paths, empty path, directory without `.gpg-id`, directory with `.gpg-id`, and the before/after transition.

- **Bug fix in `ProfileInit::needsInit()`**: previously an empty `QString` argument resolved to `QDir("")` (Qt's current directory), which returned a spurious `true`. Now returns `false` for empty paths.

## Test plan

- [x] `tst_userinfo`: 17 passed, 0 failed
- [x] `tst_profileinit`: 7 passed, 0 failed
- [x] `clang-format --dry-run -Werror` clean on all new files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile initialization now treats empty paths as non-initialized immediately, avoiding unnecessary processing and related errors.

* **Tests**
  * Automated test suite expanded with new coverage for profile initialization and comprehensive user information validation, plus added test targets and platform metadata templates to support running these tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->