### PR TITLE
refactor: replace executeWrapper override with beforeExecute hook (#1513)

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -1029,20 +1029,13 @@ void ImitatePass::finished(int id, int exitCode, const QString &out,
 }
 
 /**
- * @brief executeWrapper    overridden so that every execution is a transaction
- * @param id
- * @param app
- * @param args
- * @param input
- * @param readStdout
- * @param readStderr
+ * @brief Register a transaction before each wrapped execution.
+ *
+ * Native mode treats every git/gpg invocation as a transaction; the base
+ * Pass::executeWrapper calls this hook just before dispatching.
+ * @param id Process identifier of the command about to run.
  */
-void ImitatePass::executeWrapper(PROCESS id, const QString &app,
-                                 const QStringList &args, QString input,
-                                 bool readStdout, bool readStderr) {
-  transactionAdd(id);
-  Pass::executeWrapper(id, app, args, input, readStdout, readStderr);
-}
+void ImitatePass::beforeExecute(PROCESS id) { transactionAdd(id); }
 
 /**
  * @brief Decrypt one .gpg file and return lines matching rx.

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -183,16 +183,13 @@ protected:
                 const QString &err) override;
 
   /**
-   * @brief Execute command wrapper.
+   * @brief Open a transaction for every execution.
+   *
+   * In native (imitate) mode each wrapped command is a git/gpg transaction;
+   * register it before the subprocess runs.
    * @param id Process identifier.
-   * @param app Executable path.
-   * @param args Command arguments.
-   * @param input Data to write to stdin.
-   * @param readStdout Whether to capture stdout.
-   * @param readStderr Whether to capture stderr.
    */
-  void executeWrapper(PROCESS id, const QString &app, const QStringList &args,
-                      QString input, bool readStdout, bool readStderr) override;
+  void beforeExecute(PROCESS id) override;
 
 public:
   /**

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -117,12 +117,15 @@ void Pass::executeWrapper(PROCESS id, const QString &app,
 void Pass::executeWrapper(PROCESS id, const QString &app,
                           const QStringList &args, QString input,
                           bool readStdout, bool readStderr) {
+  beforeExecute(id);
 #ifdef QT_DEBUG
   dbg() << app << args;
 #endif
   exec.execute(id, QtPassSettings::getPassStore(), app, args, std::move(input),
                readStdout, readStderr);
 }
+
+void Pass::beforeExecute(PROCESS /*id*/) {}
 
 /**
  * @brief Initializes the pass wrapper environment.

--- a/src/pass.h
+++ b/src/pass.h
@@ -264,9 +264,17 @@ protected:
    * @param readStdout Capture stdout.
    * @param readStderr Capture stderr.
    */
-  virtual void executeWrapper(PROCESS id, const QString &app,
-                              const QStringList &args, QString input,
-                              bool readStdout, bool readStderr);
+  void executeWrapper(PROCESS id, const QString &app, const QStringList &args,
+                      QString input, bool readStdout, bool readStderr);
+  /**
+   * @brief Hook invoked just before a wrapped command is dispatched.
+   *
+   * Default is a no-op; backends override it to wrap execution (e.g.
+   * ImitatePass registers a transaction). Keeps the dispatch surface a
+   * single non-virtual executeWrapper instead of an overridden one.
+   * @param id Process identifier of the command about to run.
+   */
+  virtual void beforeExecute(PROCESS id);
 
 protected slots:
   /**


### PR DESCRIPTION
## Summary

#1513 item 1 — collapse the `executeWrapper` dispatch chain.

The Pass execution path had a three-level dispatch: the 6-arg `executeWrapper` was `virtual` purely so `ImitatePass` could prepend `transactionAdd(id)` and then delegate back to the base. That hid the transaction wrapping *inside an override of the dispatch function itself*.

This makes the 6-arg `executeWrapper` non-virtual and introduces an explicit `virtual void beforeExecute(PROCESS)` hook (no-op in the base) that it calls right before handing off to the `Executor`. `ImitatePass` now overrides only that hook to register the transaction.

## Why
- Single `executeWrapper` implementation — no more override-of-dispatch.
- The transaction wrapping is visible as an explicit lifecycle hook, not buried in a re-implementation of the execute call.
- The 5-arg convenience overload (input-less) is unchanged.

`afterExecute` is intentionally **not** added — nothing in the hierarchy needs post-dispatch work (transaction completion is handled in the `finished` slot), so adding it would be a dead virtual.

## Verification
- `make -j2` clean
- `make check`: all suites pass, including `imitatepass` and `integration` (the transaction-bearing paths)
- doxygen clean, `reuse lint` compliant, clang-format applied

Part of #1513 (items 2 partly done in #1522; items 3/4 remain). #1513 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal transaction handling architecture for password manager operations. Transaction registration has been optimized to occur earlier in the execution flow, with no change to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->