### PR TITLE
test(passworddisplaypanel): extract shared fixture and tighten assertions

### DIFF
--- a/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
+++ b/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
@@ -12,61 +12,60 @@
 class tst_passworddisplaypanel : public QObject {
   Q_OBJECT
 
+  QWidget *m_parent = nullptr;
+  QGridLayout *m_grid = nullptr;
+  QVBoxLayout *m_container = nullptr;
+  PasswordDisplayPanel *m_panel = nullptr;
+
 private Q_SLOTS:
+  void init();
+  void cleanup();
   void displayFieldsAddsRows();
   void displayFieldsSkipsEmptyPassword();
   void clearRemovesAllRows();
   void appendFieldAddsOneRow();
 };
 
-void tst_passworddisplaypanel::displayFieldsAddsRows() {
-  QWidget parent;
-  auto *grid = new QGridLayout();
-  auto *container = new QVBoxLayout(&parent);
-  container->addLayout(grid);
-  PasswordDisplayPanel panel(grid, container, &parent);
+void tst_passworddisplaypanel::init() {
+  m_parent = new QWidget;
+  m_grid = new QGridLayout;
+  m_container = new QVBoxLayout(m_parent);
+  m_container->addLayout(m_grid);
+  m_panel = new PasswordDisplayPanel(m_grid, m_container, m_parent);
+}
 
-  panel.displayFields(QStringLiteral("secret"),
-                      NamedValues{{"url", "https://example.org"}});
+void tst_passworddisplaypanel::cleanup() {
+  delete m_parent;
+  m_parent = nullptr;
+  m_grid = nullptr;
+  m_container = nullptr;
+  m_panel = nullptr;
+}
+
+void tst_passworddisplaypanel::displayFieldsAddsRows() {
+  m_panel->displayFields(QStringLiteral("secret"),
+                         NamedValues{{"url", "https://example.org"}});
   // Two fields (password + url), each a label + value widget => 4 grid items.
-  QVERIFY2(grid->count() > 0, "displayFields must populate the grid");
+  QCOMPARE(m_grid->count(), 4);
 }
 
 void tst_passworddisplaypanel::displayFieldsSkipsEmptyPassword() {
-  QWidget parent;
-  auto *grid = new QGridLayout();
-  auto *container = new QVBoxLayout(&parent);
-  container->addLayout(grid);
-  PasswordDisplayPanel panel(grid, container, &parent);
-
-  panel.displayFields(QString(), NamedValues{});
-  QVERIFY2(grid->count() == 0,
+  m_panel->displayFields(QString(), NamedValues{});
+  QVERIFY2(m_grid->count() == 0,
            "An empty password with no fields must leave the grid empty");
 }
 
 void tst_passworddisplaypanel::clearRemovesAllRows() {
-  QWidget parent;
-  auto *grid = new QGridLayout();
-  auto *container = new QVBoxLayout(&parent);
-  container->addLayout(grid);
-  PasswordDisplayPanel panel(grid, container, &parent);
-
-  panel.displayFields(QStringLiteral("secret"), NamedValues{});
-  QVERIFY2(grid->count() > 0, "precondition: grid populated");
-  panel.clear();
-  QVERIFY2(grid->count() == 0, "clear() must remove every grid row");
+  m_panel->displayFields(QStringLiteral("secret"), NamedValues{});
+  QVERIFY2(m_grid->count() > 0, "precondition: grid populated");
+  m_panel->clear();
+  QVERIFY2(m_grid->count() == 0, "clear() must remove every grid row");
 }
 
 void tst_passworddisplaypanel::appendFieldAddsOneRow() {
-  QWidget parent;
-  auto *grid = new QGridLayout();
-  auto *container = new QVBoxLayout(&parent);
-  container->addLayout(grid);
-  PasswordDisplayPanel panel(grid, container, &parent);
-
-  const int before = grid->count();
-  panel.appendField(QStringLiteral("OTP Code"), QStringLiteral("123456"));
-  QVERIFY2(grid->count() > before, "appendField must add a row");
+  const int before = m_grid->count();
+  m_panel->appendField(QStringLiteral("OTP Code"), QStringLiteral("123456"));
+  QCOMPARE(m_grid->count(), before + 2);
 }
 
 QTEST_MAIN(tst_passworddisplaypanel)

--- a/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
+++ b/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
@@ -35,11 +35,12 @@ void tst_passworddisplaypanel::init() {
 }
 
 void tst_passworddisplaypanel::cleanup() {
+  delete m_panel;
+  m_panel = nullptr;
   delete m_parent;
   m_parent = nullptr;
   m_grid = nullptr;
   m_container = nullptr;
-  m_panel = nullptr;
 }
 
 void tst_passworddisplaypanel::displayFieldsAddsRows() {


### PR DESCRIPTION
## Summary

- Extract the four identical `QWidget`/`QGridLayout`/`QVBoxLayout`/`PasswordDisplayPanel` setup blocks into `init()`/`cleanup()` fixture methods with member variables (`m_parent`, `m_grid`, `m_container`, `m_panel`)
- Tighten `displayFieldsAddsRows`: `QCOMPARE(m_grid->count(), 4)` instead of `QVERIFY2(> 0)` — two fields × (label + value) = exactly 4 grid items
- Tighten `appendFieldAddsOneRow`: `QCOMPARE(m_grid->count(), before + 2)` instead of `QVERIFY2(> before)` — one field = label + value widget = 2 items

## Test plan

- [ ] `make check` passes
- [ ] No regressions in `tst_passworddisplaypanel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored the Password Display Panel test suite to reuse a shared widget/layout fixture, reducing repeated setup and teardown.
  * Strengthened assertions in the panel’s display/clear/append behaviors to better validate expected row counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->