### PR TITLE
fix: install event filter once and add UI watchdog (#1512)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -138,6 +138,19 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
 
   connect(&searchTimer, &QTimer::timeout, this, &MainWindow::onTimeoutSearch);
 
+  // Install the search-box key filter once, not on every setUiElementsEnabled
+  // call.
+  ui->lineEdit->installEventFilter(this);
+
+  // Safety net: if a backend operation disables the UI but never signals
+  // completion, re-enable after a timeout so the window can't get stuck.
+  m_uiWatchdog.setSingleShot(true);
+  m_uiWatchdog.setInterval(UiWatchdogMs);
+  connect(&m_uiWatchdog, &QTimer::timeout, this, [this]() {
+    showStatusMessage(tr("Operation timed out; re-enabling interface."));
+    setUiElementsEnabled(true);
+  });
+
   initToolBarButtons();
   initStatusBar();
   initProcessOutputPanel();
@@ -707,9 +720,14 @@ void MainWindow::clearPanel(bool notify) {
  * @param state
  */
 void MainWindow::setUiElementsEnabled(bool state) {
+  // Arm the watchdog while the UI is disabled; disarm once re-enabled.
+  if (state) {
+    m_uiWatchdog.stop();
+  } else {
+    m_uiWatchdog.start();
+  }
   ui->treeView->setEnabled(state);
   ui->lineEdit->setEnabled(state);
-  ui->lineEdit->installEventFilter(this);
   ui->actionAddPassword->setEnabled(state);
   ui->actionAddFolder->setEnabled(state);
   ui->actionUsers->setEnabled(state);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -298,6 +298,10 @@ private:
   StoreModel proxyModel;
   QScopedPointer<QItemSelectionModel> selectionModel;
   QTimer clearPanelTimer, searchTimer;
+  // Re-enables the UI if a backend operation disables it but never reports
+  // completion (see setUiElementsEnabled).
+  QTimer m_uiWatchdog;
+  static constexpr int UiWatchdogMs = 30000;
   QDialog *m_keygenDialog{};
   QString m_currentDir;
   TrayIcon *m_tray{};


### PR DESCRIPTION
## Summary

Third slice of the MainWindow decomposition (#1512) — the UiState concern. Per the issue's *"UiState (or kill it)"* option, this fixes the two real problems in the `setUiElementsEnabled` hammer instead of wrapping it in a new class (a class would add indirection over ~15 lines of widget toggles for no clear gain).

- **Event filter installed once.** `ui->lineEdit->installEventFilter(this)` was called on *every* `setUiElementsEnabled` invocation; moved it to the constructor.
- **UI watchdog.** A 30 s single-shot timer, armed by `setUiElementsEnabled(false)` and disarmed by `setUiElementsEnabled(true)`. If a backend operation disables the UI but never signals completion, the interface re-enables itself (with a status message) instead of staying stuck.

No behavioural change on the normal path (every real operation still re-enables the UI well within 30 s).

## Verification
- `make -j2` clean
- `make check`: mainwindow tests pass
- doxygen clean, `reuse lint` compliant, clang-format applied

Remaining #1512 slice: tree-model boundary consolidation (18 `proxyModel` mutations → StoreModel). After that MainWindow is down near the issue's ≤1400-line target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the user interface could become stuck in a disabled state; the application now automatically recovers after 30 seconds if this occurs.
  * Improved search bar initialization performance by optimizing how the interface state is managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->