### PR TITLE
refactor(mainwindow): const ref Qt5 slot, rename m_initialShowDone and m_keygenDialog

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -235,7 +235,7 @@ void MainWindow::focusInput() {
   // landed; setting it eagerly in showEvent() would consume the
   // one-shot if focusInput returned early (mid-rebuild widget state)
   // and we'd never retry.
-  m_initialShowDone = true;
+  m_firstShowCompleted = true;
 }
 
 /**
@@ -264,13 +264,13 @@ void MainWindow::changeEvent(QEvent *event) {
  */
 void MainWindow::showEvent(QShowEvent *event) {
   QMainWindow::showEvent(event);
-  if (m_initialShowDone) {
+  if (m_firstShowCompleted) {
     return;
   }
   // Queue the focus pulse for the next event-loop tick so the platform
   // map round-trip and any pending widget rebuilds (e.g. setWindowFlags
   // from the config wizard path) settle before we look up the line
-  // edit. The `m_initialShowDone` latch is set inside focusInput()
+  // edit. The `m_firstShowCompleted` latch is set inside focusInput()
   // *after* it actually focuses, so a transient failed lookup just
   // re-queues on the next show rather than silently dropping.
   QMetaObject::invokeMethod(this, &MainWindow::focusInput,
@@ -396,10 +396,10 @@ auto MainWindow::getCurrentTreeViewIndex() -> QModelIndex {
 }
 
 void MainWindow::cleanKeygenDialog() {
-  if (m_keygenDialog != nullptr) {
-    m_keygenDialog->close();
+  if (m_keyGenDialog != nullptr) {
+    m_keyGenDialog->close();
   }
-  m_keygenDialog = nullptr;
+  m_keyGenDialog = nullptr;
 }
 
 /**
@@ -1213,7 +1213,7 @@ void MainWindow::messageAvailable(const QString &message) {
  * @param keygenWindow
  */
 void MainWindow::generateKeyPair(const QString &batch, QDialog *keygenWindow) {
-  m_keygenDialog = keygenWindow;
+  m_keyGenDialog = keygenWindow;
   emit generateGPGKeyPair(batch);
 }
 
@@ -1252,7 +1252,7 @@ void MainWindow::updateProfileBox() {
  * @param name
  */
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-void MainWindow::on_profileBox_currentIndexChanged(QString name) {
+void MainWindow::on_profileBox_currentIndexChanged(const QString &name) {
 #else
 /**
  * @brief Handles changes to the selected profile in the profile combo box.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -115,7 +115,7 @@ public:
    * @return Non-owning pointer to the keygen QDialog, or nullptr when none is
    * active.
    */
-  auto getKeygenDialog() -> QDialog * { return m_keygenDialog; }
+  auto getKeyGenDialog() -> QDialog * { return m_keyGenDialog; }
 
   /**
    * @brief Destroy and clear the key generation dialog.
@@ -265,7 +265,7 @@ private slots:
   void on_lineEdit_textChanged(const QString &arg1);
   void on_lineEdit_returnPressed();
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  void on_profileBox_currentIndexChanged(QString);
+  void on_profileBox_currentIndexChanged(const QString &);
 #else
   void on_profileBox_currentTextChanged(const QString &);
 #endif
@@ -285,7 +285,7 @@ private:
   QScopedPointer<Ui::MainWindow> ui;
   GrepSearchController m_grep;
   PasswordDisplayPanel *m_displayPanel = nullptr;
-  bool m_initialShowDone = false;
+  bool m_firstShowCompleted = false;
   bool m_autoScroll = true;
   int m_outputCounter = 0;
   static constexpr int MaxOutputLines = 1000;
@@ -307,7 +307,7 @@ private:
   // completion (see setUiElementsEnabled).
   QTimer m_uiWatchdog;
   static constexpr int UiWatchdogMs = 30000;
-  QDialog *m_keygenDialog{};
+  QDialog *m_keyGenDialog{};
   QString m_currentDir;
   TrayIcon *m_tray{};
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -292,7 +292,7 @@ void QtPass::processError(QProcess::ProcessError error) {
  * @param p_error The error message
  */
 void QtPass::processErrorExit(int exitCode, const QString &p_error) {
-  if (nullptr != m_mainWindow->getKeygenDialog()) {
+  if (nullptr != m_mainWindow->getKeyGenDialog()) {
     m_mainWindow->cleanKeygenDialog();
     if (exitCode != 0) {
       m_mainWindow->showStatusMessage(tr("GPG key pair generation failed"),
@@ -363,7 +363,7 @@ void QtPass::finishedInsert(const QString &p_output, const QString &p_errout) {
  */
 void QtPass::onKeyGenerationComplete(const QString &p_output,
                                      const QString &p_errout) {
-  if (nullptr != m_mainWindow->getKeygenDialog()) {
+  if (nullptr != m_mainWindow->getKeyGenDialog()) {
 #ifdef QT_DEBUG
     qDebug() << "Keygen Done";
 #endif

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -132,19 +132,19 @@ void tst_mainwindow::constructionDoesNotCrash() {
 }
 
 /**
- * @brief getKeygenDialog() returns nullptr before any keygen is started.
+ * @brief getKeyGenDialog() returns nullptr before any keygen is started.
  */
 void tst_mainwindow::getKeygenDialogInitiallyNull() {
-  QCOMPARE(m_window->getKeygenDialog(), nullptr);
+  QCOMPARE(m_window->getKeyGenDialog(), nullptr);
 }
 
 /**
  * @brief cleanKeygenDialog() is a no-op (and harmless) when no dialog exists.
  */
 void tst_mainwindow::cleanKeygenDialogWithNullIsHarmless() {
-  QCOMPARE(m_window->getKeygenDialog(), nullptr);
+  QCOMPARE(m_window->getKeyGenDialog(), nullptr);
   m_window->cleanKeygenDialog();
-  QCOMPARE(m_window->getKeygenDialog(), nullptr);
+  QCOMPARE(m_window->getKeyGenDialog(), nullptr);
 }
 
 /**


### PR DESCRIPTION
## Summary

Three naming and signature fixes flagged in code review:

- `on_profileBox_currentIndexChanged(QString)` → `on_profileBox_currentIndexChanged(const QString &)` — passes by const ref instead of value (Qt 5 slot convention; Qt 6 uses `currentTextChanged` which is already correct)
- `m_initialShowDone` → `m_firstShowCompleted` — clearer name for the first-show guard flag
- `m_keygenDialog` / `getKeygenDialog()` → `m_keyGenDialog` / `getKeyGenDialog()` — consistent camelCase for the "Gen" abbreviation

Files changed: `src/mainwindow.h`, `src/mainwindow.cpp`, `src/qtpass.cpp`, `tests/auto/mainwindow/tst_mainwindow.cpp`

## Test plan

- [ ] `make check` passes
- [ ] No regressions in `tst_mainwindow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency and organization for search-box focus handling, key generation dialog management, and profile selection logic.
  * Updated method signatures and variable naming to follow code standards throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->