### PR TITLE
refactor: add QtPassSettings::load/save AppSettings facade (#1511)

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -6,7 +6,6 @@
 #include "mainwindow.h"
 #include "profileinit.h"
 #include "qtpasssettings.h"
-#include "settingsserializer.h"
 #include "sshauthsock.h"
 #include "ui_configdialog.h"
 #include "usersdialog.h"
@@ -48,7 +47,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
     // Let window manager handle positioning for first launch
   }
 
-  applySettings(SettingsSerializer::load(*QtPassSettings::getInstance()));
+  applySettings(QtPassSettings::load());
 
   if (!QSystemTrayIcon::isSystemTrayAvailable()) {
     ui->checkBoxUseTrayIcon->setEnabled(false);
@@ -157,8 +156,7 @@ void ConfigDialog::applySettings(const AppSettings &settings) {
 auto ConfigDialog::readSettings() -> AppSettings {
   // Start from the persisted settings so keys this dialog does not own
   // (window geometry, WebDAV, profiles, etc.) survive the save.
-  AppSettings settings =
-      SettingsSerializer::load(*QtPassSettings::getInstance());
+  AppSettings settings = QtPassSettings::load();
 
   settings.passExecutable = ui->passPath->text();
   settings.gitExecutable = ui->gitPath->text();
@@ -336,13 +334,9 @@ void ConfigDialog::on_accepted() {
   const QHash<QString, QHash<QString, QString>> existingProfiles =
       QtPassSettings::getProfiles();
 
-  const AppSettings settings = readSettings();
-  SettingsSerializer::save(*QtPassSettings::getInstance(), settings);
-  // The serialiser writes the usePass key directly; re-apply it through the
-  // setter so the cached Pass backend is invalidated (pass = nullptr) and the
-  // correct backend is rebuilt on next use. (Backend lifecycle is tracked for
-  // extraction in #1513 item 4.)
-  QtPassSettings::setUsePass(settings.usePass);
+  // Persist via the facade, which also invalidates the cached Pass backend so
+  // a changed "use pass" mode takes effect.
+  QtPassSettings::save(readSettings());
 
   // Profiles are not part of AppSettings yet, so persist them separately.
   QtPassSettings::setProfiles(getProfiles());

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -14,6 +14,7 @@
 #include "qtpasssettings.h"
 #include "pass.h"
 #include "passbackendfactory.h"
+#include "settingsserializer.h"
 
 #include "util.h"
 
@@ -51,6 +52,18 @@ auto QtPassSettings::getInstance() -> QtPassSettings * {
   }
 
   return m_instance;
+}
+
+auto QtPassSettings::load() -> AppSettings {
+  return SettingsSerializer::load(*getInstance());
+}
+
+void QtPassSettings::save(const AppSettings &settings) {
+  SettingsSerializer::save(*getInstance(), settings);
+  // A settings save may have changed the "use pass" mode; drop the cached
+  // backend so the correct one is rebuilt on next use (matches the previous
+  // setUsePass() side effect).
+  PassBackendFactory::invalidate();
 }
 
 /**

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -3,6 +3,7 @@
 #ifndef SRC_QTPASSSETTINGS_H_
 #define SRC_QTPASSSETTINGS_H_
 
+#include "appsettings.h"
 #include "enums.h"
 #include "imitatepass.h"
 #include "passwordconfiguration.h"
@@ -55,6 +56,24 @@ public:
    * @return Pointer to the QtPassSettings instance.
    */
   static auto getInstance() -> QtPassSettings *;
+
+  /**
+   * @brief Load all flat settings into an AppSettings value object.
+   *
+   * Convenience facade over SettingsSerializer using the singleton store.
+   * Note: nested/keyed settings (profiles, per-dialog geometry) are not part
+   * of AppSettings and still use their dedicated accessors.
+   * @return Current settings.
+   */
+  static auto load() -> AppSettings;
+  /**
+   * @brief Persist an AppSettings value object to the singleton store.
+   *
+   * Writes via SettingsSerializer and invalidates the cached Pass backend so a
+   * changed "use pass" mode takes effect on the next getPass().
+   * @param settings Values to save.
+   */
+  static void save(const AppSettings &settings);
 
   // Window settings
   /**

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -53,6 +53,7 @@ private Q_SLOTS:
   void serializerLoadDefaults();
   void serializerRoundTrip();
   void serializerKeyCompatibility();
+  void facadeLoadReflectsSave();
 
 private:
   QString m_settingsBackupPath;
@@ -732,6 +733,20 @@ void tst_settings::serializerKeyCompatibility() {
   QCOMPARE(qs.value(SettingsConstants::passStore).toString(),
            QStringLiteral("/tmp/store"));
   QCOMPARE(qs.value(SettingsConstants::autoclearSeconds).toInt(), 13);
+}
+
+void tst_settings::facadeLoadReflectsSave() {
+  // QtPassSettings::save then ::load must round-trip through the singleton.
+  AppSettings out = QtPassSettings::load();
+  out.useMonospace = !out.useMonospace;
+  out.autoclearSeconds = 77;
+  out.passSigningKey = QStringLiteral("FACADEKEY");
+  QtPassSettings::save(out);
+
+  const AppSettings in = QtPassSettings::load();
+  QCOMPARE(in.useMonospace, out.useMonospace);
+  QCOMPARE(in.autoclearSeconds, 77);
+  QCOMPARE(in.passSigningKey, QStringLiteral("FACADEKEY"));
 }
 
 QTEST_MAIN(tst_settings)


### PR DESCRIPTION
## Summary

Stage 3 of #1511. Adds the single `load()`/`save()` pair the issue envisions as QtPassSettings' eventual public surface (replacing the 132 boilerplate getter/setters):

- `QtPassSettings::load() -> AppSettings` — via `SettingsSerializer` on the singleton store.
- `QtPassSettings::save(const AppSettings&)` — writes via `SettingsSerializer` **and** invalidates the cached Pass backend, folding in the old `setUsePass()` side effect.

Migrates **ConfigDialog** (the stage-2 consumer) onto the facade: `applySettings(QtPassSettings::load())` and `on_accepted → QtPassSettings::save(readSettings())`, dropping its direct `SettingsSerializer` dependency and the explicit `setUsePass()` backend-reset call.

## Why incremental (and not a 200-call-site swap)
Settings are **runtime-mutable** — ConfigDialog writes them and other readers must see the new values immediately. So callers can't cache an `AppSettings` globally; they read current values. `load()` gives a clean per-use snapshot without reaching for 132 individual getters. The remaining reader migration + wrapper deletion (stage 4) proceeds area-by-area on top of this facade, each verifiable on its own.

## Verification
- `make -j2` clean
- `make check`: settings (117, +1 facade round-trip) + configdialog (16) + full suite green
- doxygen clean, `reuse lint` compliant, clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal configuration management system to enhance code organization and reliability in how application settings are persisted and loaded.

* **Tests**
  * Expanded test coverage for settings save and load operations to validate configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->