### PR TITLE
refactor: extract Pass backend lifecycle into PassBackendFactory (#1513)

### DIFF
--- a/src/passbackendfactory.cpp
+++ b/src/passbackendfactory.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2016 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @class PassBackendFactory
+ * @brief Pass backend lifecycle implementation.
+ *
+ * @see passbackendfactory.h
+ */
+
+#include "passbackendfactory.h"
+#include "pass.h"
+#include "qtpasssettings.h"
+
+Pass *PassBackendFactory::pass = nullptr;
+QScopedPointer<RealPass> PassBackendFactory::realPass;
+QScopedPointer<ImitatePass> PassBackendFactory::imitatePass;
+
+auto PassBackendFactory::getPass() -> Pass * {
+  if (!pass) {
+    if (QtPassSettings::isUsePass()) {
+      pass = getRealPass();
+    } else {
+      pass = getImitatePass();
+    }
+    if (pass) {
+      pass->init();
+    }
+  }
+  return pass;
+}
+
+auto PassBackendFactory::getRealPass() -> RealPass * {
+  if (realPass.isNull()) {
+    realPass.reset(new RealPass());
+  }
+  return realPass.data();
+}
+
+auto PassBackendFactory::getImitatePass() -> ImitatePass * {
+  if (imitatePass.isNull()) {
+    imitatePass.reset(new ImitatePass());
+  }
+  return imitatePass.data();
+}
+
+void PassBackendFactory::invalidate() { pass = nullptr; }

--- a/src/passbackendfactory.h
+++ b/src/passbackendfactory.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2016 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef SRC_PASSBACKENDFACTORY_H_
+#define SRC_PASSBACKENDFACTORY_H_
+
+#include "imitatepass.h"
+#include "realpass.h"
+
+#include <QScopedPointer>
+
+class Pass;
+
+/**
+ * @class PassBackendFactory
+ * @brief Owns the Pass backend lifecycle (RealPass vs ImitatePass).
+ *
+ * Extracted from QtPassSettings, which conflated settings storage with
+ * deciding and caching which password-store backend is active. The factory
+ * lazily constructs the two concrete backends, hands out the active one based
+ * on the configured mode, and exposes invalidate() so a settings change can
+ * force the active backend to be re-selected on next use.
+ */
+class PassBackendFactory {
+public:
+  /**
+   * @brief Get the active backend, constructing and initialising it on first
+   * use after construction or invalidation.
+   * @return Pointer to the active Pass backend (RealPass when "use pass" is
+   * enabled, otherwise ImitatePass).
+   */
+  static auto getPass() -> Pass *;
+  /**
+   * @brief Get the lazily-constructed RealPass backend.
+   * @return Pointer to the RealPass instance.
+   */
+  static auto getRealPass() -> RealPass *;
+  /**
+   * @brief Get the lazily-constructed ImitatePass backend.
+   * @return Pointer to the ImitatePass instance.
+   */
+  static auto getImitatePass() -> ImitatePass *;
+  /**
+   * @brief Forget the currently active backend.
+   *
+   * The next getPass() call re-selects and re-initialises a backend. Call
+   * after changing the "use pass" setting so the switch takes effect.
+   */
+  static void invalidate();
+
+private:
+  static Pass *pass;
+  // Go via pointer to avoid dynamic initialization, due to "random"
+  // initialization order relative to other globals, especially around QObject
+  // metadata dynamic initialization can lead to crashes depending on compiler,
+  // linker etc.
+  static QScopedPointer<RealPass> realPass;
+  static QScopedPointer<ImitatePass> imitatePass;
+
+  PassBackendFactory() = default;
+};
+
+#endif // SRC_PASSBACKENDFACTORY_H_

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -13,6 +13,7 @@
 
 #include "qtpasssettings.h"
 #include "pass.h"
+#include "passbackendfactory.h"
 
 #include "util.h"
 
@@ -24,14 +25,6 @@
 #include <utility>
 
 bool QtPassSettings::initialized = false;
-
-Pass *QtPassSettings::pass;
-// Go via pointer to avoid dynamic initialization,
-// due to "random" initialization order relative to other
-// globals, especially around QObject metadata dynamic initialization
-// can lead to crashes depending on compiler, linker etc.
-QScopedPointer<RealPass> QtPassSettings::realPass;
-QScopedPointer<ImitatePass> QtPassSettings::imitatePass;
 
 QtPassSettings *QtPassSettings::m_instance = nullptr;
 /**
@@ -180,17 +173,7 @@ void QtPassSettings::setProfiles(
 }
 
 auto QtPassSettings::getPass() -> Pass * {
-  if (!pass) {
-    if (isUsePass()) {
-      pass = getRealPass();
-    } else {
-      pass = getImitatePass();
-    }
-    if (pass) {
-      pass->init();
-    }
-  }
-  return pass;
+  return PassBackendFactory::getPass();
 }
 
 auto QtPassSettings::getVersion(const QString &defaultValue) -> QString {
@@ -307,7 +290,8 @@ auto QtPassSettings::isUsePass(const bool &defaultValue) -> bool {
 }
 void QtPassSettings::setUsePass(const bool &usePass) {
   getInstance()->setValue(SettingsConstants::usePass, usePass);
-  pass = nullptr;
+  // Backend selection changed: force re-selection on next getPass().
+  PassBackendFactory::invalidate();
 }
 
 auto QtPassSettings::getClipBoardTypeRaw(
@@ -906,14 +890,8 @@ void QtPassSettings::setShowProcessOutput(const bool &showProcessOutput) {
 }
 
 auto QtPassSettings::getRealPass() -> RealPass * {
-  if (realPass.isNull()) {
-    realPass.reset(new RealPass());
-  }
-  return realPass.data();
+  return PassBackendFactory::getRealPass();
 }
 auto QtPassSettings::getImitatePass() -> ImitatePass * {
-  if (imitatePass.isNull()) {
-    imitatePass.reset(new ImitatePass());
-  }
-  return imitatePass.data();
+  return PassBackendFactory::getImitatePass();
 }

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -12,7 +12,6 @@
 #include <QByteArray>
 #include <QHash>
 #include <QPoint>
-#include <QScopedPointer>
 #include <QSettings>
 #include <QSize>
 #include <QVariant>
@@ -49,10 +48,6 @@ private:
 
   static bool initialized;
   static QtPassSettings *m_instance;
-
-  static Pass *pass;
-  static QScopedPointer<RealPass> realPass;
-  static QScopedPointer<ImitatePass> imitatePass;
 
 public:
   /**

--- a/src/src.pro
+++ b/src/src.pro
@@ -95,6 +95,7 @@ SOURCES   += mainwindow.cpp \
              qtpasssettings.cpp \
              settingsconstants.cpp \
              settingsserializer.cpp \
+             passbackendfactory.cpp \
              pass.cpp \
              gpgkeystate.cpp \
              realpass.cpp \
@@ -128,6 +129,7 @@ HEADERS   += mainwindow.h \
              enums.h \
              settingsconstants.h \
              settingsserializer.h \
+             passbackendfactory.h \
              pass.h \
              gpgkeystate.h \
              realpass.h \


### PR DESCRIPTION
## Summary

#1513 item 4. `QtPassSettings` doubled as the password-store backend dispatcher — it held the static `Pass`/`RealPass`/`ImitatePass` instances, `getPass()`/`getRealPass()`/`getImitatePass()`, and the `setUsePass()` side-effect that reset the cached backend. That's backend lifecycle, not settings storage.

This moves all of it into a dedicated **`PassBackendFactory`** (`src/passbackendfactory.{h,cpp}`):
- owns the three static instances + lazy construction,
- `getPass()` selects RealPass/ImitatePass from `QtPassSettings::isUsePass()` and initialises it once,
- `invalidate()` drops the active backend so the next `getPass()` re-selects.

`QtPassSettings::getPass()`/`getRealPass()`/`getImitatePass()` are now thin forwarders (so the ~40 call sites are unchanged), and `setUsePass()` calls `PassBackendFactory::invalidate()` instead of poking a private pointer.

## Why this shape
Keeping the forwarders makes this a low-risk, self-contained extraction — no mass call-site rename. It also removes the implicit backend-reset coupling that the AppSettings migration (#1511 stage 2) had to work around: the comment there pointed here.

## Verification
- `qmake6 -r && make -j2` clean
- `make check` all suites green
- doxygen clean, `reuse lint` compliant, clang-format applied

No behavioural change. Completes the four-part #1513; a later pass can migrate callers off the forwarders and retire them. #1513 can close once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved password backend lifecycle management to ensure proper initialization and switching between different backend modes. The system now uses centralized backend instance management with lazy initialization and caching, providing more reliable backend selection when toggling between operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->