### PR TITLE
ci: make Doxygen download resilient to doxygen.nl outages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,11 +80,33 @@ jobs:
       - name: Install Doxygen
         if: steps.need_docs.outputs.run_docs == 'true'
         run: |
-          # Install newer Doxygen from official release
-          curl -fsL https://doxygen.nl/files/doxygen-1.17.0.linux.bin.tar.gz -o doxygen.tar.gz
+          # Pinned Doxygen release. doxygen.nl has intermittent outages, so try
+          # the identical GitHub release asset (CDN-backed) first and fall back
+          # to doxygen.nl, retrying each source before giving up.
+          DOXYGEN_VERSION=1.17.0
+          tarball="doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
+          github_tag="Release_${DOXYGEN_VERSION//./_}"
+          urls=(
+            "https://github.com/doxygen/doxygen/releases/download/${github_tag}/${tarball}"
+            "https://doxygen.nl/files/${tarball}"
+          )
+          downloaded=0
+          for url in "${urls[@]}"; do
+            echo "Fetching Doxygen from ${url}"
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+                "${url}" -o doxygen.tar.gz; then
+              downloaded=1
+              break
+            fi
+            echo "::warning::Failed to download Doxygen from ${url}"
+          done
+          if [ "${downloaded}" -ne 1 ]; then
+            echo "::error::Could not download Doxygen ${DOXYGEN_VERSION}"
+            exit 1
+          fi
           tar -xzf doxygen.tar.gz
-          sudo cp -r doxygen-1.17.0/bin/* /usr/local/bin/
-          rm -rf doxygen.tar.gz doxygen-1.17.0
+          sudo cp -r "doxygen-${DOXYGEN_VERSION}/bin/"* /usr/local/bin/
+          rm -rf doxygen.tar.gz "doxygen-${DOXYGEN_VERSION}"
           # Install graphviz via apt
           sudo apt-get update && sudo apt-get install -y graphviz
 


### PR DESCRIPTION
## Why

The recurring red `docs` checks aren't our code — they're the **Install Doxygen** step. It fetched the pinned tarball solely from `doxygen.nl` with one `curl -fsL` and **no retry**, so any momentary HTTP hiccup there fails the whole job with `curl` exit 22. doxygen.nl has periodic outages; #1537 hit one (it returns 200 again now). #1535/#1536 passed simply because the download happened to work.

## Fix

- Try the **identical GitHub release asset** (`github.com/doxygen/doxygen/releases/.../doxygen-1.17.0.linux.bin.tar.gz`, CDN-backed) **first**, fall back to doxygen.nl.
- Retry each source: `curl --retry 3 --retry-delay 5 --retry-all-errors`.
- Fail only if **both** mirrors are unreachable.

Same pinned 1.17.0 binary, so WARN_AS_ERROR behaviour is unchanged — just sourced reliably.

## Verification
- `prettier --check` clean on the workflow.
- Bash is quoted/shellcheck-safe; version is parameterised (`DOXYGEN_VERSION`, `Release_${VERSION//./_}` tag).

(This is a workflow-only change, so the `need_docs` gate skips the docs run on this PR itself; the next code PR exercises the new step.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation build workflow reliability by pinning Doxygen to version 1.17.0 with multiple download sources and automatic fallback mechanisms. Improved error handling and added retry logic to ensure consistent documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->