### PR TITLE
ci: install Codecov CLI via PyPI to fix broken GPG verification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -150,6 +150,7 @@ jobs:
           name: qtpass-lcov
           fail_ci_if_error: false
           verbose: true
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
@@ -159,6 +160,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "tests/auto/*/qtpass.junit.xml"
           report_type: test_results
+          use_pypi: true
           fail_ci_if_error: true
 
       - name: Upload coverage to Coveralls


### PR DESCRIPTION
The `docs` job fails on every PR at the **Upload test results to Codecov** step. It's **not** the token — the Codecov uploader's `codecov.sh` wrapper downloads the CLI binary and GPG-verifies it, but the runner keyring has no Codecov public key:

```
==> Verifying GPG signature integrity
gpg: Signature made ... using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
Error: Process completed with exit code 1.
```

`CC_FAIL_ON_ERROR=true` on the test-results upload turns that into a job failure.

## Fix

Set `use_pypi: true` on both `codecov/codecov-action@v6.0.1` steps. That installs `codecov-cli` from PyPI (the runner already provisions Python 3.12) instead of downloading the prebuilt binary, so the GPG-verify path that's failing is never taken. No keyserver dependency, no token change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration workflow configuration to improve code coverage reporting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->