### PR TITLE
docs: clarify getKeygenDialog returns a non-owning pointer

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -108,7 +108,12 @@ public:
 
   /**
    * @brief Return the active key generation dialog, if any.
-   * @return Pointer to the keygen QDialog, or nullptr.
+   *
+   * The returned pointer is non-owning: the dialog's lifetime is managed
+   * elsewhere (cleanKeygenDialog() closes and forgets it), so callers must
+   * observe it only and never delete it.
+   * @return Non-owning pointer to the keygen QDialog, or nullptr when none is
+   * active.
    */
   auto getKeygenDialog() -> QDialog * { return m_keygenDialog; }
 


### PR DESCRIPTION
## Summary

CodeRabbit flagged `MainWindow::getKeygenDialog()` ownership semantics. Documents that the returned pointer is **non-owning** — the dialog's lifetime is managed elsewhere (`cleanKeygenDialog()` closes and forgets it), so callers must only observe it, never delete.

## On the suggested rename
Kept the `getKeygenDialog()` name rather than renaming to `keygenDialog()`. The codebase consistently uses the `get` prefix (`getFile`, `getDir`, `getStore`, `getPassStore`, …); renaming just this one would be inconsistent, and a backward-compat alias would be pointless cruft since every caller is internal (`qtpass.cpp`, tests). Took the finding's "document ownership" option instead.

Doc-only change; doxygen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify API behavior and pointer ownership details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->