### PR TITLE
docs: document backend-dependent Grep regex dialect (#1513)

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -1091,6 +1091,10 @@ auto ImitatePass::grepScanStore(const QStringList &env, const QString &gpgExe,
 /**
  * @brief Search all password content by GPG-decrypting each .gpg file.
  *
+ * The pattern is evaluated with `QRegularExpression` (**PCRE**), which differs
+ * from the POSIX BRE dialect of the `pass` backend — see Pass::Grep for the
+ * cross-backend caveat.
+ *
  * Runs a background thread to avoid blocking the UI. Results are emitted on
  * the main thread via QMetaObject::invokeMethod. A sequence counter discards
  * results from superseded searches.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -867,6 +867,14 @@ void MainWindow::on_grepButton_toggled(bool checked) {
   m_grepMode = checked;
   if (checked) {
     ui->lineEdit->setPlaceholderText(tr("Search content (regex)"));
+    // The regex dialect depends on the backend (see Pass::Grep): the pass
+    // backend uses POSIX BRE via `pass grep`, the native backend uses PCRE.
+    ui->lineEdit->setToolTip(
+        QtPassSettings::isUsePass()
+            ? tr("Content search uses POSIX basic regular expressions "
+                 "(pass grep).")
+            : tr("Content search uses Perl-compatible regular expressions "
+                 "(PCRE)."));
     ui->lineEdit->clear();
     searchTimer.stop();
     proxyModel.setFilterRegularExpression(QRegularExpression());
@@ -885,6 +893,7 @@ void MainWindow::on_grepButton_toggled(bool checked) {
     ui->lineEdit->clear();
     ui->lineEdit->blockSignals(false);
     ui->lineEdit->setPlaceholderText(tr("Search Password"));
+    ui->lineEdit->setToolTip(QString());
     ui->grepResultsList->clear();
     ui->grepResultsList->setVisible(false);
     ui->treeView->setVisible(true);

--- a/src/pass.h
+++ b/src/pass.h
@@ -152,7 +152,20 @@ public:
   virtual void Init(QString path, const QList<UserInfo> &users) = 0;
   /**
    * @brief Search password content for a pattern.
-   * @param pattern Search pattern (regular expression).
+   *
+   * @warning The regular-expression dialect is **backend-dependent**, so the
+   * same pattern can match differently depending on the configured backend:
+   * - RealPass shells out to `pass grep`, which uses **POSIX BRE** (GNU grep
+   *   default): e.g. `+`, `?`, `|`, `()` are literal unless backslash-escaped.
+   * - ImitatePass evaluates the pattern with `QRegularExpression`, which is
+   *   **PCRE**-style: those metacharacters are special without escaping.
+   *
+   * This Liskov wart is documented rather than papered over: a reliable
+   * BRE↔PCRE translation is intractable and `grep -P` is unavailable on
+   * macOS/BSD. Keep patterns to the common subset (literals, anchors `^`/`$`,
+   * `.`, `*`, bracket classes) for backend-independent results.
+   *
+   * @param pattern Search pattern (regular expression; see dialect note).
    * @param caseInsensitive true for case-insensitive search.
    */
   virtual void Grep(QString pattern, bool caseInsensitive) = 0;

--- a/src/realpass.cpp
+++ b/src/realpass.cpp
@@ -180,7 +180,11 @@ void RealPass::passMoveOrCopy(PROCESS id, const QString &subcommand,
 
 /**
  * @brief Search all password content via 'pass grep'.
- * @param pattern Search pattern.
+ *
+ * The pattern is interpreted by `pass grep` (GNU grep, **POSIX BRE**), which
+ * differs from the PCRE dialect used by the native backend — see
+ * Pass::Grep for the cross-backend caveat.
+ * @param pattern Search pattern (POSIX BRE).
  * @param caseInsensitive true for case-insensitive search.
  */
 void RealPass::Grep(QString pattern, bool caseInsensitive) {


### PR DESCRIPTION
## Summary

#1513 item 3. `RealPass::Grep` shells out to `pass grep` (**POSIX BRE**) while `ImitatePass::Grep` uses `QRegularExpression` (**PCRE**), so the same pattern can match differently depending on the configured backend — a Liskov wart.

Per the design discussion, this is **documented rather than unified**: a reliable BRE↔PCRE translation is intractable, and forcing PCRE on the pass backend (`grep -P`) is unavailable on macOS/BSD and would change results for existing users.

## Changes
- `Pass::Grep` header gains a `@warning` spelling out both dialects and the safe common subset (literals, `^`/`$`, `.`, `*`, bracket classes).
- `RealPass::Grep` / `ImitatePass::Grep` impl docs name their own engine and cross-reference `Pass::Grep`.
- The search field shows a **backend-aware tooltip** in content-search mode (POSIX BRE for pass, PCRE for native), cleared on leaving grep mode.

No behavioural change.

## Note
Two new `tr()` strings are added; their `.ts` entries are intentionally left out of this PR (picked up by the release-time `lupdate` like the prior refactor PRs in this series, to keep the diff focused).

## Verification
- `make -j2` clean, `tst_integration` passes
- doxygen clean, `reuse lint` compliant, clang-format applied

With item 3 resolved and item 1 shipped (#1526), only #1513 item 4 (backend factory) remains — blocked on #1511. #1513 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to the search input in grep/content search mode that indicate which regular-expression dialect is active based on the selected backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->