### PR TITLE
refactor(executor): replace QStringList env with QProcessEnvironment (#1510)

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -286,18 +286,12 @@ auto Executor::executeBlocking(const QString &app, const QStringList &args,
  * @param process_err Standard error
  * @return Exit code
  */
-auto Executor::executeBlocking(const QStringList &env, const QString &app,
-                               const QStringList &args, QString *process_out,
-                               QString *process_err) -> int {
+auto Executor::executeBlocking(const QProcessEnvironment &env,
+                               const QString &app, const QStringList &args,
+                               QString *process_out, QString *process_err)
+    -> int {
   QProcess process;
-  QProcessEnvironment penv;
-  for (const QString &var : env) {
-    qsizetype idx = var.indexOf('=');
-    if (idx > 0) {
-      penv.insert(var.left(idx), var.mid(idx + 1));
-    }
-  }
-  process.setProcessEnvironment(penv);
+  process.setProcessEnvironment(env);
   return runBlocking(process, app, args, QString(), process_out, process_err);
 }
 
@@ -306,12 +300,12 @@ auto Executor::executeBlocking(const QStringList &env, const QString &app,
  * for executor processes
  * @param env
  */
-void Executor::setEnvironment(const QStringList &env) {
-  m_process.setEnvironment(env);
+void Executor::setEnvironment(const QProcessEnvironment &env) {
+  m_process.setProcessEnvironment(env);
 }
 
-auto Executor::environment() const -> QStringList {
-  return m_process.environment();
+auto Executor::environment() const -> QProcessEnvironment {
+  return m_process.processEnvironment();
 }
 
 /**

--- a/src/executor.h
+++ b/src/executor.h
@@ -5,6 +5,7 @@
 
 #include <QObject>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QQueue>
 
 /**
@@ -167,28 +168,28 @@ public:
 
   /**
    * @brief Run a command synchronously with a custom environment.
-   * @param env Environment variable list in "KEY=value" format.
+   * @param env Process environment for the child process.
    * @param app Executable path.
    * @param args Command arguments.
    * @param process_out If non-null, receives stdout output.
    * @param process_err If non-null, receives stderr output.
    * @return Process exit code.
    */
-  static auto executeBlocking(const QStringList &env, const QString &app,
-                              const QStringList &args,
+  static auto executeBlocking(const QProcessEnvironment &env,
+                              const QString &app, const QStringList &args,
                               QString *process_out = nullptr,
                               QString *process_err = nullptr) -> int;
 
   /**
    * @brief Set the environment passed to all child processes.
-   * @param env Environment variable list in "KEY=value" format.
+   * @param env Process environment for child processes.
    */
-  void setEnvironment(const QStringList &env);
+  void setEnvironment(const QProcessEnvironment &env);
   /**
    * @brief Return the environment passed to child processes.
-   * @return Environment as a list of "KEY=value" strings.
+   * @return Process environment.
    */
-  auto environment() const -> QStringList;
+  auto environment() const -> QProcessEnvironment;
 
   /**
    * @brief Cancel the next queued command without executing it.

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -1040,8 +1040,8 @@ void ImitatePass::beforeExecute(PROCESS id) { transactionAdd(id); }
 /**
  * @brief Decrypt one .gpg file and return lines matching rx.
  */
-auto ImitatePass::grepMatchFile(const QStringList &env, const QString &gpgExe,
-                                const QString &filePath,
+auto ImitatePass::grepMatchFile(const QProcessEnvironment &env,
+                                const QString &gpgExe, const QString &filePath,
                                 const QRegularExpression &rx) -> QStringList {
   QString plaintext;
   const int rc =
@@ -1066,8 +1066,8 @@ auto ImitatePass::grepMatchFile(const QStringList &env, const QString &gpgExe,
 /**
  * @brief Walk the store, decrypt every .gpg file, collect matches.
  */
-auto ImitatePass::grepScanStore(const QStringList &env, const QString &gpgExe,
-                                const QString &storeDir,
+auto ImitatePass::grepScanStore(const QProcessEnvironment &env,
+                                const QString &gpgExe, const QString &storeDir,
                                 const QRegularExpression &rx)
     -> QList<QPair<QString, QStringList>> {
   QList<QPair<QString, QStringList>> results;
@@ -1143,7 +1143,7 @@ void ImitatePass::Grep(QString pattern, bool caseInsensitive) {
   }
   const QString gpgExe = QtPassSettings::getGpgExecutable();
   const QString storeDir = QtPassSettings::getPassStore();
-  const QStringList env = exec.environment();
+  const QProcessEnvironment env = exec.environment();
   QPointer<ImitatePass> self(this);
 
   auto emitResults = [self, seq](QList<QPair<QString, QStringList>> results) {

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -298,11 +298,11 @@ private:
   int m_grepSeq = 0;
   QList<QThread *> m_grepThreads;
 
-  static auto grepMatchFile(const QStringList &env, const QString &gpgExe,
-                            const QString &filePath,
+  static auto grepMatchFile(const QProcessEnvironment &env,
+                            const QString &gpgExe, const QString &filePath,
                             const QRegularExpression &rx) -> QStringList;
-  static auto grepScanStore(const QStringList &env, const QString &gpgExe,
-                            const QString &storeDir,
+  static auto grepScanStore(const QProcessEnvironment &env,
+                            const QString &gpgExe, const QString &storeDir,
                             const QRegularExpression &rx)
       -> QList<QPair<QString, QStringList>>;
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1717,8 +1717,7 @@ void MainWindow::exportPublicKey() {
   args.append(identity.split(' ', Qt::SkipEmptyParts));
   QString stdOut;
   QString stdErr;
-  int exitCode =
-      Executor::executeBlocking(gpgExe, args, &stdOut, &stdErr);
+  int exitCode = Executor::executeBlocking(gpgExe, args, &stdOut, &stdErr);
   if (exitCode != 0 || stdOut.isEmpty()) {
     QMessageBox::warning(this, tr("Export Public Key"),
                          tr("Could not export public key for %1.\n\n%2")

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1718,7 +1718,7 @@ void MainWindow::exportPublicKey() {
   QString stdOut;
   QString stdErr;
   int exitCode =
-      Executor::executeBlocking(gpgExe, args, QString(), &stdOut, &stdErr);
+      Executor::executeBlocking(gpgExe, args, &stdOut, &stdErr);
   if (exitCode != 0 || stdOut.isEmpty()) {
     QMessageBox::warning(this, tr("Export Public Key"),
                          tr("Could not export public key for %1.\n\n%2")

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -131,11 +131,15 @@ void Pass::init() {
     env.insert(QStringLiteral("PATH"),
                QStringLiteral("/usr/local/MacGPG2/bin:") +
                    env.value(QStringLiteral("PATH")));
-  // Add missing /usr/local/bin
-  if (!env.value(QStringLiteral("PATH"))
-           .contains(QStringLiteral("/usr/local/bin")))
-    env.insert(QStringLiteral("PATH"), QStringLiteral("/usr/local/bin:") +
-                                           env.value(QStringLiteral("PATH")));
+  // Add missing /usr/local/bin (exact component match, no leading colon)
+  const QString currentPath = env.value(QStringLiteral("PATH"));
+  if (!currentPath.split(':', Qt::SkipEmptyParts)
+           .contains(QStringLiteral("/usr/local/bin"))) {
+    env.insert(QStringLiteral("PATH"),
+               currentPath.isEmpty()
+                   ? QStringLiteral("/usr/local/bin")
+                   : QStringLiteral("/usr/local/bin:") + currentPath);
+  }
 #endif
 
   if (!QtPassSettings::getGpgHome().isEmpty()) {

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -11,7 +11,6 @@
 #include <QProcess>
 #include <QRandomGenerator>
 #include <QRegularExpression>
-#include <algorithm>
 #include <utility>
 
 #ifdef QT_DEBUG
@@ -65,7 +64,7 @@ auto effectiveCharset(const PasswordConfiguration &passConfig) -> QString {
 /**
  * @brief Pass::Pass wrapper for using either pass or the pass imitation
  */
-Pass::Pass() : env(QProcess::systemEnvironment()) {
+Pass::Pass() : env(QProcessEnvironment::systemEnvironment()) {
   connect(&exec,
           static_cast<void (Executor::*)(int, int, const QString &,
                                          const QString &)>(&Executor::finished),
@@ -82,21 +81,16 @@ Pass::Pass() : env(QProcess::systemEnvironment()) {
       QStringLiteral("PASSWORD_STORE_DIR/p"),
       QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w"),
       QStringLiteral("PASSWORD_STORE_CHARACTER_SET/w")};
-  const QString wslenvPrefix = QStringLiteral("WSLENV=");
-  auto it =
-      std::find_if(env.begin(), env.end(), [&wslenvPrefix](const QString &s) {
-        return s.startsWith(wslenvPrefix);
-      });
-  if (it == env.end()) {
-    env.append(wslenvPrefix + wslenvVars.join(':'));
+  const QString existing = env.value(QStringLiteral("WSLENV"));
+  if (existing.isEmpty()) {
+    env.insert(QStringLiteral("WSLENV"), wslenvVars.join(':'));
   } else {
-    QStringList parts =
-        it->mid(wslenvPrefix.size()).split(':', Qt::SkipEmptyParts);
+    QStringList parts = existing.split(':', Qt::SkipEmptyParts);
     for (const QString &v : wslenvVars) {
       if (!parts.contains(v))
         parts.append(v);
     }
-    *it = wslenvPrefix + parts.join(':');
+    env.insert(QStringLiteral("WSLENV"), parts.join(':'));
   }
 }
 
@@ -132,18 +126,23 @@ void Pass::beforeExecute(PROCESS /*id*/) {}
  */
 void Pass::init() {
 #ifdef __APPLE__
-  // If it exists, add the gpgtools to PATH
-  if (QFile("/usr/local/MacGPG2/bin").exists())
-    env.replaceInStrings("PATH=", "PATH=/usr/local/MacGPG2/bin:");
+  // If it exists, prepend gpgtools to PATH
+  if (QFile(QStringLiteral("/usr/local/MacGPG2/bin")).exists())
+    env.insert(QStringLiteral("PATH"),
+               QStringLiteral("/usr/local/MacGPG2/bin:") +
+                   env.value(QStringLiteral("PATH")));
   // Add missing /usr/local/bin
-  if (env.filter("/usr/local/bin").isEmpty())
-    env.replaceInStrings("PATH=", "PATH=/usr/local/bin:");
+  if (!env.value(QStringLiteral("PATH"))
+           .contains(QStringLiteral("/usr/local/bin")))
+    env.insert(QStringLiteral("PATH"),
+               QStringLiteral("/usr/local/bin:") +
+                   env.value(QStringLiteral("PATH")));
 #endif
 
   if (!QtPassSettings::getGpgHome().isEmpty()) {
     QDir absHome(QtPassSettings::getGpgHome());
     absHome.makeAbsolute();
-    env << "GNUPGHOME=" + absHome.path();
+    env.insert(QStringLiteral("GNUPGHOME"), absHome.path());
   }
 }
 
@@ -806,12 +805,11 @@ void Pass::setEnvVar(const QString &key, const QString &value) {
                << key;
     return;
   }
-  env.erase(std::remove_if(
-                env.begin(), env.end(),
-                [&key](const QString &entry) { return entry.startsWith(key); }),
-            env.end());
-  if (!value.isEmpty())
-    env.append(key + value);
+  const QString varName = key.chopped(1);
+  if (value.isEmpty())
+    env.remove(varName);
+  else
+    env.insert(varName, value);
 }
 
 /**

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -134,9 +134,8 @@ void Pass::init() {
   // Add missing /usr/local/bin
   if (!env.value(QStringLiteral("PATH"))
            .contains(QStringLiteral("/usr/local/bin")))
-    env.insert(QStringLiteral("PATH"),
-               QStringLiteral("/usr/local/bin:") +
-                   env.value(QStringLiteral("PATH")));
+    env.insert(QStringLiteral("PATH"), QStringLiteral("/usr/local/bin:") +
+                                           env.value(QStringLiteral("PATH")));
 #endif
 
   if (!QtPassSettings::getGpgHome().isEmpty()) {

--- a/src/pass.h
+++ b/src/pass.h
@@ -8,6 +8,7 @@
 #include "userinfo.h"
 
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QQueue>
 #include <QString>
 #include <QStringList>
@@ -51,7 +52,7 @@ class Pass : public QObject {
   Q_OBJECT
 
   bool wrapperRunning{false};
-  QStringList env;
+  QProcessEnvironment env;
 
 protected:
   /**

--- a/src/sshauthsock.cpp
+++ b/src/sshauthsock.cpp
@@ -55,7 +55,7 @@ auto isSshAgentReachable(const QString &candidate) -> bool {
   QString out;
   QString err;
   const int exitCode =
-      Executor::executeBlocking(env.toStringList(), QStringLiteral("ssh-add"),
+      Executor::executeBlocking(env, QStringLiteral("ssh-add"),
                                 {QStringLiteral("-l")}, &out, &err);
   // OpenSSH ssh-add(1) exit codes: 0 = success / has keys, 1 = no
   // identities present, 2 = couldn't open a connection. Anything else is

--- a/src/sshauthsock.cpp
+++ b/src/sshauthsock.cpp
@@ -54,9 +54,8 @@ auto isSshAgentReachable(const QString &candidate) -> bool {
   env.insert(QStringLiteral("SSH_AUTH_SOCK"), candidate);
   QString out;
   QString err;
-  const int exitCode =
-      Executor::executeBlocking(env, QStringLiteral("ssh-add"),
-                                {QStringLiteral("-l")}, &out, &err);
+  const int exitCode = Executor::executeBlocking(
+      env, QStringLiteral("ssh-add"), {QStringLiteral("-l")}, &out, &err);
   // OpenSSH ssh-add(1) exit codes: 0 = success / has keys, 1 = no
   // identities present, 2 = couldn't open a connection. Anything else is
   // also treated as unreachable (e.g. ssh-add not on PATH).

--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -134,7 +134,8 @@ void tst_executor::executeBlockingWithEnvSetsVariable() {
   // Verify that a variable injected via the env parameter is visible inside
   // the process.
   QProcessEnvironment env;
-  env.insert(QStringLiteral("QTPASS_TEST_VAR"), QStringLiteral("injected_value"));
+  env.insert(QStringLiteral("QTPASS_TEST_VAR"),
+             QStringLiteral("injected_value"));
   QString output;
   int result = Executor::executeBlocking(
       env, "sh", {"-c", "echo $QTPASS_TEST_VAR"}, &output);

--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -106,12 +106,12 @@ void tst_executor::executeBlockingSpecialChars() {
 }
 
 // Tests for the third executeBlocking overload:
-//   executeBlocking(const QStringList &env, const QString &app, ...)
-// This overload was changed from (QString app) to (const QString &app).
+//   executeBlocking(const QProcessEnvironment &env, const QString &app, ...)
 
 void tst_executor::executeBlockingWithEnv() {
   // Basic: custom env, echo succeeds, output captured.
-  QStringList env = {"MY_VAR=hello_env"};
+  QProcessEnvironment env;
+  env.insert(QStringLiteral("MY_VAR"), QStringLiteral("hello_env"));
   QString output;
   int result = Executor::executeBlocking(env, "sh", {"-c", "echo ok"}, &output);
   QVERIFY2(result == 0, "sh with custom env should exit 0");
@@ -119,9 +119,9 @@ void tst_executor::executeBlockingWithEnv() {
 }
 
 void tst_executor::executeBlockingWithEnvEmpty() {
-  // Empty env list: process starts with an empty environment.
+  // Empty env: process starts with an empty environment.
   // On POSIX, running 'env' with empty environment should succeed.
-  QStringList env;
+  const QProcessEnvironment env;
   QString output;
   QString err;
   int result =
@@ -133,7 +133,8 @@ void tst_executor::executeBlockingWithEnvEmpty() {
 void tst_executor::executeBlockingWithEnvSetsVariable() {
   // Verify that a variable injected via the env parameter is visible inside
   // the process.
-  QStringList env = {"QTPASS_TEST_VAR=injected_value"};
+  QProcessEnvironment env;
+  env.insert(QStringLiteral("QTPASS_TEST_VAR"), QStringLiteral("injected_value"));
   QString output;
   int result = Executor::executeBlocking(
       env, "sh", {"-c", "echo $QTPASS_TEST_VAR"}, &output);
@@ -177,7 +178,8 @@ void tst_executor::executeBlockingNotFound() {
 
 void tst_executor::executeBlockingWithEnvNotFound() {
   // The env-based overload should also fail gracefully for a missing binary.
-  QStringList env = {"MY_VAR=irrelevant"};
+  QProcessEnvironment env;
+  env.insert(QStringLiteral("MY_VAR"), QStringLiteral("irrelevant"));
   QString output;
   int result = Executor::executeBlocking(env, "nonexistent_command_env_xyz", {},
                                          &output);
@@ -312,13 +314,13 @@ void tst_executor::environmentDefaultsEmpty() {
 
 void tst_executor::setAndGetEnvironment() {
   Executor exec;
-  QStringList env = {"QTPASS_FOO=bar", "QTPASS_BAZ=qux"};
+  QProcessEnvironment env;
+  env.insert(QStringLiteral("QTPASS_FOO"), QStringLiteral("bar"));
+  env.insert(QStringLiteral("QTPASS_BAZ"), QStringLiteral("qux"));
   exec.setEnvironment(env);
-  QStringList expected = env;
-  expected.sort();
-  QStringList actual = exec.environment();
-  actual.sort();
-  QCOMPARE(actual, expected);
+  const QProcessEnvironment actual = exec.environment();
+  QCOMPARE(actual.value(QStringLiteral("QTPASS_FOO")), QStringLiteral("bar"));
+  QCOMPARE(actual.value(QStringLiteral("QTPASS_BAZ")), QStringLiteral("qux"));
 }
 
 void tst_executor::cancelNextEmptyReturnsMinusOne() {

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1713,8 +1713,9 @@ void tst_util::setEnvVarRemoves() {
 
 void tst_util::setEnvVarNoopOnMissingRemove() {
   TestPass pass;
+  const QProcessEnvironment before = pass.environment();
   pass.callSetEnvVar(QStringLiteral("NONEXISTENT_KEY="), QString());
-  QVERIFY(!pass.environment().contains(QStringLiteral("NONEXISTENT_KEY")));
+  QCOMPARE(pass.environment(), before);
 }
 
 void tst_util::updateEnvSetsExpectedVars() {
@@ -1727,8 +1728,9 @@ void tst_util::updateEnvSetsExpectedVars() {
   const QProcessEnvironment env = pass.environment();
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_DIR")),
            "updateEnv should set PASSWORD_STORE_DIR");
-  QVERIFY2(env.value(QStringLiteral("PASSWORD_STORE_DIR")).contains(tmpDir.path()),
-           "updateEnv should set PASSWORD_STORE_DIR to configured store path");
+  QVERIFY2(
+      env.value(QStringLiteral("PASSWORD_STORE_DIR")).contains(tmpDir.path()),
+      "updateEnv should set PASSWORD_STORE_DIR to configured store path");
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH")),
            "updateEnv should set PASSWORD_STORE_GENERATED_LENGTH");
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
@@ -1749,8 +1751,9 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
   QtPassSettings::setPasswordConfiguration(config);
 
   const QProcessEnvironment env = pass.environment();
-  QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
-           "PASSWORD_STORE_CHARACTER_SET should be set even when CUSTOM is empty");
+  QVERIFY2(
+      env.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
+      "PASSWORD_STORE_CHARACTER_SET should be set even when CUSTOM is empty");
   QVERIFY2(!env.value(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")).isEmpty(),
            "charset should fall back to ALLCHARS, not be empty");
 }

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1728,9 +1728,8 @@ void tst_util::updateEnvSetsExpectedVars() {
   const QProcessEnvironment env = pass.environment();
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_DIR")),
            "updateEnv should set PASSWORD_STORE_DIR");
-  QVERIFY2(
-      env.value(QStringLiteral("PASSWORD_STORE_DIR")).contains(tmpDir.path()),
-      "updateEnv should set PASSWORD_STORE_DIR to configured store path");
+  QCOMPARE(QDir::cleanPath(env.value(QStringLiteral("PASSWORD_STORE_DIR"))),
+           QDir::cleanPath(tmpDir.path()));
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH")),
            "updateEnv should set PASSWORD_STORE_GENERATED_LENGTH");
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -83,7 +83,7 @@ private:
     void callSetEnvVar(const QString &key, const QString &value) {
       setEnvVar(key, value);
     }
-    QStringList environment() {
+    QProcessEnvironment environment() {
       updateEnv();
       return exec.environment();
     }
@@ -1689,38 +1689,32 @@ void tst_util::findBinaryInPathStringLiteral() {
 void tst_util::setEnvVarAdds() {
   TestPass pass;
   pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("hello"));
-  QStringList env = pass.environment();
-  QVERIFY2(env.contains(QStringLiteral("TEST_KEY=hello")),
-           "setEnvVar should append key=value when absent");
+  const QProcessEnvironment env = pass.environment();
+  QVERIFY2(env.value(QStringLiteral("TEST_KEY")) == QStringLiteral("hello"),
+           "setEnvVar should set key=value when absent");
 }
 
 void tst_util::setEnvVarUpdates() {
   TestPass pass;
   pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("first"));
   pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("second"));
-  QStringList env = pass.environment();
-  QVERIFY2(env.contains(QStringLiteral("TEST_KEY=second")),
-           "setEnvVar should update existing entry");
-  QVERIFY2(!env.contains(QStringLiteral("TEST_KEY=first")),
-           "setEnvVar should remove old value");
-  QCOMPARE(env.filter(QStringLiteral("TEST_KEY=")).size(), 1);
+  const QProcessEnvironment env = pass.environment();
+  QCOMPARE(env.value(QStringLiteral("TEST_KEY")), QStringLiteral("second"));
 }
 
 void tst_util::setEnvVarRemoves() {
   TestPass pass;
   pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QStringLiteral("value"));
   pass.callSetEnvVar(QStringLiteral("TEST_KEY="), QString());
-  QStringList env = pass.environment();
-  QVERIFY2(env.filter(QStringLiteral("TEST_KEY=")).isEmpty(),
+  const QProcessEnvironment env = pass.environment();
+  QVERIFY2(!env.contains(QStringLiteral("TEST_KEY")),
            "setEnvVar with empty value should remove the entry");
 }
 
 void tst_util::setEnvVarNoopOnMissingRemove() {
   TestPass pass;
-  QStringList before = pass.environment();
   pass.callSetEnvVar(QStringLiteral("NONEXISTENT_KEY="), QString());
-  QStringList after = pass.environment();
-  QCOMPARE(before, after);
+  QVERIFY(!pass.environment().contains(QStringLiteral("NONEXISTENT_KEY")));
 }
 
 void tst_util::updateEnvSetsExpectedVars() {
@@ -1730,19 +1724,14 @@ void tst_util::updateEnvSetsExpectedVars() {
   PassStoreGuard storeGuard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(tmpDir.path());
 
-  QStringList env = pass.environment();
-  QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_DIR=")).size() == 1,
+  const QProcessEnvironment env = pass.environment();
+  QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_DIR")),
            "updateEnv should set PASSWORD_STORE_DIR");
-  QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_DIR="))
-               .first()
-               .contains(tmpDir.path()),
+  QVERIFY2(env.value(QStringLiteral("PASSWORD_STORE_DIR")).contains(tmpDir.path()),
            "updateEnv should set PASSWORD_STORE_DIR to configured store path");
-  QVERIFY2(
-      env.filter(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH=")).size() ==
-          1,
-      "updateEnv should set PASSWORD_STORE_GENERATED_LENGTH");
-  QVERIFY2(env.filter(QStringLiteral("PASSWORD_STORE_CHARACTER_SET=")).size() ==
-               1,
+  QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH")),
+           "updateEnv should set PASSWORD_STORE_GENERATED_LENGTH");
+  QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
            "updateEnv should set PASSWORD_STORE_CHARACTER_SET");
 }
 
@@ -1759,28 +1748,20 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
   config.Characters[PasswordConfiguration::CUSTOM] = QString();
   QtPassSettings::setPasswordConfiguration(config);
 
-  QStringList env = pass.environment();
-  QStringList charsetEntries =
-      env.filter(QStringLiteral("PASSWORD_STORE_CHARACTER_SET="));
-  QVERIFY2(
-      charsetEntries.size() == 1,
-      "PASSWORD_STORE_CHARACTER_SET should be set even when CUSTOM is empty");
-  QString val = charsetEntries.first().mid(
-      QStringLiteral("PASSWORD_STORE_CHARACTER_SET=").size());
-  QVERIFY2(!val.isEmpty(),
+  const QProcessEnvironment env = pass.environment();
+  QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")),
+           "PASSWORD_STORE_CHARACTER_SET should be set even when CUSTOM is empty");
+  QVERIFY2(!env.value(QStringLiteral("PASSWORD_STORE_CHARACTER_SET")).isEmpty(),
            "charset should fall back to ALLCHARS, not be empty");
 }
 
 void tst_util::updateEnvWslenvContainsRequiredVars() {
   TestPass pass;
-  const QStringList env = pass.environment();
-  // Use startsWith to avoid substring false-positives (e.g. MY_WSLENV=).
-  const QStringList wslenvEntries =
-      env.filter(QRegularExpression(QStringLiteral("^WSLENV=")));
-  QVERIFY2(!wslenvEntries.isEmpty(),
+  const QProcessEnvironment env = pass.environment();
+  QVERIFY2(env.contains(QStringLiteral("WSLENV")),
            "At least one WSLENV entry expected after Pass construction");
   // Verify Pass::Pass() merged all required keys with correct WSL flags.
-  const QString wslenv = wslenvEntries.first();
+  const QString wslenv = env.value(QStringLiteral("WSLENV"));
   QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_DIR/p")),
            "WSLENV should include PASSWORD_STORE_DIR/p");
   QVERIFY2(wslenv.contains(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH/w")),
@@ -2066,7 +2047,7 @@ void tst_util::grepMatchFileFailedDecryptReturnsEmpty() {
   // grepMatchFile with a non-existent file: executeBlocking fails (rc != 0)
   // so the result must be empty regardless of the regex
   QRegularExpression rx(QStringLiteral(".*"));
-  const QStringList env;
+  const QProcessEnvironment env;
   const QStringList matches =
       ImitatePass::grepMatchFile(env, QStringLiteral("/nonexistent/gpg"),
                                  QStringLiteral("/no/such.gpg"), rx);
@@ -2077,7 +2058,7 @@ void tst_util::grepScanStoreEmptyDirReturnsEmpty() {
   QTemporaryDir tmp;
   QVERIFY(tmp.isValid());
   QRegularExpression rx(QStringLiteral(".*"));
-  const QStringList env;
+  const QProcessEnvironment env;
   const auto results = ImitatePass::grepScanStore(
       env, QStringLiteral("/nonexistent/gpg"), tmp.path(), rx);
   QVERIFY(results.isEmpty());


### PR DESCRIPTION
## Summary

Closes #1510.

Replaces the `executeBlocking(QStringList env, …)` overload — which manually parsed `KEY=value` strings into a `QProcessEnvironment` — with a clean `executeBlocking(const QProcessEnvironment &env, …)` overload throughout the codebase.

- **`Executor`** (`executor.h` / `executor.cpp`): third `executeBlocking` overload parameter `QStringList` → `QProcessEnvironment`; same for `setEnvironment` / `environment()`
- **`Pass`** (`pass.h` / `pass.cpp`): `env` member `QStringList` → `QProcessEnvironment`; constructor (system env init), WSLENV merging, macOS PATH prepend, GNUPGHOME, and `setEnvVar` rewritten to use `insert` / `remove` / `value`; removes now-unused `#include <algorithm>`
- **`ImitatePass`** (`imitatepass.h` / `imitatepass.cpp`): `grepMatchFile` / `grepScanStore` signatures updated; local `env` variable type updated at call site
- **`SshAuthSock`** (`sshauthsock.cpp`): removes `.toStringList()` round-trip — `env` is already a `QProcessEnvironment`
- **`MainWindow`** (`mainwindow.cpp`): use the two-arg no-input `executeBlocking` overload instead of passing explicit empty `QString()`
- **Tests** (`tst_executor.cpp`, `tst_util.cpp`): updated to build `QProcessEnvironment` via `insert()` and query via `value()` / `contains()`

## Test plan

- [x] `make -j4` — clean build, zero errors or new warnings
- [x] `QT_QPA_PLATFORM=offscreen make check` — 347 tests pass across all suites; the one pre-existing `tst_settings::getPasswordConfigurationDefault` failure is unrelated (non-portable mode picks up user config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized external command environment handling to use the platform’s native environment container, including executor execution and password/grep workflows.

* **Bug Fixes**
  * Improved WSL environment merging and macOS PATH/GNUPGHOME handling to avoid duplicates and ensure correct variable updates.

* **Tests**
  * Updated unit tests for executor, pass/environment behavior, and grep helpers to validate the new environment handling end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->