### PR TITLE
refactor: dedup RealPass::Move/Copy via passMoveOrCopy (#1513)

### DIFF
--- a/src/realpass.cpp
+++ b/src/realpass.cpp
@@ -121,37 +121,7 @@ void RealPass::Init(QString path, const QList<UserInfo> &users) {
  * @param force overwrite
  */
 void RealPass::Move(const QString src, const QString dest, const bool force) {
-  QFileInfo srcFileInfo = QFileInfo(src);
-  QFileInfo destFileInfo = QFileInfo(dest);
-
-  // force mode?
-  // pass uses always the force mode, when call from eg. QT. so we have to
-  // check if this are to files and the user didn't want to move force
-  if (!force && srcFileInfo.isFile() && destFileInfo.isFile()) {
-    return;
-  }
-
-  QString passSrc = QDir(QtPassSettings::getPassStore())
-                        .relativeFilePath(QDir(src).absolutePath());
-  QString passDest = QDir(QtPassSettings::getPassStore())
-                         .relativeFilePath(QDir(dest).absolutePath());
-
-  // remove the .gpg because pass will not work
-  if (srcFileInfo.isFile() && srcFileInfo.suffix() == "gpg") {
-    passSrc.replace(Util::endsWithGpg(), "");
-  }
-  if (destFileInfo.isFile() && destFileInfo.suffix() == "gpg") {
-    passDest.replace(Util::endsWithGpg(), "");
-  }
-
-  QStringList args;
-  args << "mv";
-  if (force) {
-    args << "-f";
-  }
-  args << passSrc;
-  args << passDest;
-  executePass(PASS_MOVE, args);
+  passMoveOrCopy(PASS_MOVE, QStringLiteral("mv"), src, dest, force);
 }
 
 /**
@@ -161,8 +131,23 @@ void RealPass::Move(const QString src, const QString dest, const bool force) {
  * @param force overwrite
  */
 void RealPass::Copy(const QString src, const QString dest, const bool force) {
+  passMoveOrCopy(PASS_COPY, QStringLiteral("cp"), src, dest, force);
+}
+
+/**
+ * @brief RealPass::passMoveOrCopy shared `pass mv` / `pass cp` implementation.
+ * @param id PASS_MOVE or PASS_COPY.
+ * @param subcommand "mv" or "cp".
+ * @param src source file or folder.
+ * @param dest destination file or folder.
+ * @param force overwrite.
+ */
+void RealPass::passMoveOrCopy(PROCESS id, const QString &subcommand,
+                              const QString &src, const QString &dest,
+                              const bool force) {
   QFileInfo srcFileInfo = QFileInfo(src);
   QFileInfo destFileInfo = QFileInfo(dest);
+
   // force mode?
   // pass uses always the force mode, when call from eg. QT. so we have to
   // check if this are to files and the user didn't want to move force
@@ -182,14 +167,15 @@ void RealPass::Copy(const QString src, const QString dest, const bool force) {
   if (destFileInfo.isFile() && destFileInfo.suffix() == "gpg") {
     passDest.replace(Util::endsWithGpg(), "");
   }
+
   QStringList args;
-  args << "cp";
+  args << subcommand;
   if (force) {
     args << "-f";
   }
   args << passSrc;
   args << passDest;
-  executePass(PASS_COPY, args);
+  executePass(id, args);
 }
 
 /**

--- a/src/realpass.h
+++ b/src/realpass.h
@@ -30,6 +30,17 @@ class RealPass : public Pass {
   void executePass(PROCESS id, const QStringList &args,
                    QString input = QString(), bool readStdout = true,
                    bool readStderr = true);
+  /**
+   * @brief Shared implementation of Move and Copy via `pass mv`/`pass cp`.
+   * @param id Process id (PASS_MOVE or PASS_COPY).
+   * @param subcommand The pass subcommand, "mv" or "cp".
+   * @param src Source path.
+   * @param dest Destination path.
+   * @param force Overwrite an existing destination; without it a
+   *        file-onto-file request is a no-op (pass would otherwise force).
+   */
+  void passMoveOrCopy(PROCESS id, const QString &subcommand, const QString &src,
+                      const QString &dest, bool force);
 
 public:
   /**


### PR DESCRIPTION
Part of #1508 / #1513.

## What

`RealPass::Move` and `RealPass::Copy` were byte-identical except the pass subcommand (`mv`/`cp`) and process id (`PASS_MOVE`/`PASS_COPY`) — same force-skip guard, store-relative path mapping, `.gpg`-suffix stripping, and arg assembly. Extracted a private `passMoveOrCopy(id, subcommand, src, dest, force)`; `Move`/`Copy` are now one-line delegations.

`-33 / +30`.

## Scope note

Only the **RealPass internal** duplication is addressed. The cross-backend "normalizePaths in `Pass`" idea from #1513 doesn't fit — `ImitatePass::Move`/`Copy` are structurally different (git mv/cp + direct file ops + reencrypt) and don't share the store-relative/`.gpg` path shape. The `executeWrapper` indirection, the `Grep` BRE-vs-PCRE semantics question, and the backend-factory parts of #1513 remain open; **#1513 stays open**.

## Test plan

- [x] `qmake6 -r && make` clean
- [x] `tst_integration` 20/20 (incl. RealPass paths, real `pass`)
- [x] doxygen clean, clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate code in move and copy operations for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->