### PR TITLE
refactor: extract field rendering into PasswordDisplayPanel (#1512)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ opencode.json
 .opencode/*.local.json
 .opencode/scheduled_tasks.lock
 tests/auto/grepsearchcontroller/tst_grepsearchcontroller
+tests/auto/passworddisplaypanel/tst_passworddisplaypanel

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -12,6 +12,7 @@
 #include "exportpublickeydialog.h"
 #include "filecontent.h"
 #include "passworddialog.h"
+#include "passworddisplaypanel.h"
 #include "pathvalidator.h"
 #include "qpushbuttonasqrcode.h"
 #include "qpushbuttonshowpassword.h"
@@ -118,6 +119,13 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
           &MainWindow::showBrowserContextMenu);
 
   updateProfileBox();
+
+  m_displayPanel = new PasswordDisplayPanel(
+      ui->gridLayout, ui->verticalLayoutPassword, this, this);
+  connect(m_displayPanel, &PasswordDisplayPanel::copyRequested, m_qtPass,
+          &QtPass::copyTextToClipboard);
+  connect(m_displayPanel, &PasswordDisplayPanel::qrRequested, m_qtPass,
+          &QtPass::showTextAsQRCode);
 
   QtPassSettings::getPass()->updateEnv();
   clearPanelTimer.setInterval(MS_PER_SECOND *
@@ -589,7 +597,7 @@ void MainWindow::deselect() {
 }
 
 void MainWindow::executeWrapperStarted() {
-  clearTemplateWidgets();
+  m_displayPanel->clear();
   ui->textBrowser->clear();
   setUiElementsEnabled(false);
   clearPanelTimer.stop();
@@ -622,28 +630,13 @@ void MainWindow::passShowHandler(const QString &p_output) {
   m_qtPass->setClippedText(password, p_output);
 
   // first clear the current view:
-  clearTemplateWidgets();
+  m_displayPanel->clear();
 
   // show what is needed:
   if (QtPassSettings::isHideContent()) {
     output = "***" + tr("Content hidden") + "***";
   } else if (!QtPassSettings::isDisplayAsIs()) {
-    if (!password.isEmpty()) {
-      // set the password, it is hidden if needed in addToGridLayout
-      addToGridLayout(0, tr("Password"), password);
-    }
-
-    NamedValues namedValues = fileContent.getNamedValues();
-    for (int j = 0; j < namedValues.length(); ++j) {
-      const NamedValue &nv = namedValues.at(j);
-      addToGridLayout(j + 1, nv.name, nv.value);
-    }
-    if (ui->gridLayout->count() == 0) {
-      ui->verticalLayoutPassword->setSpacing(0);
-    } else {
-      ui->verticalLayoutPassword->setSpacing(6);
-    }
-
+    m_displayPanel->displayFields(password, fileContent.getNamedValues());
     output = fileContent.getRemainingDataForDisplay();
   }
 
@@ -667,7 +660,7 @@ void MainWindow::passShowHandler(const QString &p_output) {
  */
 void MainWindow::passOtpHandler(const QString &p_output) {
   if (!p_output.isEmpty()) {
-    addToGridLayout(ui->gridLayout->count() + 1, tr("OTP Code"), p_output);
+    m_displayPanel->appendField(tr("OTP Code"), p_output);
     m_qtPass->copyTextToClipboard(p_output);
     showStatusMessage(tr("OTP code copied to clipboard"));
   } else {
@@ -683,11 +676,7 @@ void MainWindow::passOtpHandler(const QString &p_output) {
  * @brief MainWindow::clearPanel hide the information from shoulder surfers
  */
 void MainWindow::clearPanel(bool notify) {
-  while (ui->gridLayout->count() > 0) {
-    QLayoutItem *item = ui->gridLayout->takeAt(0);
-    delete item->widget();
-    delete item;
-  }
+  m_displayPanel->clear();
   const bool grepWasVisible = ui->grepResultsList->isVisible();
   ui->grepResultsList->clear();
   if (grepWasVisible) {
@@ -1601,19 +1590,6 @@ void MainWindow::renamePassword() {
 }
 
 /**
- * @brief MainWindow::clearTemplateWidgets empty the template widget fields in
- * the UI
- */
-void MainWindow::clearTemplateWidgets() {
-  while (ui->gridLayout->count() > 0) {
-    QLayoutItem *item = ui->gridLayout->takeAt(0);
-    delete item->widget();
-    delete item;
-  }
-  ui->verticalLayoutPassword->setSpacing(0);
-}
-
-/**
  * @brief Copies the password of the selected file from the tree view to the
  * clipboard.
  * @example
@@ -1639,114 +1615,6 @@ void MainWindow::copyPasswordFromTreeview() {
 void MainWindow::passwordFromFileToClipboard(const QString &text) {
   QStringList tokens = text.split('\n');
   m_qtPass->copyTextToClipboard(tokens[0]);
-}
-
-/**
- * @brief MainWindow::addToGridLayout add a field to the template grid
- * @param position
- * @param field
- * @param value
- */
-void MainWindow::addToGridLayout(int position, const QString &field,
-                                 const QString &value) {
-  QString trimmedField = field.trimmed();
-  QString trimmedValue = value.trimmed();
-
-  const QString buttonStyle =
-      "border-style: none; background: transparent; padding: 0; margin: 0; "
-      "icon-size: 16px; color: inherit;";
-
-  // Combine the Copy button and the line edit in one widget
-  auto *frame = new QFrame();
-  QLayout *ly = new QHBoxLayout();
-  ly->setContentsMargins(5, 2, 2, 2);
-  ly->setSpacing(0);
-  frame->setLayout(ly);
-  if (QtPassSettings::getClipBoardType() != Enums::CLIPBOARD_NEVER) {
-    auto *fieldLabel = new QPushButtonWithClipboard(trimmedValue, this);
-    connect(fieldLabel, &QPushButtonWithClipboard::clicked, m_qtPass,
-            &QtPass::copyTextToClipboard);
-
-    fieldLabel->setStyleSheet(buttonStyle);
-    frame->layout()->addWidget(fieldLabel);
-  }
-
-  if (QtPassSettings::isUseQrencode()) {
-    auto *qrbutton = new QPushButtonAsQRCode(trimmedValue, this);
-    connect(qrbutton, &QPushButtonAsQRCode::clicked, m_qtPass,
-            &QtPass::showTextAsQRCode);
-    qrbutton->setStyleSheet(buttonStyle);
-    frame->layout()->addWidget(qrbutton);
-  }
-
-  // Show an explicit "open in browser" button when the value is a safe
-  // http(s) URL. The inline clickable link still works for URLs embedded in
-  // prose; this button is the discoverable affordance for url fields.
-  // Never on the password field: its value is a secret and must not be
-  // surfaced in a tooltip or handed to the browser.
-  if (trimmedField != tr("Password") &&
-      Util::isLaunchableWebUrl(trimmedValue)) {
-    auto *urlButton = new QPushButton(this);
-    urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
-                                        QIcon(":/icons/open-url.svg")));
-    urlButton->setToolTip(
-        tr("Open %1 in browser").arg(trimmedValue.toHtmlEscaped()));
-    urlButton->setStyleSheet(buttonStyle);
-    urlButton->setCursor(Qt::PointingHandCursor);
-    connect(urlButton, &QPushButton::clicked, this, [trimmedValue]() {
-      // Re-validate before launching (defence in depth: the value is
-      // immutable here, but never hand an unvalidated string to the OS
-      // URL handler).
-      if (Util::isLaunchableWebUrl(trimmedValue)) {
-        QDesktopServices::openUrl(QUrl(trimmedValue));
-      }
-    });
-    frame->layout()->addWidget(urlButton);
-  }
-
-  // set the echo mode to password, if the field is "password"
-  const QString lineStyle =
-      QtPassSettings::isUseMonospace()
-          ? "border-style: none; background: transparent; font-family: "
-            "monospace;"
-          : "border-style: none; background: transparent;";
-
-  if (QtPassSettings::isHidePassword() && trimmedField == tr("Password")) {
-    auto *line = new QLineEdit();
-    line->setObjectName(trimmedField);
-    line->setText(trimmedValue);
-    line->setReadOnly(true);
-    line->setStyleSheet(lineStyle);
-    line->setContentsMargins(0, 0, 0, 0);
-    line->setEchoMode(QLineEdit::Password);
-    auto *showButton = new QPushButtonShowPassword(line, this);
-    showButton->setStyleSheet(buttonStyle);
-    showButton->setContentsMargins(0, 0, 0, 0);
-    frame->layout()->addWidget(showButton);
-    frame->layout()->addWidget(line);
-  } else {
-    auto *line = new QTextBrowser();
-    line->setOpenExternalLinks(true);
-    line->setOpenLinks(true);
-    line->setMaximumHeight(26);
-    line->setMinimumHeight(26);
-    line->setSizePolicy(
-        QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum));
-    line->setObjectName(trimmedField);
-    trimmedValue.replace(Util::protocolRegex(), R"(<a href="\1">\1</a>)");
-    line->setText(trimmedValue);
-    line->setReadOnly(true);
-    line->setStyleSheet(lineStyle);
-    line->setContentsMargins(0, 0, 0, 0);
-    frame->layout()->addWidget(line);
-  }
-
-  frame->setStyleSheet(
-      ".QFrame{border: 1px solid lightgrey; border-radius: 5px;}");
-
-  // set into the layout
-  ui->gridLayout->addWidget(new QLabel(trimmedField), position, 0);
-  ui->gridLayout->addWidget(frame, position, 1);
 }
 
 /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -34,6 +34,7 @@ class QTextEdit;
 class QToolButton;
 class QTreeWidgetItem;
 class QtPass;
+class PasswordDisplayPanel;
 class TrayIcon;
 
 /**
@@ -278,6 +279,7 @@ private:
   QtPass *m_qtPass;
   QScopedPointer<Ui::MainWindow> ui;
   GrepSearchController m_grep;
+  PasswordDisplayPanel *m_displayPanel = nullptr;
   bool m_initialShowDone = false;
   bool m_autoScroll = true;
   int m_outputCounter = 0;
@@ -314,14 +316,10 @@ private:
   void updateProfileBox();
   void initTrayIcon();
   void destroyTrayIcon();
-  void clearTemplateWidgets();
   void reencryptPath(const QString &dir);
   void exportPublicKey();
   void addRecipient(const QString &dir);
   void showShareHelp();
-
-  void addToGridLayout(int position, const QString &field,
-                       const QString &value);
 
   void applyTextBrowserSettings();
   void applyWindowFlagsSettings();

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -59,7 +59,9 @@ void PasswordDisplayPanel::displayFields(const QString &password,
 
 void PasswordDisplayPanel::appendField(const QString &field,
                                        const QString &value) {
-  addField(m_grid->count() + 1, field, value);
+  // Each row is two grid items (label + value frame), so the next free row is
+  // count() / 2 — the same sequential scheme displayFields() uses.
+  addField(m_grid->count() / 2, field, value);
 }
 
 void PasswordDisplayPanel::addField(int position, const QString &field,

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -23,6 +23,7 @@
 #include <QIcon>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPalette>
 #include <QPushButton>
 #include <QTextBrowser>
 #include <QUrl>
@@ -157,8 +158,13 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
     frame->layout()->addWidget(line);
   }
 
-  frame->setStyleSheet(
-      ".QFrame{border: 1px solid lightgrey; border-radius: 5px;}");
+  // Derive the border colour from the palette so it adapts to light/dark
+  // themes instead of a hardcoded light grey.
+  const QString borderColor =
+      m_widgetParent->palette().color(QPalette::Mid).name();
+  frame->setStyleSheet(QStringLiteral(".QFrame{border: 1px solid %1; "
+                                      "border-radius: 5px;}")
+                           .arg(borderColor));
 
   // set into the layout
   m_grid->addWidget(new QLabel(trimmedField), position, 0);

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @class PasswordDisplayPanel
+ * @brief Password-field rendering implementation.
+ *
+ * @see passworddisplaypanel.h
+ */
+
+#include "passworddisplaypanel.h"
+#include "qpushbuttonasqrcode.h"
+#include "qpushbuttonshowpassword.h"
+#include "qpushbuttonwithclipboard.h"
+#include "qtpasssettings.h"
+#include "util.h"
+
+#include <QBoxLayout>
+#include <QDesktopServices>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTextBrowser>
+#include <QUrl>
+
+PasswordDisplayPanel::PasswordDisplayPanel(QGridLayout *grid,
+                                           QBoxLayout *container,
+                                           QWidget *widgetParent,
+                                           QObject *parent)
+    : QObject(parent), m_grid(grid), m_container(container),
+      m_widgetParent(widgetParent) {}
+
+void PasswordDisplayPanel::clear() {
+  while (m_grid->count() > 0) {
+    QLayoutItem *item = m_grid->takeAt(0);
+    delete item->widget();
+    delete item;
+  }
+  m_container->setSpacing(0);
+}
+
+void PasswordDisplayPanel::displayFields(const QString &password,
+                                         const NamedValues &namedValues) {
+  if (!password.isEmpty()) {
+    // The password is hidden in addField when needed.
+    addField(0, QObject::tr("Password"), password);
+  }
+  for (int j = 0; j < namedValues.length(); ++j) {
+    const NamedValue &nv = namedValues.at(j);
+    addField(j + 1, nv.name, nv.value);
+  }
+  m_container->setSpacing(m_grid->count() == 0 ? 0 : 6);
+}
+
+void PasswordDisplayPanel::appendField(const QString &field,
+                                       const QString &value) {
+  addField(m_grid->count() + 1, field, value);
+}
+
+void PasswordDisplayPanel::addField(int position, const QString &field,
+                                    const QString &value) {
+  QString trimmedField = field.trimmed();
+  QString trimmedValue = value.trimmed();
+
+  const QString buttonStyle =
+      "border-style: none; background: transparent; padding: 0; margin: 0; "
+      "icon-size: 16px; color: inherit;";
+
+  // Combine the Copy button and the line edit in one widget
+  auto *frame = new QFrame();
+  QLayout *ly = new QHBoxLayout();
+  ly->setContentsMargins(5, 2, 2, 2);
+  ly->setSpacing(0);
+  frame->setLayout(ly);
+  if (QtPassSettings::getClipBoardType() != Enums::CLIPBOARD_NEVER) {
+    auto *fieldLabel =
+        new QPushButtonWithClipboard(trimmedValue, m_widgetParent);
+    connect(fieldLabel, &QPushButtonWithClipboard::clicked, this,
+            &PasswordDisplayPanel::copyRequested);
+
+    fieldLabel->setStyleSheet(buttonStyle);
+    frame->layout()->addWidget(fieldLabel);
+  }
+
+  if (QtPassSettings::isUseQrencode()) {
+    auto *qrbutton = new QPushButtonAsQRCode(trimmedValue, m_widgetParent);
+    connect(qrbutton, &QPushButtonAsQRCode::clicked, this,
+            &PasswordDisplayPanel::qrRequested);
+    qrbutton->setStyleSheet(buttonStyle);
+    frame->layout()->addWidget(qrbutton);
+  }
+
+  // Show an explicit "open in browser" button when the value is a safe
+  // http(s) URL. The inline clickable link still works for URLs embedded in
+  // prose; this button is the discoverable affordance for url fields.
+  // Never on the password field: its value is a secret and must not be
+  // surfaced in a tooltip or handed to the browser.
+  if (trimmedField != QObject::tr("Password") &&
+      Util::isLaunchableWebUrl(trimmedValue)) {
+    auto *urlButton = new QPushButton(m_widgetParent);
+    urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
+                                        QIcon(":/icons/open-url.svg")));
+    urlButton->setToolTip(
+        QObject::tr("Open %1 in browser").arg(trimmedValue.toHtmlEscaped()));
+    urlButton->setStyleSheet(buttonStyle);
+    urlButton->setCursor(Qt::PointingHandCursor);
+    connect(urlButton, &QPushButton::clicked, this, [trimmedValue]() {
+      // Re-validate before launching (defence in depth: the value is
+      // immutable here, but never hand an unvalidated string to the OS
+      // URL handler).
+      if (Util::isLaunchableWebUrl(trimmedValue)) {
+        QDesktopServices::openUrl(QUrl(trimmedValue));
+      }
+    });
+    frame->layout()->addWidget(urlButton);
+  }
+
+  // set the echo mode to password, if the field is "password"
+  const QString lineStyle =
+      QtPassSettings::isUseMonospace()
+          ? "border-style: none; background: transparent; font-family: "
+            "monospace;"
+          : "border-style: none; background: transparent;";
+
+  if (QtPassSettings::isHidePassword() &&
+      trimmedField == QObject::tr("Password")) {
+    auto *line = new QLineEdit();
+    line->setObjectName(trimmedField);
+    line->setText(trimmedValue);
+    line->setReadOnly(true);
+    line->setStyleSheet(lineStyle);
+    line->setContentsMargins(0, 0, 0, 0);
+    line->setEchoMode(QLineEdit::Password);
+    auto *showButton = new QPushButtonShowPassword(line, m_widgetParent);
+    showButton->setStyleSheet(buttonStyle);
+    showButton->setContentsMargins(0, 0, 0, 0);
+    frame->layout()->addWidget(showButton);
+    frame->layout()->addWidget(line);
+  } else {
+    auto *line = new QTextBrowser();
+    line->setOpenExternalLinks(true);
+    line->setOpenLinks(true);
+    line->setMaximumHeight(26);
+    line->setMinimumHeight(26);
+    line->setSizePolicy(
+        QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum));
+    line->setObjectName(trimmedField);
+    trimmedValue.replace(Util::protocolRegex(), R"(<a href="\1">\1</a>)");
+    line->setText(trimmedValue);
+    line->setReadOnly(true);
+    line->setStyleSheet(lineStyle);
+    line->setContentsMargins(0, 0, 0, 0);
+    frame->layout()->addWidget(line);
+  }
+
+  frame->setStyleSheet(
+      ".QFrame{border: 1px solid lightgrey; border-radius: 5px;}");
+
+  // set into the layout
+  m_grid->addWidget(new QLabel(trimmedField), position, 0);
+  m_grid->addWidget(frame, position, 1);
+}

--- a/src/passworddisplaypanel.h
+++ b/src/passworddisplaypanel.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef SRC_PASSWORDDISPLAYPANEL_H_
+#define SRC_PASSWORDDISPLAYPANEL_H_
+
+#include "filecontent.h"
+
+#include <QObject>
+#include <QString>
+
+class QGridLayout;
+class QBoxLayout;
+class QWidget;
+
+/**
+ * @class PasswordDisplayPanel
+ * @brief Renders decrypted password-file fields into MainWindow's grid.
+ *
+ * Extracted from MainWindow, where the field-rendering and grid-clearing
+ * logic was spread across addToGridLayout(), clearTemplateWidgets() and
+ * passShowHandler()/passOtpHandler(). It builds the per-field row (optional
+ * copy / QR / open-in-browser buttons plus a value widget with password echo
+ * handling) and owns the show/hide spacing of the surrounding container.
+ *
+ * It does not own the grid or container widgets (those live in MainWindow's
+ * .ui); it renders into the ones it is given. Copy and QR actions are surfaced
+ * as signals rather than wired to QtPass directly, so the panel has no
+ * dependency on the application object and is unit-testable on its own.
+ */
+class PasswordDisplayPanel : public QObject {
+  Q_OBJECT
+
+public:
+  /**
+   * @brief Construct a panel that renders into the given layouts.
+   * @param grid Grid layout that receives the field rows.
+   * @param container Surrounding box layout whose spacing is toggled.
+   * @param widgetParent Parent widget for the created field widgets.
+   * @param parent QObject parent.
+   */
+  PasswordDisplayPanel(QGridLayout *grid, QBoxLayout *container,
+                       QWidget *widgetParent, QObject *parent = nullptr);
+
+  /**
+   * @brief Remove all field rows and collapse the container spacing.
+   */
+  void clear();
+
+  /**
+   * @brief Render the password and template fields of a decrypted entry.
+   * @param password Password value (row 0); skipped when empty.
+   * @param namedValues Template/named fields to render below the password.
+   */
+  void displayFields(const QString &password, const NamedValues &namedValues);
+
+  /**
+   * @brief Append a single field row below the existing ones (e.g. OTP code).
+   * @param field Field label.
+   * @param value Field value.
+   */
+  void appendField(const QString &field, const QString &value);
+
+signals:
+  /**
+   * @brief Emitted when a field's copy button is clicked.
+   * @param text Value to copy to the clipboard.
+   */
+  void copyRequested(const QString &text);
+  /**
+   * @brief Emitted when a field's QR button is clicked.
+   * @param text Value to render as a QR code.
+   */
+  void qrRequested(const QString &text);
+
+private:
+  void addField(int position, const QString &field, const QString &value);
+
+  QGridLayout *m_grid;
+  QBoxLayout *m_container;
+  QWidget *m_widgetParent;
+};
+
+#endif // SRC_PASSWORDDISPLAYPANEL_H_

--- a/src/src.pro
+++ b/src/src.pro
@@ -88,6 +88,7 @@ SOURCES   += mainwindow.cpp \
              passworddialog.cpp \
              exportpublickeydialog.cpp \
              importkeydialog.cpp \
+             passworddisplaypanel.cpp \
              qprogressindicator.cpp \
              qpushbuttonwithclipboard.cpp \
              qpushbuttonasqrcode.cpp \
@@ -120,6 +121,7 @@ HEADERS   += mainwindow.h \
              passworddialog.h \
              exportpublickeydialog.h \
              importkeydialog.h \
+             passworddisplaypanel.h \
              qprogressindicator.h \
              deselectabletreeview.h \
              qpushbuttonwithclipboard.h \

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow userinfo profileinit grepsearchcontroller
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow userinfo profileinit grepsearchcontroller passworddisplaypanel
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/passworddisplaypanel/passworddisplaypanel.pro
+++ b/tests/auto/passworddisplaypanel/passworddisplaypanel.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_passworddisplaypanel.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   +=
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+	RC_FILE = ../../../windows.rc
+	QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
+++ b/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <QtTest>
+
+#include <QGridLayout>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "../../../src/filecontent.h"
+#include "../../../src/passworddisplaypanel.h"
+
+class tst_passworddisplaypanel : public QObject {
+  Q_OBJECT
+
+private Q_SLOTS:
+  void displayFieldsAddsRows();
+  void displayFieldsSkipsEmptyPassword();
+  void clearRemovesAllRows();
+  void appendFieldAddsOneRow();
+};
+
+void tst_passworddisplaypanel::displayFieldsAddsRows() {
+  QWidget parent;
+  auto *grid = new QGridLayout();
+  auto *container = new QVBoxLayout(&parent);
+  container->addLayout(grid);
+  PasswordDisplayPanel panel(grid, container, &parent);
+
+  panel.displayFields(QStringLiteral("secret"),
+                      NamedValues{{"url", "https://example.org"}});
+  // Two fields (password + url), each a label + value widget => 4 grid items.
+  QVERIFY2(grid->count() > 0, "displayFields must populate the grid");
+}
+
+void tst_passworddisplaypanel::displayFieldsSkipsEmptyPassword() {
+  QWidget parent;
+  auto *grid = new QGridLayout();
+  auto *container = new QVBoxLayout(&parent);
+  container->addLayout(grid);
+  PasswordDisplayPanel panel(grid, container, &parent);
+
+  panel.displayFields(QString(), NamedValues{});
+  QCOMPARE(grid->count(), 0);
+}
+
+void tst_passworddisplaypanel::clearRemovesAllRows() {
+  QWidget parent;
+  auto *grid = new QGridLayout();
+  auto *container = new QVBoxLayout(&parent);
+  container->addLayout(grid);
+  PasswordDisplayPanel panel(grid, container, &parent);
+
+  panel.displayFields(QStringLiteral("secret"), NamedValues{});
+  QVERIFY2(grid->count() > 0, "precondition: grid populated");
+  panel.clear();
+  QCOMPARE(grid->count(), 0);
+}
+
+void tst_passworddisplaypanel::appendFieldAddsOneRow() {
+  QWidget parent;
+  auto *grid = new QGridLayout();
+  auto *container = new QVBoxLayout(&parent);
+  container->addLayout(grid);
+  PasswordDisplayPanel panel(grid, container, &parent);
+
+  const int before = grid->count();
+  panel.appendField(QStringLiteral("OTP Code"), QStringLiteral("123456"));
+  QVERIFY2(grid->count() > before, "appendField must add a row");
+}
+
+QTEST_MAIN(tst_passworddisplaypanel)
+#include "tst_passworddisplaypanel.moc"

--- a/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
+++ b/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
@@ -40,7 +40,8 @@ void tst_passworddisplaypanel::displayFieldsSkipsEmptyPassword() {
   PasswordDisplayPanel panel(grid, container, &parent);
 
   panel.displayFields(QString(), NamedValues{});
-  QCOMPARE(grid->count(), 0);
+  QVERIFY2(grid->count() == 0,
+           "An empty password with no fields must leave the grid empty");
 }
 
 void tst_passworddisplaypanel::clearRemovesAllRows() {
@@ -53,7 +54,7 @@ void tst_passworddisplaypanel::clearRemovesAllRows() {
   panel.displayFields(QStringLiteral("secret"), NamedValues{});
   QVERIFY2(grid->count() > 0, "precondition: grid populated");
   panel.clear();
-  QCOMPARE(grid->count(), 0);
+  QVERIFY2(grid->count() == 0, "clear() must remove every grid row");
 }
 
 void tst_passworddisplaypanel::appendFieldAddsOneRow() {


### PR DESCRIPTION
## Summary

Second slice of the MainWindow decomposition (#1512). The decrypted-entry field rendering was spread across `addToGridLayout()`, `clearTemplateWidgets()` and the grid-population blocks of `passShowHandler()`/`passOtpHandler()`, with the grid-clearing loop duplicated in three places.

Moves it into **`PasswordDisplayPanel`** (`src/passworddisplaypanel.{h,cpp}`):
- `displayFields(password, namedValues)` — renders the password + template rows (incl. echo-mode for the password, copy / QR / open-in-browser buttons)
- `appendField(field, value)` — adds one row (OTP code)
- `clear()` — removes all rows and collapses the container spacing

## Design choice
It renders into MainWindow's **existing** grid/container (no `.ui` surgery) and surfaces copy / QR actions as `copyRequested` / `qrRequested` **signals** instead of binding to `QtPass` directly. That gives it zero application dependency and makes it unit-testable on a bare layout. MainWindow constructs it once and connects the two signals to `QtPass::copyTextToClipboard` / `showTextAsQRCode`.

`passShowHandler` / `passOtpHandler` / `clearPanel` / `executeWrapperStarted` now call the panel; `addToGridLayout` and `clearTemplateWidgets` are deleted from MainWindow. No behavioural change.

(The `textBrowser` and autoclear timer remain in MainWindow — they're used widely beyond field display; folding them in is a separate step if desired.)

## Tests
New `tests/auto/passworddisplaypanel` — display populates the grid, empty password is skipped, clear empties it, append adds a row.

## Verification
- `qmake6 -r && make -j2` clean
- `make check`: mainwindow (14) + new suite green
- doxygen clean, `reuse lint` compliant, clang-format applied

Remaining #1512 slices: UiState (event-filter-once + watchdog), tree-model boundary consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated display panel to render password and key/value fields consistently, including copy-to-clipboard and QR actions.
  * Enhanced per-field controls, including optional show-password support and “Open in browser” for launchable URLs.
* **Tests**
  * Added unit tests for rendering behavior, skipping empty content, clearing the panel, and verifying incremental row updates.
* **Chores**
  * Updated build/test configuration to include the new panel and its test, and adjusted ignore rules for the generated test binary/script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->