### PR TITLE
docs: refresh docs to reflect post-1.7.0 work

### DIFF
--- a/.opencode/skills/qtpass-docs/SKILL.md
+++ b/.opencode/skills/qtpass-docs/SKILL.md
@@ -131,6 +131,11 @@ doxygen Doxyfile
 ls docs/index.html
 ```
 
+CI pins **Doxygen 1.17.0** and treats warnings as errors; a local Doxygen of a
+different version may report differently. The `docs.yml` install step fetches
+the pinned binary from the GitHub release mirror first, then doxygen.nl, with
+retries (doxygen.nl outages previously caused spurious `docs` failures).
+
 ## Common Pitfalls
 
 ### Forgetting to Run Prettier

--- a/.opencode/skills/qtpass-linting/SKILL.md
+++ b/.opencode/skills/qtpass-linting/SKILL.md
@@ -147,6 +147,8 @@ act push -W .github/workflows/reuse.yml
 
 The CI enforces zero Doxygen warnings via `docs.yml`. `WARN_AS_ERROR = FAIL_ON_WARNINGS` in `Doxyfile` causes the step to fail on any undocumented public symbol.
 
+CI pins **Doxygen 1.17.0** (local Doxygen may be older and miss/add warnings). The `docs.yml` install step downloads that pinned binary from the GitHub release mirror first, falling back to doxygen.nl, with retries — doxygen.nl has intermittent outages that previously caused spurious `docs` failures (a red `docs` check is often a download blip, not your change; re-run before debugging).
+
 ### Run Doxygen Locally
 
 ```bash

--- a/.opencode/skills/qtpass-testing/SKILL.md
+++ b/.opencode/skills/qtpass-testing/SKILL.md
@@ -27,7 +27,13 @@ make -j4
 make lcov
 ```
 
-## Existing Test Suites (8 total)
+## Existing Test Suites
+
+> The suites below are representative, not exhaustive — `tests/auto/auto.pro`
+> `SUBDIRS` is the source of truth. Newer suites include `settings`,
+> `configdialog`, `mainwindow`, `importkeydialog`, `exportpublickeydialog`,
+> `keygendialog`, `trayicon`, `userinfo`, `profileinit`, `grepsearchcontroller`
+> and `passworddisplaypanel`.
 
 ### tests/auto/gpgkeystate/tst_gpgkeystate.cpp
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 - Import GPG keys from file or clipboard via the Users dialog [#1517](https://github.com/IJHack/QtPass/pull/1517)
 - Export your public key and add recipients from the Share submenu
-- Opt-in content search across decrypted entries (regex)
+- Opt-in content search across decrypted entries (regular expression)
 - Manual `SSH_AUTH_SOCK` override with `gpgconf` auto-probe fallback
 - Process output panel with command labels, colour-coded errors and auto-scroll [#252](https://github.com/IJHack/QtPass/issues/252), [#1172](https://github.com/IJHack/QtPass/pull/1172)
 
 ### Code Quality (umbrella [#1508](https://github.com/IJHack/QtPass/issues/1508))
 
 - Split the `Util` grab-bag into `PathValidator`, `SshAuthSock` and `TemplateIO`, and consolidated `StoreModel` drag-drop [#1514](https://github.com/IJHack/QtPass/issues/1514)
-- Tightened the `Pass` interface: `beforeExecute()` hook, `Move`/`Copy` dedup, documented Grep regex dialect, and `PassBackendFactory` [#1513](https://github.com/IJHack/QtPass/issues/1513)
+- Tightened the `Pass` interface: `beforeExecute()` hook, `Move`/`Copy` dedup, documented Grep regular-expression dialect, and `PassBackendFactory` [#1513](https://github.com/IJHack/QtPass/issues/1513)
 - Decomposed `MainWindow` into `GrepSearchController`, `PasswordDisplayPanel`, a UI watchdog, and `StoreModel::rootIndexFor` [#1512](https://github.com/IJHack/QtPass/issues/1512)
 - Introduced `AppSettings` + `SettingsSerializer` with a `QtPassSettings::load()`/`save()` facade [#1511](https://github.com/IJHack/QtPass/issues/1511)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased]
+
+### New Features
+
+- Import GPG keys from file or clipboard via the Users dialog [#1517](https://github.com/IJHack/QtPass/pull/1517)
+- Export your public key and add recipients from the Share submenu
+- Opt-in content search across decrypted entries (regex)
+- Manual `SSH_AUTH_SOCK` override with `gpgconf` auto-probe fallback
+- Process output panel with command labels, colour-coded errors and auto-scroll
+
+### Code Quality (umbrella [#1508](https://github.com/IJHack/QtPass/issues/1508))
+
+- Split the `Util` grab-bag into `PathValidator`, `SshAuthSock` and `TemplateIO`, and consolidated `StoreModel` drag-drop [#1514](https://github.com/IJHack/QtPass/issues/1514)
+- Tightened the `Pass` interface: `beforeExecute()` hook, `Move`/`Copy` dedup, documented Grep regex dialect, and `PassBackendFactory` [#1513](https://github.com/IJHack/QtPass/issues/1513)
+- Decomposed `MainWindow` into `GrepSearchController`, `PasswordDisplayPanel`, a UI watchdog, and `StoreModel::rootIndexFor` [#1512](https://github.com/IJHack/QtPass/issues/1512)
+- Introduced `AppSettings` + `SettingsSerializer` with a `QtPassSettings::load()`/`save()` facade [#1511](https://github.com/IJHack/QtPass/issues/1511)
+
+### Build / CI
+
+- Made the Doxygen download resilient to doxygen.nl outages (GitHub-release mirror + retries) [#1538](https://github.com/IJHack/QtPass/pull/1538)
+
 ## [1.7.0](https://github.com/IJHack/QtPass/tree/v1.7.0) (2026-04-20)
 
 - Qt 6.10 `beginFilterChange`/`endFilterChange` support [#1052](https://github.com/IJHack/QtPass/pull/1052)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Export your public key and add recipients from the Share submenu
 - Opt-in content search across decrypted entries (regex)
 - Manual `SSH_AUTH_SOCK` override with `gpgconf` auto-probe fallback
-- Process output panel with command labels, colour-coded errors and auto-scroll
+- Process output panel with command labels, colour-coded errors and auto-scroll [#252](https://github.com/IJHack/QtPass/issues/252), [#1172](https://github.com/IJHack/QtPass/pull/1172)
 
 ### Code Quality (umbrella [#1508](https://github.com/IJHack/QtPass/issues/1508))
 
@@ -20,6 +20,8 @@
 ### Build / CI
 
 - Made the Doxygen download resilient to doxygen.nl outages (GitHub-release mirror + retries) [#1538](https://github.com/IJHack/QtPass/pull/1538)
+
+[Full Changelog](https://github.com/IJHack/QtPass/compare/v1.7.0...HEAD)
 
 ## [1.7.0](https://github.com/IJHack/QtPass/tree/v1.7.0) (2026-04-20)
 
@@ -48,7 +50,7 @@
 - Use ed25519 for GPG key generation when available [#790](https://github.com/IJHack/QtPass/pull/790)
 - Improved GPG key parsing with new `gpgkeystate` module
 
-### New Features
+### New Features <!-- markdownlint-disable-line MD024 -->
 
 - Added auto-detect Git in existing password-store
 - Use ed25519 (ECC) for GPG key generation when GPG supports it
@@ -100,12 +102,6 @@
 - CI/CD workflow optimizations
 
 [Full Changelog](https://github.com/IJHack/QtPass/compare/v1.5.1...v1.6.0)
-
-## [Unreleased](https://github.com/IJHack/QtPass/tree/HEAD)
-
-- Added process output panel in main window status bar [#252](https://github.com/IJHack/QtPass/issues/252), [#1172](https://github.com/IJHack/QtPass/pull/1172)
-
-[Full Changelog](https://github.com/IJHack/QtPass/compare/v1.7.0...HEAD)
 
 ## [1.5.1](https://github.com/IJHack/QtPass/tree/v1.5.1) (2026-03-22)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,13 @@ Both inherit from `Pass` (`src/pass.h`), an abstract base exposing the password 
 **Core classes:**
 
 - `MainWindow` — central UI orchestrator; owns the `Pass` instance and `StoreModel`
-- `Pass` / `RealPass` / `ImitatePass` — password store operations (add, edit, delete, copy, show, Git)
+- `Pass` / `RealPass` / `ImitatePass` — password store operations (add, edit, delete, copy, show, Git); `PassBackendFactory` (`src/passbackendfactory.h`) owns backend selection/lifecycle
 - `Executor` (`src/executor.h`) — FIFO queue for external process execution; all `gpg`/`git`/`pass` calls go through here
-- `StoreModel` (`src/storemodel.h`) — `QSortFilterProxyModel` wrapping `QFileSystemModel` for the password tree
-- `QtPassSettings` (`src/qtpasssettings.h`) — singleton managing all app configuration via `QSettings`
+- `StoreModel` (`src/storemodel.h`) — `QSortFilterProxyModel` wrapping `QFileSystemModel` for the password tree; `rootIndexFor()` maps a directory to the tree root
+- `QtPassSettings` (`src/qtpasssettings.h`) — singleton managing all app configuration via `QSettings`; `AppSettings` (`src/appsettings.h`) + `SettingsSerializer` (`src/settingsserializer.h`) are the value-object/load-save facade
 - `FileContent` (`src/filecontent.h`) — parses password files; supports template fields beyond the first line
-- `Util` (`src/util.h`) — static helpers for path normalization and binary discovery
+- `Util` (`src/util.h`) — static path/binary-discovery helpers, now narrowed: `PathValidator` (store-boundary checks), `SshAuthSock` (SSH_AUTH_SOCK discovery), and `TemplateIO` (`.templates`/`.default_template` I/O) are split out
+- `MainWindow` helpers: `GrepSearchController` (`src/grepsearchcontroller.h`) owns content-search state; `PasswordDisplayPanel` (`src/passworddisplaypanel.h`) renders decrypted fields into the grid
 
 **Signal/slot flow:** `MainWindow` calls `Pass` methods → `Pass` queues commands via `Executor` → `Executor` emits signals with stdout/stderr → `Pass` processes output and emits higher-level signals → `MainWindow` updates the UI.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ _Available in over 60 languages_
 - Multiple profiles support
 - OTP (One-Time Password) support
 - Password generation with configurable complexity
-- Content search across decrypted entries (regex; opt-in)
+- Content search across decrypted entries (regular expression; opt-in)
 - Git integration for version control
 - Smartcard and USB token support (OpenPGP, YubiKey)
 - Configurable shoulder surfing protection

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Available in over 60 languages_
 - Multiple profiles support
 - OTP (One-Time Password) support
 - Password generation with configurable complexity
+- Content search across decrypted entries (regex; opt-in)
 - Git integration for version control
 - Smartcard and USB token support (OpenPGP, YubiKey)
 - Configurable shoulder surfing protection

--- a/qtpass.appdata.xml
+++ b/qtpass.appdata.xml
@@ -21,6 +21,12 @@
     <li>Per-folder user selection for multi recipient encryption</li>
     <li>Configuration options for backends and executable/folder locations</li>
     <li>Copying password to clipboard</li>
+    <li>Password generation with configurable complexity</li>
+    <li>OTP (one-time password) support</li>
+    <li>Smartcard and USB token support (OpenPGP, YubiKey)</li>
+    <li>Importing GPG keys from file or clipboard</li>
+    <li>Re-encrypting a folder, exporting your public key and adding recipients</li>
+    <li>Opt-in content search across decrypted entries</li>
     <li>Configurable shoulder surfing protection options</li>
     <li>Experimental WebDAV support</li>
    </ul>
@@ -43,4 +49,8 @@
       <image width="900" height="637">https://qtpass.org/images/config.png</image>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="1.7.0" date="2026-04-20"/>
+    <release version="1.6.0" date="2026-04-13"/>
+  </releases>
 </component>


### PR DESCRIPTION
## Summary

Docs had drifted behind the import-key feature and the #1508 code-quality refactor series. This catches them up (docs-only, no code).

- **README** — add the content-search (regex, opt-in) feature bullet (feature existed, was undocumented).
- **CLAUDE.md** — refresh the Core-classes list with the #1508 extractions: `PathValidator`, `SshAuthSock`, `TemplateIO`, `PassBackendFactory`, `AppSettings`/`SettingsSerializer`, `GrepSearchController`, `PasswordDisplayPanel`, `StoreModel::rootIndexFor`.
- **CHANGELOG** — add an `[Unreleased]` section (import-key dialog, content search, SSH_AUTH_SOCK override, process-output panel, the #1511/#1512/#1513/#1514 refactors, the #1538 CI fix).
- **qtpass.appdata.xml** — freshen the AppStream feature list and add a `<releases>` block (1.7.0, 1.6.0).
- **Skills** (`qtpass-testing`/`linting`/`docs`) — note the suite list is representative (`auto.pro` is source of truth) and document the pinned Doxygen 1.17.0 + resilient download. (`.claude` and `.opencode` skill trees are symlinked, so one edit covers both.)

## Verification
- `qtpass.appdata.xml` well-formed (`xmllint --noout`)
- `prettier --check` clean on all touched Markdown
- `reuse lint` compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and desktop metadata to highlight new/expanded capabilities, including opt-in, regex-based content search across decrypted entries, OTP support, smartcard/USB token support, GPG key import, and folder re-encryption options.
* **Chores**
  * Refreshed skill and architecture documentation, clarified test-suite coverage, and reorganized the changelog’s Unreleased section.
* **Build / CI**
  * Improved documentation build reliability by pinning Doxygen (1.17.0) and using a resilient download flow with fallback and retries to prevent intermittent docs-check failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->