### PR TITLE
feat: add "Open in browser" button for web URLs (#1516)

### DIFF
--- a/icons/open-url.svg
+++ b/icons/open-url.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M14 3a1 1 0 0 0 0 2h3.586l-8.293 8.293a1 1 0 0 0 1.414 1.414L19 6.414V10a1 1 0 1 0 2 0V4a1 1 0 0 0-1-1h-6z"/><path d="M5 5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5a1 1 0 1 0-2 0v5H5V7h5a1 1 0 0 0 0-2H5z"/></svg>

--- a/resources.qrc
+++ b/resources.qrc
@@ -19,5 +19,6 @@
         <file alias="folder-new.svg">icons/folder-new.svg</file>
         <file alias="view.svg">icons/view.svg</file>
         <file alias="hide.svg">icons/hide.svg</file>
+        <file alias="open-url.svg">icons/open-url.svg</file>
     </qresource>
 </RCC>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1678,7 +1678,8 @@ void MainWindow::addToGridLayout(int position, const QString &field,
     auto *urlButton = new QPushButton(this);
     urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
                                         QIcon(":/icons/open-url.svg")));
-    urlButton->setToolTip(tr("Open %1 in browser").arg(trimmedValue));
+    urlButton->setToolTip(
+        tr("Open %1 in browser").arg(trimmedValue.toHtmlEscaped()));
     urlButton->setStyleSheet(buttonStyle);
     urlButton->setCursor(Qt::PointingHandCursor);
     connect(urlButton, &QPushButton::clicked, this, [trimmedValue]() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,6 +34,7 @@
 #include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QTextCursor>
@@ -41,6 +42,7 @@
 #include <QTimer>
 #include <QToolButton>
 #include <QTreeWidget>
+#include <QUrl>
 #include <utility>
 
 /**
@@ -1667,6 +1669,27 @@ void MainWindow::addToGridLayout(int position, const QString &field,
             &QtPass::showTextAsQRCode);
     qrbutton->setStyleSheet(buttonStyle);
     frame->layout()->addWidget(qrbutton);
+  }
+
+  // Show an explicit "open in browser" button when the value is a safe
+  // http(s) URL. The inline clickable link still works for URLs embedded in
+  // prose; this button is the discoverable affordance for url fields.
+  if (Util::isLaunchableWebUrl(trimmedValue)) {
+    auto *urlButton = new QPushButton(this);
+    urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
+                                        QIcon(":/icons/open-url.svg")));
+    urlButton->setToolTip(tr("Open %1 in browser").arg(trimmedValue));
+    urlButton->setStyleSheet(buttonStyle);
+    urlButton->setCursor(Qt::PointingHandCursor);
+    connect(urlButton, &QPushButton::clicked, this, [trimmedValue]() {
+      // Re-validate before launching (defence in depth: the value is
+      // immutable here, but never hand an unvalidated string to the OS
+      // URL handler).
+      if (Util::isLaunchableWebUrl(trimmedValue)) {
+        QDesktopServices::openUrl(QUrl(trimmedValue));
+      }
+    });
+    frame->layout()->addWidget(urlButton);
   }
 
   // set the echo mode to password, if the field is "password"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1674,7 +1674,10 @@ void MainWindow::addToGridLayout(int position, const QString &field,
   // Show an explicit "open in browser" button when the value is a safe
   // http(s) URL. The inline clickable link still works for URLs embedded in
   // prose; this button is the discoverable affordance for url fields.
-  if (Util::isLaunchableWebUrl(trimmedValue)) {
+  // Never on the password field: its value is a secret and must not be
+  // surfaced in a tooltip or handed to the browser.
+  if (trimmedField != tr("Password") &&
+      Util::isLaunchableWebUrl(trimmedValue)) {
     auto *urlButton = new QPushButton(this);
     urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
                                         QIcon(":/icons/open-url.svg")));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -20,6 +20,7 @@
 #include <QHash>
 #include <QSaveFile>
 #include <QTextStream>
+#include <QUrl>
 #include <algorithm>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QStringConverter>
@@ -507,6 +508,47 @@ auto Util::protocolRegex() -> const QRegularExpression & {
   static const QRegularExpression regex{
       R"(((?:https?|ftp|ssh|sftp|ftps|webdav|webdavs)://[^" <>\)\]\[]+))"};
   return regex;
+}
+
+/**
+ * @brief Validate a value as a launchable http(s) URL.
+ *
+ * Security gate for the "open in browser" action. See util.h for the full
+ * contract. Deliberately stricter than protocolRegex(): only http/https,
+ * valid host, no embedded credentials, no control characters.
+ *
+ * @param value Candidate URL string.
+ * @return true if launchable in a browser, false otherwise.
+ */
+auto Util::isLaunchableWebUrl(const QString &value) -> bool {
+  const QString trimmed = value.trimmed();
+  if (trimmed.isEmpty()) {
+    return false;
+  }
+  // Reject control characters first, before QUrl normalisation can hide a
+  // CR/LF/NUL injection into the OS URL handler.
+  for (const QChar &c : trimmed) {
+    if (c == QLatin1Char('\r') || c == QLatin1Char('\n') ||
+        c == QChar(QChar::Null)) {
+      return false;
+    }
+  }
+  const QUrl url(trimmed, QUrl::StrictMode);
+  if (!url.isValid()) {
+    return false;
+  }
+  const QString scheme = url.scheme().toLower();
+  if (scheme != QLatin1String("http") && scheme != QLatin1String("https")) {
+    return false;
+  }
+  if (url.host().isEmpty()) {
+    return false;
+  }
+  // Embedded userinfo (user:pass@host) would leak into browser history.
+  if (!url.userName().isEmpty() || !url.password().isEmpty()) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -125,6 +125,25 @@ public:
    */
   static auto protocolRegex() -> const QRegularExpression &;
   /**
+   * @brief Check whether a value is a safe, launchable web URL.
+   *
+   * Stricter than protocolRegex(): intended to gate an "open in browser"
+   * action, where launching a non-web scheme would be a security risk.
+   * Returns true only when the trimmed value:
+   * - contains no control characters (CR, LF, NUL),
+   * - parses to a valid QUrl,
+   * - has scheme exactly "http" or "https" (case-insensitive),
+   * - has a non-empty host,
+   * - carries no embedded userinfo (user:password@host).
+   *
+   * Deliberately rejects file://, javascript:, data:, ftp/ssh/webdav and
+   * scheme-less inputs (e.g. "www.example.com").
+   *
+   * @param value Candidate URL string (typically a password-file field).
+   * @return true if the value is a launchable http(s) URL, false otherwise.
+   */
+  static auto isLaunchableWebUrl(const QString &value) -> bool;
+  /**
    * @brief Returns a regex to match newline characters.
    * @return Reference to static regex
    */

--- a/src/util.h
+++ b/src/util.h
@@ -134,7 +134,7 @@ public:
    * - parses to a valid QUrl,
    * - has scheme exactly "http" or "https" (case-insensitive),
    * - has a non-empty host,
-   * - carries no embedded userinfo (user:password@host).
+   * - carries no embedded userinfo (user:password\@host).
    *
    * Deliberately rejects file://, javascript:, data:, ftp/ssh/webdav and
    * scheme-less inputs (e.g. "www.example.com").

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1561,15 +1561,20 @@ void tst_util::utilRegexProtocol() {
 }
 
 void tst_util::isLaunchableWebUrlAccepts() {
-  QVERIFY(Util::isLaunchableWebUrl("https://example.com"));
-  QVERIFY(Util::isLaunchableWebUrl("http://example.com"));
-  QVERIFY(Util::isLaunchableWebUrl("https://example.com/path?q=1#frag"));
-  QVERIFY(Util::isLaunchableWebUrl("https://nas.local:8080"));
-  // Surrounding whitespace is trimmed.
-  QVERIFY(Util::isLaunchableWebUrl("  https://example.com  "));
-  // Scheme is case-insensitive.
-  QVERIFY(Util::isLaunchableWebUrl("HTTPS://example.com"));
-  QVERIFY(Util::isLaunchableWebUrl("HtTp://Example.com"));
+  const QStringList accepted = {
+      QStringLiteral("https://example.com"),
+      QStringLiteral("http://example.com"),
+      QStringLiteral("https://example.com/path?q=1#frag"),
+      QStringLiteral("https://nas.local:8080"),
+      QStringLiteral("  https://example.com  "), // surrounding whitespace
+      QStringLiteral("HTTPS://example.com"),     // scheme case-insensitive
+      QStringLiteral("HtTp://Example.com"),
+  };
+  for (const QString &url : accepted) {
+    QVERIFY2(
+        Util::isLaunchableWebUrl(url),
+        qPrintable(QStringLiteral("expected launchable web URL: %1").arg(url)));
+  }
 }
 
 void tst_util::isLaunchableWebUrlRejects() {

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -147,6 +147,8 @@ private Q_SLOTS:
   void buildClipboardMimeDataMac();
   void utilRegexEnsuresGpg();
   void utilRegexProtocol();
+  void isLaunchableWebUrlAccepts();
+  void isLaunchableWebUrlRejects();
   void utilRegexNewLines();
   void reencryptPathNormalization();
   void reencryptPathAbsolutePath();
@@ -1556,6 +1558,43 @@ void tst_util::utilRegexProtocol() {
   QVERIFY2(rex.match("https://secure.com").hasMatch(), "Should match https://");
   QVERIFY2(rex.match("ssh://host").hasMatch(), "Should match ssh://");
   QVERIFY2(!rex.match("://no-protocol").hasMatch(), "Should not match invalid");
+}
+
+void tst_util::isLaunchableWebUrlAccepts() {
+  QVERIFY(Util::isLaunchableWebUrl("https://example.com"));
+  QVERIFY(Util::isLaunchableWebUrl("http://example.com"));
+  QVERIFY(Util::isLaunchableWebUrl("https://example.com/path?q=1#frag"));
+  QVERIFY(Util::isLaunchableWebUrl("https://nas.local:8080"));
+  // Surrounding whitespace is trimmed.
+  QVERIFY(Util::isLaunchableWebUrl("  https://example.com  "));
+  // Scheme is case-insensitive.
+  QVERIFY(Util::isLaunchableWebUrl("HTTPS://example.com"));
+  QVERIFY(Util::isLaunchableWebUrl("HtTp://Example.com"));
+}
+
+void tst_util::isLaunchableWebUrlRejects() {
+  QVERIFY2(!Util::isLaunchableWebUrl(""), "empty");
+  QVERIFY2(!Util::isLaunchableWebUrl("   "), "whitespace only");
+  // Scheme-less inputs must be rejected (no auto-prefixing).
+  QVERIFY2(!Util::isLaunchableWebUrl("www.example.com"), "scheme-less");
+  QVERIFY2(!Util::isLaunchableWebUrl("example.com"), "bare host");
+  // Non-web schemes the launcher must never hand to the OS.
+  QVERIFY2(!Util::isLaunchableWebUrl("file:///etc/passwd"), "file");
+  QVERIFY2(!Util::isLaunchableWebUrl("javascript:alert(1)"), "javascript");
+  QVERIFY2(!Util::isLaunchableWebUrl("data:text/html,<b>x</b>"), "data");
+  QVERIFY2(!Util::isLaunchableWebUrl("ftp://host/file"), "ftp");
+  QVERIFY2(!Util::isLaunchableWebUrl("ssh://host"), "ssh");
+  QVERIFY2(!Util::isLaunchableWebUrl("webdav://host"), "webdav");
+  // Embedded credentials leak into browser history.
+  QVERIFY2(!Util::isLaunchableWebUrl("https://user:pass@example.com"), "creds");
+  // Missing host.
+  QVERIFY2(!Util::isLaunchableWebUrl("https://"), "no host");
+  // Control-character injection.
+  QVERIFY2(!Util::isLaunchableWebUrl("https://example.com\r\nHost: evil"),
+           "CRLF");
+  QVERIFY2(
+      !Util::isLaunchableWebUrl(QString("https://e.com") + QChar(0) + ".com"),
+      "NUL");
 }
 
 void tst_util::utilRegexNewLines() {


### PR DESCRIPTION
Closes #1516.

## What

Adds a discoverable per-field **"Open in browser"** button next to the existing copy / QR buttons, shown when a field value is a safe `http(s)` URL. Click → opens the default browser via `QDesktopServices::openUrl`.

Requested by @MoonBurst for his non-technical father: he wants a visible button to land on a login page from QtPass; autofill is then handled by a browser extension (browserpass, which he already uses). URLs were already clickable inline (#226), but a small link in a field isn't a discoverable affordance — this is the obvious button.

## Security

The button is gated by a new strict validator `Util::isLaunchableWebUrl()`, deliberately stricter than `protocolRegex()` (which also matches `ftp`/`ssh`/`webdav` — fine for a click-through link, too loose for a launch primitive). Accepts only:

- no control chars (CR/LF/NUL checked **before** QUrl parsing)
- valid `QUrl` with scheme exactly `http`/`https` (case-insensitive)
- non-empty host
- no embedded userinfo (`user:pass@host`)

Rejects `file://`, `javascript:`, `data:`, `ftp`/`ssh`/`webdav`, and scheme-less inputs. The click handler re-validates before `openUrl` (defence in depth). The permissive `protocolRegex` display path is unchanged.

Renders only when the **whole** field value passes — never appears for non-web fields; URLs in prose keep the existing inline link. No new setting (always on for valid web URLs).

## Files

- `src/util.{h,cpp}` — `Util::isLaunchableWebUrl` (+ `#include <QUrl>`)
- `src/mainwindow.cpp` — button in `addToGridLayout`, `applications-internet` themed icon w/ bundled fallback, tooltip = full URL
- `icons/open-url.svg` + `resources.qrc` — bundled fallback icon
- `tests/auto/util/tst_util.cpp` — accept/reject cases

## Test plan

- [x] `qmake6 && make` clean
- [x] `tst_util` 138/138 (2 new cases)
- [x] doxygen zero warnings
- [x] `reuse lint` compliant
- [x] clang-format applied
- [ ] manual: entry with `url: https://example.com` shows the button, opens browser; entry with `url: file:///etc/passwd` shows no button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open in browser" button for detected web URLs; only safe http/https links are allowed and links with embedded credentials are blocked.
* **Tests**
  * Added unit tests verifying accepted and rejected URL cases (trimming, scheme handling, ports/fragments, and unsafe inputs like control characters or credentialed URLs).
* **Chores**
  * Added an icon asset for the "Open in browser" action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->