### PR TITLE
refactor: extract SSH_AUTH_SOCK logic into SshAuthSock module (#1514)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "mainwindow.h"
-#include "util.h"
+#include "sshauthsock.h"
 #if SINGLE_APP
 #include "singleapplication.h"
 #endif
@@ -148,7 +148,7 @@ auto main(int argc, char *argv[]) -> int {
   // Probe / set SSH_AUTH_SOCK before any subprocess runs (issue #543).
   // GUI launchers don't inherit shell-set env vars, so users with
   // gpg-agent's SSH support get failed git push/pull until this fires.
-  Util::initialiseSshAuthSock();
+  SshAuthSock::initialise();
 
   // Setup and load translator for localization.
   //

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -5,6 +5,7 @@
 #include "mainwindow.h"
 #include "profileinit.h"
 #include "qtpasssettings.h"
+#include "sshauthsock.h"
 #include "ui_configdialog.h"
 #include "usersdialog.h"
 #include "util.h"
@@ -253,16 +254,16 @@ void ConfigDialog::on_accepted() {
   const QString sshAuthSockOverride = ui->sshAuthSockOverride->text().trimmed();
   if (!sshAuthSockOverride.isEmpty()) {
     QString reason;
-    switch (Util::sshAuthSockOverrideStatus(sshAuthSockOverride)) {
-    case Util::SshAuthSockOverrideStatus::Valid:
+    switch (SshAuthSock::overrideStatus(sshAuthSockOverride)) {
+    case SshAuthSock::OverrideStatus::Valid:
       break;
-    case Util::SshAuthSockOverrideStatus::DoesNotExist:
+    case SshAuthSock::OverrideStatus::DoesNotExist:
       reason = tr("The path does not exist.");
       break;
-    case Util::SshAuthSockOverrideStatus::NotReadable:
+    case SshAuthSock::OverrideStatus::NotReadable:
       reason = tr("The path is not readable.");
       break;
-    case Util::SshAuthSockOverrideStatus::NotUnixDomainSocket:
+    case SshAuthSock::OverrideStatus::NotUnixDomainSocket:
       reason = tr("The path is not a Unix domain socket.");
       break;
     }

--- a/src/src.pro
+++ b/src/src.pro
@@ -79,6 +79,7 @@ SOURCES   += mainwindow.cpp \
              configdialog.cpp \
              storemodel.cpp \
              util.cpp \
+             sshauthsock.cpp \
              usersdialog.cpp \
              keygendialog.cpp \
              trayicon.cpp \
@@ -105,6 +106,7 @@ HEADERS   += mainwindow.h \
              configdialog.h \
              storemodel.h \
              util.h \
+             sshauthsock.h \
              usersdialog.h \
              keygendialog.h \
              trayicon.h \

--- a/src/sshauthsock.cpp
+++ b/src/sshauthsock.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @class SshAuthSock
+ * @brief SSH_AUTH_SOCK discovery and validation implementation.
+ *
+ * @see sshauthsock.h
+ */
+
+#include "sshauthsock.h"
+#include "executor.h"
+#include "qtpasssettings.h"
+#include <QFileInfo>
+#include <QProcessEnvironment>
+#ifndef Q_OS_WIN
+#include <sys/stat.h>
+#endif
+
+#ifdef QT_DEBUG
+#include "debughelper.h"
+#endif
+
+namespace {
+/**
+ * @brief Verify that a candidate SSH_AUTH_SOCK socket has a live agent
+ *        listening, before letting QtPass switch the environment to it.
+ *
+ * Why: a user may have a working external SSH agent (OpenSSH ssh-agent,
+ * KeePassXC / 1Password / yubikey-agent / gnome-keyring) configured in
+ * their shell, but its env didn't propagate to the GUI launcher. If we
+ * blindly adopt whatever `gpgconf --list-dirs agent-ssh-socket` reports —
+ * even when gpg-agent isn't running with SSH support, or has no keys —
+ * we'd be silently switching them away from their real agent.
+ *
+ * Approach: spawn `ssh-add -l` with SSH_AUTH_SOCK pointed at the candidate
+ * (via Executor's env-aware overload, so the parent env isn't disturbed).
+ * Treat exit codes 0 (keys present) and 1 (agent alive but key list empty —
+ * legitimate for YubiKey-backed setups that enumerate on tap) as
+ * "reachable". Anything else, including ssh-add not being on PATH, means
+ * we don't adopt the candidate.
+ *
+ * @param candidate Path to validate.
+ * @return true if the socket has a reachable agent; false otherwise.
+ */
+auto isSshAgentReachable(const QString &candidate) -> bool {
+  if (candidate.isEmpty()) {
+    return false;
+  }
+  // Build a minimal env that overrides SSH_AUTH_SOCK without polluting the
+  // parent process. systemEnvironment() captures whatever was set when
+  // QtPass started, then we override the one var of interest.
+  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+  env.insert(QStringLiteral("SSH_AUTH_SOCK"), candidate);
+  QString out;
+  QString err;
+  const int exitCode =
+      Executor::executeBlocking(env.toStringList(), QStringLiteral("ssh-add"),
+                                {QStringLiteral("-l")}, &out, &err);
+  // OpenSSH ssh-add(1) exit codes: 0 = success / has keys, 1 = no
+  // identities present, 2 = couldn't open a connection. Anything else is
+  // also treated as unreachable (e.g. ssh-add not on PATH).
+  return exitCode == 0 || exitCode == 1;
+}
+} // namespace
+
+auto SshAuthSock::overrideStatus(const QString &path) -> OverrideStatus {
+  const QFileInfo fi(path);
+  if (!fi.exists()) {
+    return OverrideStatus::DoesNotExist;
+  }
+  if (!fi.isReadable()) {
+    return OverrideStatus::NotReadable;
+  }
+#ifdef Q_OS_UNIX
+  // S_ISSOCK isn't exposed by QFileInfo; go through stat(2). On Windows
+  // ssh-agent uses a named pipe (\\.\pipe\openssh-ssh-agent.<sid>) and the
+  // socket check would always fail, so skip it there — exists + readable is
+  // the best we can do.
+  struct stat st{};
+  if (::stat(path.toLocal8Bit().constData(), &st) != 0 ||
+      !S_ISSOCK(st.st_mode)) {
+    return OverrideStatus::NotUnixDomainSocket;
+  }
+#endif
+  return OverrideStatus::Valid;
+}
+
+/**
+ * @brief Probe and set SSH_AUTH_SOCK if missing — see header for full rules.
+ *
+ * Implementation notes:
+ * - Reads QtPassSettings::getSshAuthSockOverride() for the manual override
+ *   path; if non-empty, uses it verbatim (no validation — explicit override).
+ * - Otherwise runs `gpgconf --list-dirs agent-ssh-socket` (gpg-agent's
+ *   canonical socket reporter). On macOS, additionally tries `launchctl
+ *   getenv SSH_AUTH_SOCK`.
+ * - Auto-probed candidates are validated via `ssh-add -l` before adoption,
+ *   so users with a different external SSH agent aren't silently switched
+ *   to an empty gpg-agent SSH socket.
+ * - All probes go through Executor::executeBlocking with short, bounded
+ *   subprocess executions; any failure is silently absorbed (the user just
+ *   doesn't get the auto-fix).
+ */
+void SshAuthSock::initialise() {
+  // Honour any value already in the environment — terminal launches,
+  // explicit `.desktop` Exec= overrides, and parent-process exports must win.
+  if (!qgetenv("SSH_AUTH_SOCK").isEmpty()) {
+    return;
+  }
+
+  // Manual override from settings takes precedence over auto-probe.
+  const QString override = QtPassSettings::getSshAuthSockOverride();
+  if (!override.isEmpty()) {
+    qputenv("SSH_AUTH_SOCK", override.toUtf8());
+#ifdef QT_DEBUG
+    dbg() << "SshAuthSock::initialise(): set from settings override:"
+          << override;
+#endif
+    return;
+  }
+
+  // Auto-probe via gpgconf (canonical for gpg-agent's SSH support).
+  QString out;
+  QString err;
+  if (Executor::executeBlocking(
+          QStringLiteral("gpgconf"),
+          {QStringLiteral("--list-dirs"), QStringLiteral("agent-ssh-socket")},
+          &out, &err) == 0) {
+    const QString socket = out.trimmed();
+    if (!socket.isEmpty() && isSshAgentReachable(socket)) {
+      qputenv("SSH_AUTH_SOCK", socket.toUtf8());
+#ifdef QT_DEBUG
+      dbg() << "SshAuthSock::initialise(): set from gpgconf:" << socket;
+#endif
+      return;
+    }
+#ifdef QT_DEBUG
+    if (!socket.isEmpty()) {
+      dbg() << "SshAuthSock::initialise(): gpgconf reported" << socket
+            << "but ssh-add -l rejected it; not adopting";
+    }
+#endif
+  }
+
+#ifdef Q_OS_MACOS
+  // On macOS, GUI-launched apps may have SSH_AUTH_SOCK in launchd's
+  // per-session environment but not in the inherited process env.
+  out.clear();
+  err.clear();
+  if (Executor::executeBlocking(
+          QStringLiteral("launchctl"),
+          {QStringLiteral("getenv"), QStringLiteral("SSH_AUTH_SOCK")}, &out,
+          &err) == 0) {
+    const QString socket = out.trimmed();
+    if (!socket.isEmpty() && isSshAgentReachable(socket)) {
+      qputenv("SSH_AUTH_SOCK", socket.toUtf8());
+#ifdef QT_DEBUG
+      dbg() << "SshAuthSock::initialise(): set from launchctl:" << socket;
+#endif
+    }
+#ifdef QT_DEBUG
+    else if (!socket.isEmpty()) {
+      dbg() << "SshAuthSock::initialise(): launchctl reported" << socket
+            << "but ssh-add -l rejected it; not adopting";
+    }
+#endif
+  }
+#endif
+}

--- a/src/sshauthsock.h
+++ b/src/sshauthsock.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef SRC_SSHAUTHSOCK_H_
+#define SRC_SSHAUTHSOCK_H_
+
+#include <QString>
+#include <cstdint>
+
+/**
+ * @class SshAuthSock
+ * @brief SSH_AUTH_SOCK discovery and validation for child processes.
+ *
+ * Extracted from Util. GUI-launched applications don't inherit shell-set
+ * environment variables, so users with gpg-agent's SSH support or another
+ * external SSH agent see git push/pull fail. See initialise(). Issue #543.
+ */
+class SshAuthSock {
+public:
+  /**
+   * @brief Classify a non-empty SSH_AUTH_SOCK override path supplied by the
+   *        user.
+   *
+   * Empty / unset input is handled by the caller (no warning when the field
+   * is blank). For a non-empty path, this returns one of:
+   *
+   * - `Valid` — exists, readable, and on Unix is a Unix domain socket.
+   * - `DoesNotExist` — `QFileInfo::exists()` returned false.
+   * - `NotReadable` — exists but `QFileInfo::isReadable()` returned false.
+   * - `NotUnixDomainSocket` — Unix-only: `stat()` says it's not `S_ISSOCK`.
+   *
+   * On Windows the socket check is skipped — ssh-agent uses a named pipe.
+   */
+  enum class OverrideStatus : std::uint8_t {
+    Valid,
+    DoesNotExist,
+    NotReadable,
+    NotUnixDomainSocket,
+  };
+  /**
+   * @brief Validate an SSH_AUTH_SOCK override path. Caller is expected to
+   *        skip validation when the input is empty / whitespace-only.
+   * @param path Non-empty candidate path.
+   * @return Classification per OverrideStatus.
+   */
+  static auto overrideStatus(const QString &path) -> OverrideStatus;
+
+  /**
+   * @brief Ensure SSH_AUTH_SOCK is set for child processes.
+   *
+   * GUI-launched applications don't inherit shell-set environment variables
+   * (`.bashrc`/`.zshrc`/etc.), so users with gpg-agent's SSH support or other
+   * external SSH agents see `git push`/`git pull` fail when QtPass launches
+   * from a desktop launcher rather than a terminal. Issue #543.
+   *
+   * Resolution order:
+   * 1. If `SSH_AUTH_SOCK` is already set (terminal launch, .desktop override,
+   *    parent process), do nothing.
+   * 2. If a `sshAuthSockOverride` setting is configured in QtPass, use it
+   *    verbatim as an explicit user choice (no validation is performed here).
+   *    Users should ensure this path points to a valid, accessible SSH agent
+   *    socket; otherwise SSH operations may fail for child processes. The
+   *    Settings dialog shows a non-blocking warning at save time when the
+   *    override path looks bogus (missing, unreadable, or not a socket).
+   * 3. Probe `gpgconf --list-dirs agent-ssh-socket` (canonical for gpg-agent),
+   *    then validate the candidate with `ssh-add -l` (must exit 0 or 1) before
+   *    adopting. Validation prevents silently switching users from a working
+   *    external SSH agent to an empty gpg-agent SSH socket.
+   * 4. On macOS, fall back to `launchctl getenv SSH_AUTH_SOCK`, with the same
+   *    `ssh-add -l` validation.
+   *
+   * Sets the variable via qputenv so child processes inherit it.
+   */
+  static void initialise();
+
+private:
+  SshAuthSock() = default;
+};
+
+#endif // SRC_SSHAUTHSOCK_H_

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -28,7 +28,6 @@
 #ifdef Q_OS_WIN
 #include <windows.h>
 #else
-#include <sys/stat.h>
 #include <sys/time.h>
 #endif
 #include "qtpasssettings.h"
@@ -39,132 +38,6 @@
 
 QProcessEnvironment Util::_env;
 bool Util::_envInitialised = false;
-
-namespace {
-/**
- * @brief Verify that a candidate SSH_AUTH_SOCK socket has a live agent
- *        listening, before letting QtPass switch the environment to it.
- *
- * Why: a user may have a working external SSH agent (OpenSSH ssh-agent,
- * KeePassXC / 1Password / yubikey-agent / gnome-keyring) configured in
- * their shell, but its env didn't propagate to the GUI launcher. If we
- * blindly adopt whatever `gpgconf --list-dirs agent-ssh-socket` reports —
- * even when gpg-agent isn't running with SSH support, or has no keys —
- * we'd be silently switching them away from their real agent.
- *
- * Approach: spawn `ssh-add -l` with SSH_AUTH_SOCK pointed at the candidate
- * (via Executor's env-aware overload, so the parent env isn't disturbed).
- * Treat exit codes 0 (keys present) and 1 (agent alive but key list empty —
- * legitimate for YubiKey-backed setups that enumerate on tap) as
- * "reachable". Anything else, including ssh-add not being on PATH, means
- * we don't adopt the candidate.
- *
- * @param candidate Path to validate.
- * @return true if the socket has a reachable agent; false otherwise.
- */
-auto isSshAgentReachable(const QString &candidate) -> bool {
-  if (candidate.isEmpty()) {
-    return false;
-  }
-  // Build a minimal env that overrides SSH_AUTH_SOCK without polluting the
-  // parent process. systemEnvironment() captures whatever was set when
-  // QtPass started, then we override the one var of interest.
-  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert(QStringLiteral("SSH_AUTH_SOCK"), candidate);
-  QString out;
-  QString err;
-  const int exitCode =
-      Executor::executeBlocking(env.toStringList(), QStringLiteral("ssh-add"),
-                                {QStringLiteral("-l")}, &out, &err);
-  // OpenSSH ssh-add(1) exit codes: 0 = success / has keys, 1 = no
-  // identities present, 2 = couldn't open a connection. Anything else is
-  // also treated as unreachable (e.g. ssh-add not on PATH).
-  return exitCode == 0 || exitCode == 1;
-}
-} // namespace
-
-/**
- * @brief Probe and set SSH_AUTH_SOCK if missing — see header for full rules.
- *
- * Implementation notes:
- * - Reads QtPassSettings::getSshAuthSockOverride() for the manual override
- *   path; if non-empty, uses it verbatim (no validation — explicit override).
- * - Otherwise runs `gpgconf --list-dirs agent-ssh-socket` (gpg-agent's
- *   canonical socket reporter). On macOS, additionally tries `launchctl
- *   getenv SSH_AUTH_SOCK`.
- * - Auto-probed candidates are validated via `ssh-add -l` before adoption,
- *   so users with a different external SSH agent aren't silently switched
- *   to an empty gpg-agent SSH socket.
- * - All probes go through Executor::executeBlocking with short, bounded
- *   subprocess executions; any failure is silently absorbed (the user just
- *   doesn't get the auto-fix).
- */
-void Util::initialiseSshAuthSock() {
-  // Honour any value already in the environment — terminal launches,
-  // explicit `.desktop` Exec= overrides, and parent-process exports must win.
-  if (!qgetenv("SSH_AUTH_SOCK").isEmpty()) {
-    return;
-  }
-
-  // Manual override from settings takes precedence over auto-probe.
-  const QString override = QtPassSettings::getSshAuthSockOverride();
-  if (!override.isEmpty()) {
-    qputenv("SSH_AUTH_SOCK", override.toUtf8());
-#ifdef QT_DEBUG
-    dbg() << "Util::initialiseSshAuthSock(): set from settings override:"
-          << override;
-#endif
-    return;
-  }
-
-  // Auto-probe via gpgconf (canonical for gpg-agent's SSH support).
-  QString out;
-  QString err;
-  if (Executor::executeBlocking(
-          QStringLiteral("gpgconf"),
-          {QStringLiteral("--list-dirs"), QStringLiteral("agent-ssh-socket")},
-          &out, &err) == 0) {
-    const QString socket = out.trimmed();
-    if (!socket.isEmpty() && isSshAgentReachable(socket)) {
-      qputenv("SSH_AUTH_SOCK", socket.toUtf8());
-#ifdef QT_DEBUG
-      dbg() << "Util::initialiseSshAuthSock(): set from gpgconf:" << socket;
-#endif
-      return;
-    }
-#ifdef QT_DEBUG
-    if (!socket.isEmpty()) {
-      dbg() << "Util::initialiseSshAuthSock(): gpgconf reported" << socket
-            << "but ssh-add -l rejected it; not adopting";
-    }
-#endif
-  }
-
-#ifdef Q_OS_MACOS
-  // On macOS, GUI-launched apps may have SSH_AUTH_SOCK in launchd's
-  // per-session environment but not in the inherited process env.
-  out.clear();
-  err.clear();
-  if (Executor::executeBlocking(
-          QStringLiteral("launchctl"),
-          {QStringLiteral("getenv"), QStringLiteral("SSH_AUTH_SOCK")}, &out,
-          &err) == 0) {
-    const QString socket = out.trimmed();
-    if (!socket.isEmpty() && isSshAgentReachable(socket)) {
-      qputenv("SSH_AUTH_SOCK", socket.toUtf8());
-#ifdef QT_DEBUG
-      dbg() << "Util::initialiseSshAuthSock(): set from launchctl:" << socket;
-#endif
-    }
-#ifdef QT_DEBUG
-    else if (!socket.isEmpty()) {
-      dbg() << "Util::initialiseSshAuthSock(): launchctl reported" << socket
-            << "but ssh-add -l rejected it; not adopting";
-    }
-#endif
-  }
-#endif
-}
 
 /**
  * @brief Initializes the process environment and augments PATH with
@@ -288,29 +161,6 @@ auto Util::isPathInStore(const QString &storeRoot, const QString &candidate)
   }
   return resolved == rootCanon ||
          resolved.startsWith(rootCanon + QLatin1Char('/'));
-}
-
-auto Util::sshAuthSockOverrideStatus(const QString &path)
-    -> SshAuthSockOverrideStatus {
-  const QFileInfo fi(path);
-  if (!fi.exists()) {
-    return SshAuthSockOverrideStatus::DoesNotExist;
-  }
-  if (!fi.isReadable()) {
-    return SshAuthSockOverrideStatus::NotReadable;
-  }
-#ifdef Q_OS_UNIX
-  // S_ISSOCK isn't exposed by QFileInfo; go through stat(2). On Windows
-  // ssh-agent uses a named pipe (\\.\pipe\openssh-ssh-agent.<sid>) and the
-  // socket check would always fail, so skip it there — exists + readable is
-  // the best we can do.
-  struct stat st{};
-  if (::stat(path.toLocal8Bit().constData(), &st) != 0 ||
-      !S_ISSOCK(st.st_mode)) {
-    return SshAuthSockOverrideStatus::NotUnixDomainSocket;
-  }
-#endif
-  return SshAuthSockOverrideStatus::Valid;
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -20,34 +20,6 @@ class StoreModel;
 class Util {
 public:
   /**
-   * @brief Classify a non-empty SSH_AUTH_SOCK override path supplied by the
-   *        user.
-   *
-   * Empty / unset input is handled by the caller (no warning when the field
-   * is blank). For a non-empty path, this returns one of:
-   *
-   * - `Valid` — exists, readable, and on Unix is a Unix domain socket.
-   * - `DoesNotExist` — `QFileInfo::exists()` returned false.
-   * - `NotReadable` — exists but `QFileInfo::isReadable()` returned false.
-   * - `NotUnixDomainSocket` — Unix-only: `stat()` says it's not `S_ISSOCK`.
-   *
-   * On Windows the socket check is skipped — ssh-agent uses a named pipe.
-   */
-  enum class SshAuthSockOverrideStatus {
-    Valid,
-    DoesNotExist,
-    NotReadable,
-    NotUnixDomainSocket,
-  };
-  /**
-   * @brief Validate an SSH_AUTH_SOCK override path. Caller is expected to
-   *        skip validation when the input is empty / whitespace-only.
-   * @param path Non-empty candidate path.
-   * @return Classification per SshAuthSockOverrideStatus.
-   */
-  static auto sshAuthSockOverrideStatus(const QString &path)
-      -> SshAuthSockOverrideStatus;
-  /**
    * @brief Locate an executable by searching the process PATH and (on Windows)
    * falling back to WSL.
    * @param binary Executable name or relative path to locate (e.g., "gpg" or
@@ -184,34 +156,6 @@ public:
    */
   static auto getFolderTemplate(const QString &folderPath,
                                 const QString &storePath) -> QString;
-
-  /**
-   * @brief Ensure SSH_AUTH_SOCK is set for child processes.
-   *
-   * GUI-launched applications don't inherit shell-set environment variables
-   * (`.bashrc`/`.zshrc`/etc.), so users with gpg-agent's SSH support or other
-   * external SSH agents see `git push`/`git pull` fail when QtPass launches
-   * from a desktop launcher rather than a terminal. Issue #543.
-   *
-   * Resolution order:
-   * 1. If `SSH_AUTH_SOCK` is already set (terminal launch, .desktop override,
-   *    parent process), do nothing.
-   * 2. If a `sshAuthSockOverride` setting is configured in QtPass, use it
-   *    verbatim as an explicit user choice (no validation is performed here).
-   *    Users should ensure this path points to a valid, accessible SSH agent
-   *    socket; otherwise SSH operations may fail for child processes. The
-   *    Settings dialog shows a non-blocking warning at save time when the
-   *    override path looks bogus (missing, unreadable, or not a socket).
-   * 3. Probe `gpgconf --list-dirs agent-ssh-socket` (canonical for gpg-agent),
-   *    then validate the candidate with `ssh-add -l` (must exit 0 or 1) before
-   *    adopting. Validation prevents silently switching users from a working
-   *    external SSH agent to an empty gpg-agent SSH socket.
-   * 4. On macOS, fall back to `launchctl getenv SSH_AUTH_SOCK`, with the same
-   *    `ssh-add -l` validation.
-   *
-   * Sets the variable via qputenv so child processes inherit it.
-   */
-  static void initialiseSshAuthSock();
 
 private:
   static void initialiseEnvironment();

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -28,6 +28,7 @@
 #include "../../../src/qtpass.h"
 #include "../../../src/qtpasssettings.h"
 #include "../../../src/simpletransaction.h"
+#include "../../../src/sshauthsock.h"
 #include "../../../src/userinfo.h"
 #include "../../../src/util.h"
 
@@ -2178,7 +2179,7 @@ void tst_util::initialiseSshAuthSockHonoursExistingEnv() {
   // Even if an override is configured, the existing env wins.
   QtPassSettings::setSshAuthSockOverride(
       QStringLiteral("/tmp/qtpass-override-sock"));
-  Util::initialiseSshAuthSock();
+  SshAuthSock::initialise();
   QCOMPARE(qgetenv("SSH_AUTH_SOCK"), existing);
 }
 
@@ -2191,7 +2192,7 @@ void tst_util::initialiseSshAuthSockUsesOverride() {
   qunsetenv("SSH_AUTH_SOCK");
   const QString override = QStringLiteral("/tmp/qtpass-override-sock");
   QtPassSettings::setSshAuthSockOverride(override);
-  Util::initialiseSshAuthSock();
+  SshAuthSock::initialise();
   QCOMPARE(qgetenv("SSH_AUTH_SOCK"), override.toUtf8());
 }
 
@@ -2205,7 +2206,7 @@ void tst_util::initialiseSshAuthSockNoOverrideNoEnvProbes() {
   testutils::SshAuthSockGuard guard;
   qunsetenv("SSH_AUTH_SOCK");
   QtPassSettings::setSshAuthSockOverride(QString{});
-  Util::initialiseSshAuthSock();
+  SshAuthSock::initialise();
   // Either gpgconf set it (non-empty), or it stayed empty. Both fine.
   // The contract is: never crash, never set garbage.
   const QByteArray result = qgetenv("SSH_AUTH_SOCK");
@@ -2232,7 +2233,7 @@ void tst_util::initialiseSshAuthSockOverrideSkipsAgentValidation() {
       QStringLiteral("/tmp/qtpass-deliberately-dead-sock-") +
       QUuid::createUuid().toString();
   QtPassSettings::setSshAuthSockOverride(deadSocket);
-  Util::initialiseSshAuthSock();
+  SshAuthSock::initialise();
   QCOMPARE(qgetenv("SSH_AUTH_SOCK"), deadSocket.toUtf8());
 }
 
@@ -2244,7 +2245,7 @@ void tst_util::initialiseSshAuthSockEmptyOverrideFallsThrough() {
   testutils::SshAuthSockGuard guard;
   qunsetenv("SSH_AUTH_SOCK");
   QtPassSettings::setSshAuthSockOverride(QString{});
-  Util::initialiseSshAuthSock();
+  SshAuthSock::initialise();
   // After calling: SSH_AUTH_SOCK is either set by gpgconf probe or unset.
   // Both are acceptable; importantly, it must NOT be set to the empty string.
   if (qEnvironmentVariableIsSet("SSH_AUTH_SOCK")) {
@@ -2405,8 +2406,8 @@ void tst_util::writeGpgIdFileSetsOwnerOnlyPerms() {
 void tst_util::sshAuthSockOverrideStatusDoesNotExist() {
   QTemporaryDir tmp;
   QVERIFY2(tmp.isValid(), "tmp dir should be valid");
-  QCOMPARE(Util::sshAuthSockOverrideStatus(tmp.path() + "/no-such-socket"),
-           Util::SshAuthSockOverrideStatus::DoesNotExist);
+  QCOMPARE(SshAuthSock::overrideStatus(tmp.path() + "/no-such-socket"),
+           SshAuthSock::OverrideStatus::DoesNotExist);
 }
 
 /**
@@ -2424,8 +2425,8 @@ void tst_util::sshAuthSockOverrideStatusRegularFileRejected() {
   QFile f(filePath);
   QVERIFY2(f.open(QIODevice::WriteOnly), "should be able to create a file");
   f.close();
-  QCOMPARE(Util::sshAuthSockOverrideStatus(filePath),
-           Util::SshAuthSockOverrideStatus::NotUnixDomainSocket);
+  QCOMPARE(SshAuthSock::overrideStatus(filePath),
+           SshAuthSock::OverrideStatus::NotUnixDomainSocket);
 #endif
 }
 
@@ -2451,8 +2452,8 @@ void tst_util::sshAuthSockOverrideStatusNotReadable() {
   f.close();
   QVERIFY2(QFile::setPermissions(filePath, QFile::Permissions{}),
            "should be able to chmod 0 on the file");
-  QCOMPARE(Util::sshAuthSockOverrideStatus(filePath),
-           Util::SshAuthSockOverrideStatus::NotReadable);
+  QCOMPARE(SshAuthSock::overrideStatus(filePath),
+           SshAuthSock::OverrideStatus::NotReadable);
   // Restore something so QTemporaryDir can clean up.
   QFile::setPermissions(filePath, QFile::ReadOwner | QFile::WriteOwner);
 #endif
@@ -2490,8 +2491,8 @@ void tst_util::sshAuthSockOverrideStatusValid() {
     QFAIL("bind(AF_UNIX) failed");
   }
 
-  QCOMPARE(Util::sshAuthSockOverrideStatus(sockPath),
-           Util::SshAuthSockOverrideStatus::Valid);
+  QCOMPARE(SshAuthSock::overrideStatus(sockPath),
+           SshAuthSock::OverrideStatus::Valid);
 
   ::close(fd);
   // QTemporaryDir will rm -rf the directory on destruction, removing the


### PR DESCRIPTION
Part of #1508 / #1514 — **first slice** of the Util grab-bag split.

## What

The SSH_AUTH_SOCK discovery/validation code (the #543 work) had accreted onto the generic `Util` class. Move it to a dedicated `SshAuthSock` module:

| was | now |
|---|---|
| `Util::initialiseSshAuthSock()` | `SshAuthSock::initialise()` |
| `Util::sshAuthSockOverrideStatus()` | `SshAuthSock::overrideStatus()` |
| `Util::SshAuthSockOverrideStatus` enum | `SshAuthSock::OverrideStatus` |
| anon `isSshAgentReachable()` | moved verbatim |

Logic unchanged (verbatim move); only the home + symbol names change. The `OverrideStatus` enum is now `std::uint8_t`-sized (silences the `performance-enum-size` nit the old Util enum always drew).

## Knock-on

- `util.cpp` drops `<sys/stat.h>` (only the moved socket check used it); keeps `<QUrl>` (isLaunchableWebUrl) and `executor.h` (WSL findBinaryInPath).
- `main.cpp`: includes `sshauthsock.h`, drops now-unused `util.h`.
- `configdialog.cpp`: adds `sshauthsock.h`.
- SSH tests in `tst_util.cpp` retargeted to the new symbols.
- `src.pro` gains the module.

`+273 / −226` (mostly the verbatim move).

## Scope

This is one extraction. The remaining Util-split candidates (PathValidator for `isPathInStore`, Template I/O) are separate follow-up PRs; **#1514 stays open**.

## Test plan

- [x] `qmake6 -r && make` clean
- [x] `tst_util` 138/138 (all SSH cases pass against the new module)
- [x] doxygen clean, `reuse lint` compliant, clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized SSH agent socket discovery and validation logic into a dedicated component for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->