### PR TITLE
refactor: dedup executeBlocking + clarify isPathInStore guard (#1510)

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -220,12 +220,11 @@ static auto decodeAssumingUtf8(const QByteArray &in) -> QString {
  * Note: Returning error code instead of throwing to maintain compatibility
  * with the existing error handling pattern used throughout QtPass.
  */
-auto Executor::executeBlocking(const QString &app, const QStringList &args,
-                               const QString &input, QString *process_out,
-                               QString *process_err) -> int {
-  QProcess internal;
-  startProcessBlocking(internal, app, args);
-  if (!internal.waitForStarted(-1)) {
+auto Executor::runBlocking(QProcess &process, const QString &app,
+                           const QStringList &args, const QString &input,
+                           QString *process_out, QString *process_err) -> int {
+  startProcessBlocking(process, app, args);
+  if (!process.waitForStarted(-1)) {
 #ifdef QT_DEBUG
     dbg() << "Process failed to start:" << app;
 #endif
@@ -233,28 +232,33 @@ auto Executor::executeBlocking(const QString &app, const QStringList &args,
   }
   if (!input.isEmpty()) {
     QByteArray data = input.toUtf8();
-    if (internal.write(data) != data.length()) {
+    if (process.write(data) != data.length()) {
 #ifdef QT_DEBUG
       dbg() << "Not all input written:" << app;
 #endif
     }
-    internal.closeWriteChannel();
+    process.closeWriteChannel();
   }
-  internal.waitForFinished(-1);
-  if (internal.exitStatus() == QProcess::NormalExit) {
-    QString pout = decodeAssumingUtf8(internal.readAllStandardOutput());
-    QString perr = decodeAssumingUtf8(internal.readAllStandardError());
-    if (process_out != nullptr) {
-      *process_out = pout;
-    }
-    if (process_err != nullptr) {
-      *process_err = perr;
-    }
-    return internal.exitCode();
+  process.waitForFinished(-1);
+  if (process.exitStatus() != QProcess::NormalExit) {
+    // Process failed to start or crashed; return -1 to indicate error.
+    // The calling code checks for non-zero exit codes for error handling.
+    return -1;
   }
-  // Process failed to start or crashed; return -1 to indicate error.
-  // The calling code checks for non-zero exit codes for error handling.
-  return -1;
+  if (process_out != nullptr) {
+    *process_out = decodeAssumingUtf8(process.readAllStandardOutput());
+  }
+  if (process_err != nullptr) {
+    *process_err = decodeAssumingUtf8(process.readAllStandardError());
+  }
+  return process.exitCode();
+}
+
+auto Executor::executeBlocking(const QString &app, const QStringList &args,
+                               const QString &input, QString *process_out,
+                               QString *process_err) -> int {
+  QProcess internal;
+  return runBlocking(internal, app, args, input, process_out, process_err);
 }
 
 /**
@@ -292,24 +296,7 @@ auto Executor::executeBlocking(const QStringList &env, const QString &app,
     }
   }
   process.setProcessEnvironment(penv);
-  startProcessBlocking(process, app, args);
-  if (!process.waitForStarted(-1)) {
-#ifdef QT_DEBUG
-    dbg() << "Process failed to start:" << app;
-#endif
-    return -1;
-  }
-  process.waitForFinished(-1);
-  if (process.exitStatus() != QProcess::NormalExit) {
-    return -1;
-  }
-  if (process_out) {
-    *process_out = decodeAssumingUtf8(process.readAllStandardOutput());
-  }
-  if (process_err) {
-    *process_err = decodeAssumingUtf8(process.readAllStandardError());
-  }
-  return process.exitCode();
+  return runBlocking(process, app, args, QString(), process_out, process_err);
 }
 
 /**

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -237,8 +237,10 @@ auto Executor::runBlocking(QProcess &process, const QString &app,
       dbg() << "Not all input written:" << app;
 #endif
     }
-    process.closeWriteChannel();
   }
+  // Always close stdin so a child blocking on EOF doesn't hang when no
+  // input is written (these are one-shot blocking runs that never stream).
+  process.closeWriteChannel();
   process.waitForFinished(-1);
   if (process.exitStatus() != QProcess::NormalExit) {
     // Process failed to start or crashed; return -1 to indicate error.

--- a/src/executor.h
+++ b/src/executor.h
@@ -65,6 +65,21 @@ class Executor : public QObject {
   void startProcess(const QString &app, const QStringList &args);
   static void startProcessBlocking(QProcess &internal, const QString &app,
                                    const QStringList &args);
+  /**
+   * @brief Shared blocking run: start @p process, optionally feed @p input on
+   * stdin, wait, and capture stdout/stderr. Backs the executeBlocking
+   * overloads. The caller configures @p process (e.g. environment) first.
+   * @param process Pre-configured QProcess to run.
+   * @param app Executable path.
+   * @param args Command arguments.
+   * @param input Data to write to stdin (empty = none).
+   * @param process_out If non-null, receives stdout.
+   * @param process_err If non-null, receives stderr.
+   * @return Process exit code, or -1 on start/crash failure.
+   */
+  static auto runBlocking(QProcess &process, const QString &app,
+                          const QStringList &args, const QString &input,
+                          QString *process_out, QString *process_err) -> int;
 
 public:
   /**

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -268,6 +268,9 @@ auto Util::isPathInStore(const QString &storeRoot, const QString &candidate)
     tail.prepend(fi.fileName());
     while (!parent.exists()) {
       tail.prepend(parent.dirName());
+      // The filesystem root always exists, so the loop terminates there
+      // before cdUp() can fail; this guard is defensive against a
+      // pathological QDir that can neither exist nor ascend.
       if (!parent.cdUp()) {
         return false;
       }


### PR DESCRIPTION
Part of #1508 (thermonuclear audit). Two small cleanups from #1510.

## 1. Dedup `Executor::executeBlocking` run body

The input-taking overload and the env-aware overload each had their own copy of the start → optional-stdin → wait → decode logic. Extracted a private `Executor::runBlocking()` helper; both route through it. **No public signature change.**

## 2. Clarify the `Util::isPathInStore` ancestor-walk guard

The `cdUp()` guard the audit flagged as "effectively dead" is actually defensive — the filesystem root always exists, so the loop terminates before `cdUp()` can fail. Documented the invariant inline instead of removing the guard (removing risks an unbounded walk on pathological `QDir` state; restructuring breaks the path-reconstruction ordering).

## Deferred (noted in #1510)

The "collapse to two overloads taking `QProcessEnvironment`" idea is **not** done here: changing the public env type from `QStringList` ripples into `Pass::env` and `Executor::environment()` plumbing — not a small cleanup. Left for a focused follow-up; #1510 stays open to track it.

## Test plan

- [x] `qmake6 -r && make` clean
- [x] `tst_util` 138, `tst_executor` 32, `tst_integration` 20 — all pass (executeBlocking is exercised heavily by the integration suite via real gpg)
- [x] doxygen clean, clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated blocking process execution for more consistent start/wait/exit behavior, reliable output decoding, and clearer exit-code signaling.
  * Ensured stdin handling and write-channel closure are applied consistently.
  * Strengthened filesystem-path checks with defensive safeguards and documentation to avoid edge-case failures.
  * Improves maintainability and runtime reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->