### PR TITLE
test: cover useGrepSearch, showProcessOutput, sshAuthSockOverride settings

### DIFF
--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -221,6 +221,10 @@ const BoolSetting boolSettings[] = {
     {"useAutoclearPanel", QtPassSettings::setUseAutoclearPanel,
      QtPassSettings::isUseAutoclearPanel},
     {"maximized", QtPassSettings::setMaximized, QtPassSettings::isMaximized},
+    {"useGrepSearch", QtPassSettings::setUseGrepSearch,
+     QtPassSettings::isUseGrepSearch},
+    {"showProcessOutput", QtPassSettings::setShowProcessOutput,
+     QtPassSettings::isShowProcessOutput},
 };
 } // namespace
 
@@ -307,6 +311,8 @@ const StringSetting stringSettings[] = {
     {"profile", QtPassSettings::setProfile, QtPassSettings::getProfile},
     {"passTemplate", QtPassSettings::setPassTemplate,
      QtPassSettings::getPassTemplate},
+    {"sshAuthSockOverride", QtPassSettings::setSshAuthSockOverride,
+     QtPassSettings::getSshAuthSockOverride},
 };
 } // namespace
 
@@ -366,6 +372,8 @@ void tst_settings::stringRoundTrip_data() {
   addString("profile", "personal");
   addString("passTemplate", "username: {username}\npassword: {password}");
   addString("passTemplate", "user: {username}\npass: {password}");
+  addString("sshAuthSockOverride", "/run/user/1000/gnupg/S.gpg-agent.ssh");
+  addString("sshAuthSockOverride", "");
 }
 
 void tst_settings::stringRoundTrip() {


### PR DESCRIPTION
## Summary

Three settings had getters/setters in `QtPassSettings` but no round-trip coverage in `tst_settings`:

- `isUseGrepSearch` / `setUseGrepSearch` → added to `boolSettings` table (2 new test rows)
- `isShowProcessOutput` / `setShowProcessOutput` → added to `boolSettings` table (2 new test rows)
- `getSshAuthSockOverride` / `setSshAuthSockOverride` → added to `stringSettings` table + 2 `addString` rows (socket path and empty string)

## Test plan

- [x] `make check` passes locally: 102 → 113 test rows, 0 failures
- [x] `clang-format --style=file` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for settings round-trip validation to include additional configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IJHack/QtPass/pull/1494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->