### PR TITLE
test(grepsearchcontroller): assert restoreCursor on subsequent finishSearch

### DIFF
--- a/tests/auto/grepsearchcontroller/tst_grepsearchcontroller.cpp
+++ b/tests/auto/grepsearchcontroller/tst_grepsearchcontroller.cpp
@@ -72,7 +72,9 @@ void tst_grepsearchcontroller::finishDiscardsWhenCancelled() {
   QCOMPARE(outcome.restoreCursor, false);
   QCOMPARE(outcome.discard, true);
   // The discard flag is consumed: a subsequent finish keeps results.
-  QCOMPARE(c.finishSearch().discard, false);
+  const GrepSearchController::FinishOutcome subsequent = c.finishSearch();
+  QCOMPARE(subsequent.restoreCursor, false);
+  QCOMPARE(subsequent.discard, false);
 }
 
 void tst_grepsearchcontroller::leaveWhileBusyInterruptsAndDiscards() {


### PR DESCRIPTION
## Summary

- In `finishDiscardsWhenCancelled`, capture the subsequent `finishSearch()` result and assert both `restoreCursor` and `discard` fields, so a regression in either is caught (previously only `discard` was checked)

**Skipped:** The suggestion to shorten `#include "../../../src/grepsearchcontroller.h"` to `#include "grepsearchcontroller.h"` (relying on `INCLUDEPATH`) was not applied — every other test file in the project uses the explicit relative prefix; changing this one file alone would create inconsistency.

## Test plan

- [ ] `make check` passes
- [ ] No regressions in `tst_grepsearchcontroller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for search cancellation behavior to verify proper flag consumption and state handling.

**Note:** This is an internal test improvement with no visible end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->