### PR TITLE
ci: bump pinned Doxygen 1.16.1 → 1.17.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,10 +81,10 @@ jobs:
         if: steps.need_docs.outputs.run_docs == 'true'
         run: |
           # Install newer Doxygen from official release
-          curl -fsL https://doxygen.nl/files/doxygen-1.16.1.linux.bin.tar.gz -o doxygen.tar.gz
+          curl -fsL https://doxygen.nl/files/doxygen-1.17.0.linux.bin.tar.gz -o doxygen.tar.gz
           tar -xzf doxygen.tar.gz
-          sudo cp -r doxygen-1.16.1/bin/* /usr/local/bin/
-          rm -rf doxygen.tar.gz doxygen-1.16.1
+          sudo cp -r doxygen-1.17.0/bin/* /usr/local/bin/
+          rm -rf doxygen.tar.gz doxygen-1.17.0
           # Install graphviz via apt
           sudo apt-get update && sudo apt-get install -y graphviz
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.16.1
+# Doxyfile 1.17.0
 
 # This file describes the settings to be used by the documentation system
 # Doxygen (www.doxygen.org) for a project.


### PR DESCRIPTION
Bumps the Doxygen binary pinned in `docs.yml` from 1.16.1 to the current release 1.17.0.

- 1.17.0 is what `doxygen.nl/files/` currently serves as the latest `.linux.bin.tar.gz` (1.16.1 still resolves, so no urgency, but staying current).
- Verified locally: `doxygen Doxyfile` on 1.17.0 generates the whole tree with **zero** warnings under `WARN_AS_ERROR=FAIL_ON_WARNINGS`, so no doc comments need touching.

One-line infra change; the `docs` job exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the documentation tooling to version 1.17.0 across CI and config so docs build uses the newer Doxygen release.
  * Kept existing install and cleanup steps; no other workflow or configuration changes were made.
  * Expected outcome: documentation builds remain compatible and may benefit from the updated tool release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->