### PR TITLE
refactor: collapse StoreModel drag-drop handlers into one performDrop (#1514)

### DIFF
--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -365,67 +365,36 @@ auto StoreModel::executeDropAction(const dragAndDropInfoPasswordStore &info,
   }
 
   switch (info.kind) {
-  case dragAndDropInfoPasswordStore::ItemKind::Directory:
-    return handleDirDrop(cleanedSrc, destFileinfo, srcFileInfo, action);
+  case dragAndDropInfoPasswordStore::ItemKind::Directory: {
+    // Dropping a folder onto a folder: move/copy it *into* the target.
+    if (!destFileinfo.isDir()) {
+      return false;
+    }
+    const QString destDir =
+        QDir::cleanPath(QDir(cleanedDest).filePath(srcFileInfo.fileName()));
+    return performDrop(cleanedSrc, destDir, action, false);
+  }
   case dragAndDropInfoPasswordStore::ItemKind::File:
-    return handleFileDrop(cleanedSrc, cleanedDest, destFileinfo, action);
+    // File onto a folder drops into it (no clash); file onto an existing
+    // file asks before overwriting.
+    if (destFileinfo.isDir()) {
+      return performDrop(cleanedSrc, cleanedDest, action, false);
+    }
+    return performDrop(
+        cleanedSrc, cleanedDest, action,
+        QMessageBox::question(
+            qobject_cast<QWidget *>(QObject::parent()), tr("Force overwrite?"),
+            tr("overwrite %1 with %2?").arg(cleanedDest, cleanedSrc),
+            QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes);
   default:
     qWarning() << "executeDropAction: unexpected ItemKind, ignoring drop";
     return false;
   }
 }
 
-auto StoreModel::handleDirDrop(const QString &cleanedSrc,
-                               const QFileInfo &destFileinfo,
-                               const QFileInfo &srcFileInfo,
-                               Qt::DropAction action) -> bool {
-  if (!destFileinfo.isDir()) {
-    return false;
-  }
-
-  QDir destDir = QDir(QDir::cleanPath(destFileinfo.absoluteFilePath()))
-                     .filePath(srcFileInfo.fileName());
-  QString cleanedDestDir = QDir::cleanPath(destDir.absolutePath());
-
-  if (action == Qt::MoveAction) {
-    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDestDir, false);
-  } else if (action == Qt::CopyAction) {
-    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDestDir, false);
-  }
-  return true;
-}
-
-auto StoreModel::handleFileDrop(const QString &cleanedSrc,
-                                const QString &cleanedDest,
-                                const QFileInfo &destFileinfo,
-                                Qt::DropAction action) -> bool {
-  if (destFileinfo.isDir()) {
-    return handleFileToDirDrop(cleanedSrc, cleanedDest, action);
-  }
-  return handleFileToFileDrop(cleanedSrc, cleanedDest, action);
-}
-
-auto StoreModel::handleFileToDirDrop(const QString &cleanedSrc,
-                                     const QString &cleanedDest,
-                                     Qt::DropAction action) -> bool {
-  if (action == Qt::MoveAction) {
-    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDest, false);
-  } else if (action == Qt::CopyAction) {
-    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDest, false);
-  }
-  return true;
-}
-
-auto StoreModel::handleFileToFileDrop(const QString &cleanedSrc,
-                                      const QString &cleanedDest,
-                                      Qt::DropAction action) -> bool {
-  QWidget *parentWidget = qobject_cast<QWidget *>(parent());
-  int answer = QMessageBox::question(
-      parentWidget, tr("Force overwrite?"),
-      tr("overwrite %1 with %2?").arg(cleanedDest, cleanedSrc),
-      QMessageBox::Yes | QMessageBox::No);
-  bool force = answer == QMessageBox::Yes;
-
+auto StoreModel::performDrop(const QString &cleanedSrc,
+                             const QString &cleanedDest, Qt::DropAction action,
+                             bool force) -> bool {
   if (action == Qt::MoveAction) {
     QtPassSettings::getPass()->Move(cleanedSrc, cleanedDest, force);
   } else if (action == Qt::CopyAction) {

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -73,18 +73,16 @@ private:
   auto executeDropAction(const dragAndDropInfoPasswordStore &info,
                          Qt::DropAction action, const QModelIndex &parent)
       -> bool;
-  auto handleDirDrop(const QString &cleanedSrc, const QFileInfo &destFileinfo,
-                     const QFileInfo &srcFileInfo, Qt::DropAction action)
-      -> bool;
-  auto handleFileDrop(const QString &cleanedSrc, const QString &cleanedDest,
-                      const QFileInfo &destFileinfo, Qt::DropAction action)
-      -> bool;
-  auto handleFileToDirDrop(const QString &cleanedSrc,
-                           const QString &cleanedDest, Qt::DropAction action)
-      -> bool;
-  auto handleFileToFileDrop(const QString &cleanedSrc,
-                            const QString &cleanedDest, Qt::DropAction action)
-      -> bool;
+  /**
+   * @brief Perform the actual Move/Copy for a validated drop.
+   * @param cleanedSrc Canonical source path (inside the store).
+   * @param cleanedDest Canonical destination path (inside the store).
+   * @param action Qt::MoveAction or Qt::CopyAction.
+   * @param force Overwrite an existing destination.
+   * @return true once the operation has been dispatched.
+   */
+  static auto performDrop(const QString &cleanedSrc, const QString &cleanedDest,
+                          Qt::DropAction action, bool force) -> bool;
 
 public:
   /**


### PR DESCRIPTION
Part of #1508 / #1514. The StoreModel half of #1514.

## What

The four `handle*` drop methods were near-duplicate Move/Copy dispatch with a bit of per-case routing:

- `handleDirDrop`, `handleFileDrop`, `handleFileToDirDrop`, `handleFileToFileDrop`

Replaced with one static `performDrop(src, dest, action, force)`; the case-specific destination + force is computed inline in the `executeDropAction` switch:

| case | dest | force |
|---|---|---|
| dir → dir | `dest/<srcName>` | false |
| file → dir | the directory | false |
| file → file | the file | ask (overwrite prompt) |

Behaviour preserved; the existing `dropMimeData`/`canDrop` tests (incl. the path-traversal rejection cases) cover every path.

Net: `-66 / +33`, four methods → one.

## Note

`parent()` inside `executeDropAction` now uses `QObject::parent()` — the method's `QModelIndex` parameter is also named `parent` and would shadow it.

The Util grab-bag split (the other half of #1514) is a larger separate follow-up; **#1514 stays open** for it.

## Test plan

- [x] `qmake6 -r && make` clean
- [x] `tst_storemodel` 36/36
- [x] doxygen clean, clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced drag-and-drop handling with improved validation for directory and file operations, and added confirmation prompts when overwriting existing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->