### PR TITLE
test(settings): tighten assertions and simplify cleanup guard

### DIFF
--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -7,8 +7,6 @@
 #include <QSettings>
 #include <QTemporaryDir>
 
-#include <utility>
-
 #include "../../../src/appsettings.h"
 #include "../../../src/passwordconfiguration.h"
 #include "../../../src/qtpasssettings.h"
@@ -94,7 +92,7 @@ void tst_settings::cleanupTestCase() {
 
   // Restore original settings after all tests
   // This ensures make check doesn't change user's live config
-  if (m_isPortableMode && !m_settingsBackupPath.isEmpty()) {
+  if (m_isPortableMode) {
     QString settingsFile = QtPassSettings::getInstance()->fileName();
     QtPassSettings::getInstance()->sync();
     QVERIFY2(QFile::remove(settingsFile) || !QFile::exists(settingsFile),
@@ -108,8 +106,8 @@ void tst_settings::cleanupTestCase() {
 
 void tst_settings::getPasswordConfigurationDefault() {
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
-  QVERIFY(config.length >= 0);
-  QVERIFY(config.selected >= 0);
+  QCOMPARE(config.length, 16);
+  QCOMPARE(config.selected, PasswordConfiguration::ALLCHARS);
 }
 
 void tst_settings::setAndGetPasswordConfiguration() {
@@ -167,7 +165,7 @@ void tst_settings::setAndGetGeometry() {
 void tst_settings::getPassStore() {
   QString store = QtPassSettings::getPassStore();
   const bool plausiblePath = store.isEmpty() || QDir::isAbsolutePath(store) ||
-                             store.contains('/') || store.contains('\\');
+                             store.contains(QDir::separator());
   QVERIFY2(plausiblePath, "Pass store should be empty or a plausible path");
 }
 
@@ -506,11 +504,11 @@ void tst_settings::setAndGetMultipleProfiles() {
   QHash<QString, QHash<QString, QString>> profiles;
   QHash<QString, QString> profile1;
   profile1["path"] = "/path/to/store1";
-  profiles["profile1"] = std::move(profile1);
+  profiles["profile1"] = profile1;
 
   QHash<QString, QString> profile2;
   profile2["path"] = "/path/to/store2";
-  profiles["profile2"] = std::move(profile2);
+  profiles["profile2"] = profile2;
 
   QtPassSettings::setProfiles(profiles);
   QHash<QString, QHash<QString, QString>> readProfiles =

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -165,7 +165,7 @@ void tst_settings::setAndGetGeometry() {
 void tst_settings::getPassStore() {
   QString store = QtPassSettings::getPassStore();
   const bool plausiblePath = store.isEmpty() || QDir::isAbsolutePath(store) ||
-                             store.contains(QDir::separator());
+                             store.contains('/') || store.contains('\\');
   QVERIFY2(plausiblePath, "Pass store should be empty or a plausible path");
 }
 


### PR DESCRIPTION
## Summary

- Remove redundant `!m_settingsBackupPath.isEmpty()` in `cleanupTestCase` — the backup path is always set when `m_isPortableMode` is true
- Replace `QVERIFY(config.length >= 0)` / `QVERIFY(config.selected >= 0)` with `QCOMPARE` against documented defaults (16 / `ALLCHARS`) in `getPasswordConfigurationDefault`
- Remove `std::move` from `QHash` inserts in `setAndGetMultipleProfiles` — Qt implicit sharing makes it a no-op and can inhibit copy-on-write optimisations
- Drop now-unused `#include <utility>`

**Skipped / reverted:**
- `qScopeGuard` for `.git` in `autoDetectGit`: the explicit `gitDir.rmdir(".git")` mid-test transitions the test state, it is not just cleanup
- `QDir::separator()` in `getPassStore`: `QDir::cleanPath()` normalises to `/` on all platforms; a Windows path may contain `/` even though `QDir::separator()` returns `\\`. The original `contains('/') || contains('\\')` is the correct project convention

## Test plan

- [ ] `make check` passes
- [ ] No regressions in `tst_settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Strengthened validation of the default password configuration by asserting exact expected values (length and selected character set).
  * Improved portable mode cleanup behavior by simplifying the conditions used to restore settings, making it more consistent.
  * Updated multiple profile setup in the test to use direct assignment for more reliable verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->