### PR TITLE
test: add edge-case tests for simpletransaction and filecontent

### DIFF
--- a/tests/auto/filecontent/tst_filecontent.cpp
+++ b/tests/auto/filecontent/tst_filecontent.cpp
@@ -27,6 +27,11 @@ private Q_SLOTS:
   void parseWhitespaceOnlyContent();
   void parseOnlyNamedFields();
   void parseTemplateFieldsWithEmptyValues();
+  void parseAllFieldsModeIncludesExtraFields();
+  void parseAllFieldsModeExcludesUrlLines();
+  void parseCrlfNamedValuesAreTrimmed();
+  void parseMultipleOtpauthLinesAllHidden();
+  void parseOtpauthCaseInsensitiveHidden();
 };
 
 void tst_filecontent::parsePlainPassword() {
@@ -231,6 +236,61 @@ void tst_filecontent::parseTemplateFieldsWithEmptyValues() {
     QVERIFY2(nv[1].name == "username", "second field should be username");
     QVERIFY2(nv[1].value.isEmpty(), "username value should be empty");
   }
+}
+
+void tst_filecontent::parseAllFieldsModeIncludesExtraFields() {
+  QString content = "secret\nnote: some note\nkey: value";
+  FileContent fc = FileContent::parse(content, QStringList(), true);
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY2(nv.size() == 2,
+           "allFields=true should include all name:value pairs");
+  QVERIFY2(nv[0].name == "note" && nv[0].value == "some note",
+           "first field should be note");
+  QVERIFY2(nv[1].name == "key" && nv[1].value == "value",
+           "second field should be key");
+  QVERIFY2(fc.getRemainingData().isEmpty(),
+           "no remaining data when all fields are named");
+}
+
+void tst_filecontent::parseAllFieldsModeExcludesUrlLines() {
+  QString content = "secret\nhttp://example.com\nkey: value";
+  FileContent fc = FileContent::parse(content, QStringList(), true);
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY2(nv.size() == 1, "URL-like lines should not become named values");
+  QVERIFY2(nv[0].name == "key" && nv[0].value == "value",
+           "non-url field should be parsed");
+  QVERIFY2(fc.getRemainingData().contains("http://example.com"),
+           "URL line should stay in remaining data");
+}
+
+void tst_filecontent::parseCrlfNamedValuesAreTrimmed() {
+  QString content = "secret\r\nusername: john\r\n";
+  FileContent fc = FileContent::parse(content, {"username"}, false);
+  NamedValues nv = fc.getNamedValues();
+  QVERIFY2(nv.size() == 1, "CRLF file should yield one named value");
+  QVERIFY2(nv[0].value == "john",
+           "value.trimmed() must strip trailing \\r from CRLF lines");
+}
+
+void tst_filecontent::parseMultipleOtpauthLinesAllHidden() {
+  QString content =
+      "secret\notpauth://totp/A?secret=x\notpauth://totp/B?secret=y";
+  FileContent fc = FileContent::parse(content, QStringList(), false);
+  QVERIFY2(fc.getRemainingData().contains("otpauth://totp/A"),
+           "otpauth lines must appear in getRemainingData");
+  QVERIFY2(fc.getRemainingData().contains("otpauth://totp/B"),
+           "both otpauth lines must appear in getRemainingData");
+  QVERIFY2(fc.getRemainingDataForDisplay().isEmpty(),
+           "getRemainingDataForDisplay must hide all otpauth lines");
+}
+
+void tst_filecontent::parseOtpauthCaseInsensitiveHidden() {
+  QString content = "secret\nOTPAUTH://totp/Example?secret=key";
+  FileContent fc = FileContent::parse(content, QStringList(), false);
+  QVERIFY2(fc.getRemainingData().contains("OTPAUTH://"),
+           "uppercase OTPAUTH should be in remaining data");
+  QVERIFY2(fc.getRemainingDataForDisplay().isEmpty(),
+           "uppercase OTPAUTH must be hidden from display");
 }
 
 QTEST_MAIN(tst_filecontent)

--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -90,25 +90,36 @@ void tst_simpletransaction::transactionQueueOrder() {
 void tst_simpletransaction::transactionIsOverWrongIdReturnsInvalid() {
   simpleTransaction st;
   st.transactionAdd(Enums::PASS_SHOW);
-  QCOMPARE(st.transactionIsOver(Enums::PASS_INSERT), Enums::INVALID);
+  QVERIFY2(
+      st.transactionIsOver(Enums::PASS_INSERT) == Enums::INVALID,
+      "transactionIsOver(PASS_INSERT) must return INVALID when queue front "
+      "holds PASS_SHOW");
 }
 
 void tst_simpletransaction::transactionIsOverEmptyQueueReturnsInvalid() {
   simpleTransaction st;
-  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::INVALID);
+  QVERIFY2(st.transactionIsOver(Enums::PASS_SHOW) == Enums::INVALID,
+           "transactionIsOver(PASS_SHOW) must return INVALID on empty queue");
 }
 
 void tst_simpletransaction::transactionEndWithoutStartIsNoop() {
   simpleTransaction st;
   st.transactionEnd(Enums::PASS_SHOW);
-  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::INVALID);
+  QVERIFY2(
+      st.transactionIsOver(Enums::PASS_SHOW) == Enums::INVALID,
+      "transactionEnd(PASS_SHOW) without transactionStart must not enqueue "
+      "anything; transactionIsOver(PASS_SHOW) must return INVALID");
 }
 
 void tst_simpletransaction::transactionStartEndWithoutAddIsNoop() {
   simpleTransaction st;
   st.transactionStart();
   st.transactionEnd(Enums::PASS_SHOW);
-  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::INVALID);
+  QVERIFY2(
+      st.transactionIsOver(Enums::PASS_SHOW) == Enums::INVALID,
+      "transactionStart + transactionEnd(PASS_SHOW) without transactionAdd "
+      "must not enqueue anything; transactionIsOver(PASS_SHOW) must return "
+      "INVALID");
 }
 
 void tst_simpletransaction::transactionEndResultDiffersFromAdd() {
@@ -116,7 +127,11 @@ void tst_simpletransaction::transactionEndResultDiffersFromAdd() {
   st.transactionStart();
   st.transactionAdd(Enums::PASS_SHOW);
   st.transactionEnd(Enums::PASS_INSERT);
-  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::PASS_INSERT);
+  QVERIFY2(
+      st.transactionIsOver(Enums::PASS_SHOW) == Enums::PASS_INSERT,
+      "transactionIsOver(PASS_SHOW) must return PASS_INSERT: transactionAdd "
+      "sets the trigger (PASS_SHOW), transactionEnd sets the result "
+      "(PASS_INSERT)");
 }
 
 void tst_simpletransaction::deeplyNestedTransactionUsesLastAdd() {
@@ -127,7 +142,11 @@ void tst_simpletransaction::deeplyNestedTransactionUsesLastAdd() {
   st.transactionAdd(Enums::GIT_COMMIT);
   st.transactionEnd(Enums::GIT_COMMIT);
   st.transactionEnd(Enums::GIT_PUSH);
-  QCOMPARE(st.transactionIsOver(Enums::GIT_COMMIT), Enums::GIT_PUSH);
+  QVERIFY2(
+      st.transactionIsOver(Enums::GIT_COMMIT) == Enums::GIT_PUSH,
+      "transactionIsOver(GIT_COMMIT) must return GIT_PUSH: inner "
+      "transactionAdd(GIT_COMMIT) overwrites GIT_ADD as the trigger; outer "
+      "transactionEnd(GIT_PUSH) sets the result");
 }
 
 QTEST_MAIN(tst_simpletransaction)

--- a/tests/auto/simpletransaction/tst_simpletransaction.cpp
+++ b/tests/auto/simpletransaction/tst_simpletransaction.cpp
@@ -15,6 +15,12 @@ private Q_SLOTS:
   void nestedTransaction();
   void transactionStartEndExplicit();
   void transactionQueueOrder();
+  void transactionIsOverWrongIdReturnsInvalid();
+  void transactionIsOverEmptyQueueReturnsInvalid();
+  void transactionEndWithoutStartIsNoop();
+  void transactionStartEndWithoutAddIsNoop();
+  void transactionEndResultDiffersFromAdd();
+  void deeplyNestedTransactionUsesLastAdd();
 };
 
 void tst_simpletransaction::transactionAddAndComplete() {
@@ -79,6 +85,49 @@ void tst_simpletransaction::transactionQueueOrder() {
   QVERIFY2(r2 == Enums::PASS_REMOVE, "PASS_REMOVE should complete second");
   Enums::PROCESS r3 = st.transactionIsOver(Enums::PASS_SHOW);
   QVERIFY2(r3 == Enums::PASS_SHOW, "PASS_SHOW should complete third");
+}
+
+void tst_simpletransaction::transactionIsOverWrongIdReturnsInvalid() {
+  simpleTransaction st;
+  st.transactionAdd(Enums::PASS_SHOW);
+  QCOMPARE(st.transactionIsOver(Enums::PASS_INSERT), Enums::INVALID);
+}
+
+void tst_simpletransaction::transactionIsOverEmptyQueueReturnsInvalid() {
+  simpleTransaction st;
+  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::INVALID);
+}
+
+void tst_simpletransaction::transactionEndWithoutStartIsNoop() {
+  simpleTransaction st;
+  st.transactionEnd(Enums::PASS_SHOW);
+  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::INVALID);
+}
+
+void tst_simpletransaction::transactionStartEndWithoutAddIsNoop() {
+  simpleTransaction st;
+  st.transactionStart();
+  st.transactionEnd(Enums::PASS_SHOW);
+  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::INVALID);
+}
+
+void tst_simpletransaction::transactionEndResultDiffersFromAdd() {
+  simpleTransaction st;
+  st.transactionStart();
+  st.transactionAdd(Enums::PASS_SHOW);
+  st.transactionEnd(Enums::PASS_INSERT);
+  QCOMPARE(st.transactionIsOver(Enums::PASS_SHOW), Enums::PASS_INSERT);
+}
+
+void tst_simpletransaction::deeplyNestedTransactionUsesLastAdd() {
+  simpleTransaction st;
+  st.transactionStart();
+  st.transactionAdd(Enums::GIT_ADD);
+  st.transactionStart();
+  st.transactionAdd(Enums::GIT_COMMIT);
+  st.transactionEnd(Enums::GIT_COMMIT);
+  st.transactionEnd(Enums::GIT_PUSH);
+  QCOMPARE(st.transactionIsOver(Enums::GIT_COMMIT), Enums::GIT_PUSH);
 }
 
 QTEST_MAIN(tst_simpletransaction)


### PR DESCRIPTION
## Summary

- **simpletransaction** (6 → 14 tests): covers `transactionIsOver` with wrong id, empty queue, `transactionEnd` without `transactionStart`, start+end without add, result process differing from trigger process, and deeply nested transactions
- **filecontent** (19 → 26 tests): covers `allFields=true` mode, URL-line exclusion in allFields, CRLF named-value trimming, multiple `otpauth://` lines hidden from display, and case-insensitive `OTPAUTH://` hiding

## Test plan

- [x] `make check` passes locally for both suites (14 + 26 tests, 0 failures)
- [x] `clang-format --style=file` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded file-content parsing tests: improved coverage for extracting name:value fields, excluding URL-like lines, normalizing CRLF line endings, and preserving/hiding protocol-specific lines from display while retaining them in remaining data.
  * Extended transaction tests: added coverage for invalid/empty-queue states, no-op end/start scenarios, result identity vs. trigger, and deeply nested transaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->