### PR TITLE
refactor(pass): inject AppSettings into Pass hierarchy (PR A of #1511)

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -61,16 +61,18 @@ ImitatePass::~ImitatePass() {
 }
 
 auto ImitatePass::pgit(const QString &path) const -> QString {
+  QString normalizedPath = QDir::cleanPath(path);
   if (!m_settings.gitExecutable.startsWith(QStringLiteral("wsl ")))
-    return path;
-  QString res = QStringLiteral("$(wslpath ") + path + QLatin1Char(')');
+    return normalizedPath;
+  QString res = QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
   return res.replace('\\', '/');
 }
 
 auto ImitatePass::pgpg(const QString &path) const -> QString {
+  QString normalizedPath = QDir::cleanPath(path);
   if (!m_settings.gpgExecutable.startsWith(QStringLiteral("wsl ")))
-    return path;
-  QString res = QStringLiteral("$(wslpath ") + path + QLatin1Char(')');
+    return normalizedPath;
+  QString res = QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
   return res.replace('\\', '/');
 }
 
@@ -726,7 +728,7 @@ auto ImitatePass::createBackupCommit() -> bool {
 void ImitatePass::reencryptPath(const QString &dir) {
   emit statusMsg(tr("Re-encrypting from folder %1").arg(dir), 3000);
   emit startReencryptPath();
-  if (m_settings.autoPull) {
+  if (m_settings.autoPull && m_settings.useGit) {
     emit statusMsg(tr("Updating password-store"), 2000);
     GitPull_b();
   }
@@ -781,7 +783,7 @@ void ImitatePass::reencryptPath(const QString &dir) {
         3000);
   }
 
-  if (m_settings.autoPush) {
+  if (m_settings.autoPush && m_settings.useGit) {
     emit statusMsg(tr("Updating password-store"), 2000);
     GitPush();
   }

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "imitatepass.h"
 #include "executor.h"
-#include "qtpasssettings.h"
 #include "util.h"
 #include <QDirIterator>
 #include <QElapsedTimer>
@@ -61,19 +60,17 @@ ImitatePass::~ImitatePass() {
   }
 }
 
-static auto pgit(const QString &path) -> QString {
-  if (!QtPassSettings::getGitExecutable().startsWith("wsl ")) {
+auto ImitatePass::pgit(const QString &path) const -> QString {
+  if (!m_settings.gitExecutable.startsWith(QStringLiteral("wsl ")))
     return path;
-  }
-  QString res = "$(wslpath " + path + ")";
+  QString res = QStringLiteral("$(wslpath ") + path + QLatin1Char(')');
   return res.replace('\\', '/');
 }
 
-static auto pgpg(const QString &path) -> QString {
-  if (!QtPassSettings::getGpgExecutable().startsWith("wsl ")) {
+auto ImitatePass::pgpg(const QString &path) const -> QString {
+  if (!m_settings.gpgExecutable.startsWith(QStringLiteral("wsl ")))
     return path;
-  }
-  QString res = "$(wslpath " + path + ")";
+  QString res = QStringLiteral("$(wslpath ") + path + QLatin1Char(')');
   return res.replace('\\', '/');
 }
 
@@ -81,7 +78,7 @@ static auto pgpg(const QString &path) -> QString {
  * @brief ImitatePass::GitInit git init wrapper
  */
 void ImitatePass::GitInit() {
-  executeGit(GIT_INIT, {"init", pgit(QtPassSettings::getPassStore())});
+  executeGit(GIT_INIT, {"init", pgit(m_settings.passStore)});
 }
 
 /**
@@ -93,14 +90,14 @@ void ImitatePass::GitPull() { executeGit(GIT_PULL, {"pull"}); }
  * @brief ImitatePass::GitPull_b git pull wrapper
  */
 void ImitatePass::GitPull_b() {
-  Executor::executeBlocking(QtPassSettings::getGitExecutable(), {"pull"});
+  Executor::executeBlocking(m_settings.gitExecutable, {"pull"});
 }
 
 /**
  * @brief ImitatePass::GitPush git push wrapper
  */
 void ImitatePass::GitPush() {
-  if (QtPassSettings::isUseGit()) {
+  if (m_settings.useGit) {
     executeGit(GIT_PUSH, {"push"});
   }
 }
@@ -109,7 +106,7 @@ void ImitatePass::GitPush() {
  * @brief ImitatePass::Show shows content of file
  */
 void ImitatePass::Show(QString file) {
-  file = QtPassSettings::getPassStore() + file + ".gpg";
+  file = m_settings.passStore + file + ".gpg";
   QStringList args = {"-d",      "--quiet",     "--yes",   "--no-encrypt-to",
                       "--batch", "--use-agent", pgpg(file)};
   executeGpg(PASS_SHOW, args);
@@ -162,12 +159,12 @@ void ImitatePass::Insert(QString file, QString newValue, bool overwrite) {
   }
   args.append("-");
   executeGpg(PASS_INSERT, args, newValue);
-  if (!QtPassSettings::isUseWebDav() && QtPassSettings::isUseGit()) {
+  if (!m_settings.useWebDav && m_settings.useGit) {
     // Git is used when enabled - this is the standard pass workflow
     if (!overwrite) {
       executeGit(GIT_ADD, {"add", pgit(file)});
     }
-    QString path = QDir(QtPassSettings::getPassStore()).relativeFilePath(file);
+    QString path = QDir(m_settings.passStore).relativeFilePath(file);
     path.replace(Util::endsWithGpg(), "");
     QString msg =
         QString(overwrite ? "Edit" : "Add") + " for " + path + " using QtPass.";
@@ -193,15 +190,15 @@ void ImitatePass::gitCommit(const QString &file, const QString &msg) {
  * @brief ImitatePass::Remove custom implementation of "pass remove"
  */
 void ImitatePass::Remove(QString file, bool isDir) {
-  file = QtPassSettings::getPassStore() + file;
+  file = m_settings.passStore + file;
   transactionHelper trans(this, PASS_REMOVE);
   if (!isDir) {
     file += ".gpg";
   }
-  if (QtPassSettings::isUseGit()) {
+  if (m_settings.useGit) {
     executeGit(GIT_RM, {"rm", (isDir ? "-rf" : "-f"), pgit(file)});
     // Normalize path the same way as add/edit operations
-    QString path = QDir(QtPassSettings::getPassStore()).relativeFilePath(file);
+    QString path = QDir(m_settings.passStore).relativeFilePath(file);
     path.replace(Util::endsWithGpg(), "");
     gitCommit(file, "Remove for " + path + " using QtPass.");
   } else {
@@ -225,8 +222,7 @@ auto ImitatePass::checkSigningKeys(const QStringList &signingKeys) -> bool {
   QString out;
   QStringList args =
       QStringList{"--status-fd=1", "--list-secret-keys"} + signingKeys;
-  int result =
-      Executor::executeBlocking(QtPassSettings::getGpgExecutable(), args, &out);
+  int result = Executor::executeBlocking(m_settings.gpgExecutable, args, &out);
   if (result != 0) {
 #ifdef QT_DEBUG
     dbg() << "GPG list-secret-keys failed with code:" << result;
@@ -311,8 +307,7 @@ auto ImitatePass::signGpgIdFile(const QString &gpgIdFile,
     args.append(QStringList{"--default-key", signingKeys.first()});
   }
   args.append(QStringList{"--yes", "--detach-sign", gpgIdFile});
-  int result =
-      Executor::executeBlocking(QtPassSettings::getGpgExecutable(), args);
+  int result = Executor::executeBlocking(m_settings.gpgExecutable, args);
   if (result != 0) {
 #ifdef QT_DEBUG
     dbg() << "GPG signing failed with code:" << result;
@@ -376,10 +371,10 @@ void ImitatePass::gitAddGpgId(const QString &gpgIdFile,
 void ImitatePass::Init(QString path, const QList<UserInfo> &users) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   QStringList signingKeys =
-      QtPassSettings::getPassSigningKey().split(" ", Qt::SkipEmptyParts);
+      m_settings.passSigningKey.split(" ", Qt::SkipEmptyParts);
 #else
   QStringList signingKeys =
-      QtPassSettings::getPassSigningKey().split(" ", QString::SkipEmptyParts);
+      m_settings.passSigningKey.split(" ", QString::SkipEmptyParts);
 #endif
   QString gpgIdSigFile = path + ".gpg-id.sig";
   bool addSigFile = false;
@@ -399,7 +394,7 @@ void ImitatePass::Init(QString path, const QList<UserInfo> &users) {
   QString gpgIdFile = path + ".gpg-id";
   bool addFile = false;
   transactionHelper trans(this, PASS_INIT);
-  if (QtPassSettings::isAddGPGId(true)) {
+  if (m_settings.addGPGId) {
     QFileInfo checkFile(gpgIdFile);
     if (!checkFile.exists() || !checkFile.isFile()) {
       addFile = true;
@@ -413,8 +408,8 @@ void ImitatePass::Init(QString path, const QList<UserInfo> &users) {
     }
   }
 
-  if (!QtPassSettings::isUseWebDav() && QtPassSettings::isUseGit() &&
-      !QtPassSettings::getGitExecutable().isEmpty()) {
+  if (!m_settings.useWebDav && m_settings.useGit &&
+      !m_settings.gitExecutable.isEmpty()) {
     gitAddGpgId(gpgIdFile, gpgIdSigFile, addFile, addSigFile);
   }
   reencryptPath(path);
@@ -428,10 +423,10 @@ void ImitatePass::Init(QString path, const QList<UserInfo> &users) {
 auto ImitatePass::verifyGpgIdFile(const QString &file) -> bool {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   QStringList signingKeys =
-      QtPassSettings::getPassSigningKey().split(" ", Qt::SkipEmptyParts);
+      m_settings.passSigningKey.split(" ", Qt::SkipEmptyParts);
 #else
   QStringList signingKeys =
-      QtPassSettings::getPassSigningKey().split(" ", QString::SkipEmptyParts);
+      m_settings.passSigningKey.split(" ", QString::SkipEmptyParts);
 #endif
   if (signingKeys.isEmpty()) {
     return true;
@@ -439,8 +434,7 @@ auto ImitatePass::verifyGpgIdFile(const QString &file) -> bool {
   QString out;
   QStringList args =
       QStringList{"--verify", "--status-fd=1", pgpg(file) + ".sig", pgpg(file)};
-  int result =
-      Executor::executeBlocking(QtPassSettings::getGpgExecutable(), args, &out);
+  int result = Executor::executeBlocking(m_settings.gpgExecutable, args, &out);
   if (result != 0) {
 #ifdef QT_DEBUG
     dbg() << "GPG verify failed with code:" << result;
@@ -536,8 +530,8 @@ auto ImitatePass::getKeysFromFile(const QString &fileName) -> QStringList {
       "--list-only", "--keyid-format=long", pgpg(fileName)};
   QString keys;
   QString err;
-  const int result = Executor::executeBlocking(
-      QtPassSettings::getGpgExecutable(), args, &keys, &err);
+  const int result =
+      Executor::executeBlocking(m_settings.gpgExecutable, args, &keys, &err);
   if (result != 0 && keys.isEmpty() && err.isEmpty()) {
     return {};
   }
@@ -585,8 +579,8 @@ auto ImitatePass::reencryptSingleFile(const QString &fileName,
   QStringList args = {
       "-d",      "--quiet",     "--yes",       "--no-encrypt-to",
       "--batch", "--use-agent", pgpg(fileName)};
-  int result = Executor::executeBlocking(QtPassSettings::getGpgExecutable(),
-                                         args, &local_lastDecrypt);
+  int result = Executor::executeBlocking(m_settings.gpgExecutable, args,
+                                         &local_lastDecrypt);
 
   if (result != 0 || local_lastDecrypt.isEmpty()) {
 #ifdef QT_DEBUG
@@ -615,7 +609,7 @@ auto ImitatePass::reencryptSingleFile(const QString &fileName,
     args.append(i);
   }
   args.append("-");
-  result = Executor::executeBlocking(QtPassSettings::getGpgExecutable(), args,
+  result = Executor::executeBlocking(m_settings.gpgExecutable, args,
                                      local_lastDecrypt);
 
   if (result != 0) {
@@ -629,8 +623,8 @@ auto ImitatePass::reencryptSingleFile(const QString &fileName,
   // Verify encryption worked by attempting to decrypt the temp file
   QString verifyOutput;
   args = QStringList{"-d", "--quiet", "--batch", "--use-agent", pgpg(tempPath)};
-  result = Executor::executeBlocking(QtPassSettings::getGpgExecutable(), args,
-                                     &verifyOutput);
+  result =
+      Executor::executeBlocking(m_settings.gpgExecutable, args, &verifyOutput);
   if (result != 0 || verifyOutput.isEmpty()) {
 #ifdef QT_DEBUG
     dbg() << "Verification failed for:" << tempPath;
@@ -672,13 +666,12 @@ auto ImitatePass::reencryptSingleFile(const QString &fileName,
   // Success - remove backup
   QFile::remove(backupPath);
 
-  if (!QtPassSettings::isUseWebDav() && QtPassSettings::isUseGit()) {
-    Executor::executeBlocking(QtPassSettings::getGitExecutable(),
+  if (!m_settings.useWebDav && m_settings.useGit) {
+    Executor::executeBlocking(m_settings.gitExecutable,
                               {"add", pgit(fileName)});
-    QString path =
-        QDir(QtPassSettings::getPassStore()).relativeFilePath(fileName);
+    QString path = QDir(m_settings.passStore).relativeFilePath(fileName);
     path.replace(Util::endsWithGpg(), "");
-    Executor::executeBlocking(QtPassSettings::getGitExecutable(),
+    Executor::executeBlocking(m_settings.gitExecutable,
                               {"commit", pgit(fileName), "-m",
                                "Re-encrypt for " + path + " using QtPass."});
   }
@@ -691,12 +684,11 @@ auto ImitatePass::reencryptSingleFile(const QString &fileName,
  * @return true if backup created or not needed, false if backup failed.
  */
 auto ImitatePass::createBackupCommit() -> bool {
-  if (!QtPassSettings::isUseGit() ||
-      QtPassSettings::getGitExecutable().isEmpty()) {
+  if (!m_settings.useGit || m_settings.gitExecutable.isEmpty()) {
     return true;
   }
   emit statusMsg(tr("Creating backup commit"), 2000);
-  const QString git = QtPassSettings::getGitExecutable();
+  const QString git = m_settings.gitExecutable;
   QString statusOut;
   if (Executor::executeBlocking(git, {"status", "--porcelain"}, &statusOut) !=
       0) {
@@ -734,7 +726,7 @@ auto ImitatePass::createBackupCommit() -> bool {
 void ImitatePass::reencryptPath(const QString &dir) {
   emit statusMsg(tr("Re-encrypting from folder %1").arg(dir), 3000);
   emit startReencryptPath();
-  if (QtPassSettings::isAutoPull()) {
+  if (m_settings.autoPull) {
     emit statusMsg(tr("Updating password-store"), 2000);
     GitPull_b();
   }
@@ -789,7 +781,7 @@ void ImitatePass::reencryptPath(const QString &dir) {
         3000);
   }
 
-  if (QtPassSettings::isAutoPush()) {
+  if (m_settings.autoPush) {
     emit statusMsg(tr("Updating password-store"), 2000);
     GitPush();
   }
@@ -879,10 +871,9 @@ void ImitatePass::executeMoveGit(const QString &src, const QString &destFile,
   args << pgit(destFile);
   executeGit(GIT_MOVE, args);
 
-  QString relSrc = QDir(QtPassSettings::getPassStore()).relativeFilePath(src);
+  QString relSrc = QDir(m_settings.passStore).relativeFilePath(src);
   relSrc.replace(Util::endsWithGpg(), "");
-  QString relDest =
-      QDir(QtPassSettings::getPassStore()).relativeFilePath(destFile);
+  QString relDest = QDir(m_settings.passStore).relativeFilePath(destFile);
   relDest.replace(Util::endsWithGpg(), "");
   QString message = QString("Moved for %1 to %2 using QtPass.");
   message = message.arg(relSrc, relDest);
@@ -913,7 +904,7 @@ void ImitatePass::Move(const QString src, const QString dest,
   dbg() << "Move Destination: " << destFile;
 #endif
 
-  if (QtPassSettings::isUseGit()) {
+  if (m_settings.useGit) {
     executeMoveGit(src, destFile, force);
   } else {
     QDir qDir;
@@ -940,7 +931,7 @@ void ImitatePass::Copy(const QString src, const QString dest,
                        const bool force) {
   QFileInfo destFileInfo(dest);
   transactionHelper trans(this, PASS_COPY);
-  if (QtPassSettings::isUseGit()) {
+  if (m_settings.useGit) {
     QStringList args;
     args << "cp";
     if (force) {
@@ -974,7 +965,7 @@ void ImitatePass::Copy(const QString src, const QString dest,
  */
 void ImitatePass::executeGpg(PROCESS id, const QStringList &args, QString input,
                              bool readStdout, bool readStderr) {
-  executeWrapper(id, QtPassSettings::getGpgExecutable(), args, std::move(input),
+  executeWrapper(id, m_settings.gpgExecutable, args, std::move(input),
                  readStdout, readStderr);
 }
 
@@ -984,7 +975,7 @@ void ImitatePass::executeGpg(PROCESS id, const QStringList &args, QString input,
  */
 void ImitatePass::executeGit(PROCESS id, const QStringList &args, QString input,
                              bool readStdout, bool readStderr) {
-  executeWrapper(id, QtPassSettings::getGitExecutable(), args, std::move(input),
+  executeWrapper(id, m_settings.gitExecutable, args, std::move(input),
                  readStdout, readStderr);
 }
 
@@ -1043,11 +1034,16 @@ void ImitatePass::beforeExecute(PROCESS id) { transactionAdd(id); }
 auto ImitatePass::grepMatchFile(const QProcessEnvironment &env,
                                 const QString &gpgExe, const QString &filePath,
                                 const QRegularExpression &rx) -> QStringList {
+  QString translatedPath = filePath;
+  if (gpgExe.startsWith(QStringLiteral("wsl "))) {
+    translatedPath = QStringLiteral("$(wslpath ") + filePath + QLatin1Char(')');
+    translatedPath.replace('\\', '/');
+  }
   QString plaintext;
   const int rc =
       Executor::executeBlocking(env, gpgExe,
                                 {"-d", "--quiet", "--yes", "--no-encrypt-to",
-                                 "--batch", "--use-agent", pgpg(filePath)},
+                                 "--batch", "--use-agent", translatedPath},
                                 &plaintext);
   if (rc != 0 || plaintext.isEmpty())
     return {};
@@ -1141,8 +1137,8 @@ void ImitatePass::Grep(QString pattern, bool caseInsensitive) {
         Qt::QueuedConnection);
     return;
   }
-  const QString gpgExe = QtPassSettings::getGpgExecutable();
-  const QString storeDir = QtPassSettings::getPassStore();
+  const QString gpgExe = m_settings.gpgExecutable;
+  const QString storeDir = m_settings.passStore;
   const QProcessEnvironment env = exec.environment();
   QPointer<ImitatePass> self(this);
 

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -64,7 +64,8 @@ auto ImitatePass::pgit(const QString &path) const -> QString {
   QString normalizedPath = QDir::cleanPath(path);
   if (!m_settings.gitExecutable.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
-  QString res = QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
+  QString res =
+      QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
   return res.replace('\\', '/');
 }
 
@@ -72,7 +73,8 @@ auto ImitatePass::pgpg(const QString &path) const -> QString {
   QString normalizedPath = QDir::cleanPath(path);
   if (!m_settings.gpgExecutable.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
-  QString res = QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
+  QString res =
+      QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
   return res.replace('\\', '/');
 }
 

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -298,6 +298,21 @@ private:
   int m_grepSeq = 0;
   QList<QThread *> m_grepThreads;
 
+  /**
+   * @brief Translate @p path for git when WSL-routed: wraps in wslpath
+   * substitution, otherwise returns @p path unchanged.
+   * @param path Native filesystem path.
+   * @return Path suitable for the configured git executable.
+   */
+  auto pgit(const QString &path) const -> QString;
+  /**
+   * @brief Translate @p path for gpg when WSL-routed: wraps in wslpath
+   * substitution, otherwise returns @p path unchanged.
+   * @param path Native filesystem path.
+   * @return Path suitable for the configured gpg executable.
+   */
+  auto pgpg(const QString &path) const -> QString;
+
   static auto grepMatchFile(const QProcessEnvironment &env,
                             const QString &gpgExe, const QString &filePath,
                             const QRegularExpression &rx) -> QStringList;

--- a/src/keygendialog.cpp
+++ b/src/keygendialog.cpp
@@ -38,7 +38,8 @@ KeygenDialog::KeygenDialog(ConfigDialog *parent)
     // Let window manager handle positioning for first launch
   }
 
-  ui->plainTextEdit->setPlainText(Pass::getDefaultKeyTemplate());
+  ui->plainTextEdit->setPlainText(
+      Pass::getDefaultKeyTemplate(QtPassSettings::getGpgExecutable()));
 }
 
 /**

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "pass.h"
 #include "gpgkeystate.h"
-#include "qtpasssettings.h"
+#include "qtpasssettings.h" // TODO(#1511 PR-C): remove once getGpgIdPath is migrated
 #include "util.h"
 #include <QCoreApplication>
 #include <QDebug>
@@ -115,16 +115,18 @@ void Pass::executeWrapper(PROCESS id, const QString &app,
 #ifdef QT_DEBUG
   dbg() << app << args;
 #endif
-  exec.execute(id, QtPassSettings::getPassStore(), app, args, std::move(input),
+  exec.execute(id, m_settings.passStore, app, args, std::move(input),
                readStdout, readStderr);
 }
 
 void Pass::beforeExecute(PROCESS /*id*/) {}
 
 /**
- * @brief Initializes the pass wrapper environment.
+ * @brief Initializes the pass wrapper with a settings snapshot.
+ * @param settings Application settings to use for this backend lifetime.
  */
-void Pass::init() {
+void Pass::init(const AppSettings &settings) {
+  m_settings = settings;
 #ifdef __APPLE__
   // If it exists, prepend gpgtools to PATH
   if (QFile(QStringLiteral("/usr/local/MacGPG2/bin")).exists())
@@ -142,8 +144,8 @@ void Pass::init() {
   }
 #endif
 
-  if (!QtPassSettings::getGpgHome().isEmpty()) {
-    QDir absHome(QtPassSettings::getGpgHome());
+  if (!m_settings.gpgHome.isEmpty()) {
+    QDir absHome(m_settings.gpgHome);
     absHome.makeAbsolute();
     env.insert(QStringLiteral("GNUPGHOME"), absHome.path());
   }
@@ -164,23 +166,21 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
     return {};
   }
   QString passwd;
-  if (QtPassSettings::isUsePwgen()) {
+  if (m_settings.usePwgen) {
     // --secure goes first as it overrides --no-* otherwise
     QStringList args;
     args.append("-1");
-    if (!QtPassSettings::isLessRandom()) {
+    if (!m_settings.lessRandom) {
       args.append("--secure");
     }
-    args.append(QtPassSettings::isAvoidCapitals() ? "--no-capitalize"
-                                                  : "--capitalize");
-    args.append(QtPassSettings::isAvoidNumbers() ? "--no-numerals"
-                                                 : "--numerals");
-    if (QtPassSettings::isUseSymbols()) {
+    args.append(m_settings.avoidCapitals ? "--no-capitalize" : "--capitalize");
+    args.append(m_settings.avoidNumbers ? "--no-numerals" : "--numerals");
+    if (m_settings.useSymbols) {
       args.append("--symbols");
     }
     args.append(QString::number(length));
     // executeBlocking returns 0 on success, non-zero on failure
-    if (Executor::executeBlocking(QtPassSettings::getPwgenExecutable(), args,
+    if (Executor::executeBlocking(m_settings.pwgenExecutable, args,
                                   &passwd) == 0) {
       static const QRegularExpression literalNewLines{"[\\n\\r]"};
       passwd.remove(literalNewLines);
@@ -197,8 +197,8 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
     // Validate charset - if CUSTOM is selected but chars are empty,
     // fall back to ALLCHARS to prevent weak passwords (issue #780)
     const QString cs = fallbackCharset(
-        charset, QtPassSettings::getPasswordConfiguration()
-                     .Characters[PasswordConfiguration::ALLCHARS]);
+        charset,
+        m_settings.passwordConfiguration.Characters[PasswordConfiguration::ALLCHARS]);
     if (cs.length() > 0) {
       passwd = generateRandomPassword(cs, length);
     } else {
@@ -216,10 +216,10 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
  * GPG 2.1+ supports ed25519 which is much faster for key generation
  * @return true if ed25519 is supported
  */
-bool Pass::gpgSupportsEd25519() {
+bool Pass::gpgSupportsEd25519(const QString &gpgExecutable) {
+  const QString exe = gpgExecutable.isEmpty() ? QStringLiteral("gpg") : gpgExecutable;
   QString out, err;
-  if (Executor::executeBlocking(QtPassSettings::getGpgExecutable(),
-                                {"--version"}, &out, &err) != 0) {
+  if (Executor::executeBlocking(exe, {"--version"}, &out, &err) != 0) {
     return false;
   }
   QRegularExpression versionRegex(R"(gpg \(GnuPG\) (\d+)\.(\d+))");
@@ -237,8 +237,8 @@ bool Pass::gpgSupportsEd25519() {
  * Uses ed25519 if supported, otherwise falls back to RSA
  * @return GPG batch template string
  */
-QString Pass::getDefaultKeyTemplate() {
-  if (gpgSupportsEd25519()) {
+QString Pass::getDefaultKeyTemplate(const QString &gpgExecutable) {
+  if (gpgSupportsEd25519(gpgExecutable)) {
     return QStringLiteral("%echo Generating a default key\n"
                           "Key-Type: EdDSA\n"
                           "Key-Curve: Ed25519\n"
@@ -445,7 +445,7 @@ auto Pass::resolveGpgconfCommand(const QString &gpgPath)
 void Pass::GenerateGPGKeys(QString batch) {
   // Kill any stale GPG agents that might be holding locks on the key database
   // This helps avoid "database locked" timeouts during key generation
-  QString gpgPath = QtPassSettings::getGpgExecutable();
+  const QString gpgPath = m_settings.gpgExecutable;
   if (!gpgPath.isEmpty()) {
     ResolvedGpgconfCommand resolvedGpgconf = resolveGpgconfCommand(gpgPath);
     QStringList killArgs = resolvedGpgconf.arguments;
@@ -478,8 +478,7 @@ auto Pass::listKeys(QStringList keystrings, bool secret) -> QList<UserInfo> {
     }
   }
   QString p_out;
-  if (Executor::executeBlocking(QtPassSettings::getGpgExecutable(), args,
-                                &p_out) != 0) {
+  if (Executor::executeBlocking(m_settings.gpgExecutable, args, &p_out) != 0) {
     return {};
   }
   return parseGpgColonOutput(p_out, secret);
@@ -825,11 +824,10 @@ void Pass::setEnvVar(const QString &key, const QString &value) {
  */
 void Pass::updateEnv() {
   setEnvVar(QStringLiteral("PASSWORD_STORE_SIGNING_KEY="),
-            QtPassSettings::getPassSigningKey());
-  setEnvVar(QStringLiteral("PASSWORD_STORE_DIR="),
-            QtPassSettings::getPassStore());
+            m_settings.passSigningKey);
+  setEnvVar(QStringLiteral("PASSWORD_STORE_DIR="), m_settings.passStore);
 
-  PasswordConfiguration passConfig = QtPassSettings::getPasswordConfiguration();
+  const PasswordConfiguration &passConfig = m_settings.passwordConfiguration;
   setEnvVar(QStringLiteral("PASSWORD_STORE_GENERATED_LENGTH="),
             QString::number(passConfig.length));
 

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -180,8 +180,8 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
     }
     args.append(QString::number(length));
     // executeBlocking returns 0 on success, non-zero on failure
-    if (Executor::executeBlocking(m_settings.pwgenExecutable, args,
-                                  &passwd) == 0) {
+    if (Executor::executeBlocking(m_settings.pwgenExecutable, args, &passwd) ==
+        0) {
       static const QRegularExpression literalNewLines{"[\\n\\r]"};
       passwd.remove(literalNewLines);
     } else {
@@ -197,8 +197,8 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
     // Validate charset - if CUSTOM is selected but chars are empty,
     // fall back to ALLCHARS to prevent weak passwords (issue #780)
     const QString cs = fallbackCharset(
-        charset,
-        m_settings.passwordConfiguration.Characters[PasswordConfiguration::ALLCHARS]);
+        charset, m_settings.passwordConfiguration
+                     .Characters[PasswordConfiguration::ALLCHARS]);
     if (cs.length() > 0) {
       passwd = generateRandomPassword(cs, length);
     } else {
@@ -217,7 +217,8 @@ auto Pass::generatePassword(unsigned int length, const QString &charset)
  * @return true if ed25519 is supported
  */
 bool Pass::gpgSupportsEd25519(const QString &gpgExecutable) {
-  const QString exe = gpgExecutable.isEmpty() ? QStringLiteral("gpg") : gpgExecutable;
+  const QString exe =
+      gpgExecutable.isEmpty() ? QStringLiteral("gpg") : gpgExecutable;
   QString out, err;
   if (Executor::executeBlocking(exe, {"--version"}, &out, &err) != 0) {
     return false;

--- a/src/pass.h
+++ b/src/pass.h
@@ -3,6 +3,7 @@
 #ifndef SRC_PASS_H_
 #define SRC_PASS_H_
 
+#include "appsettings.h"
 #include "enums.h"
 #include "executor.h"
 #include "userinfo.h"
@@ -56,6 +57,13 @@ class Pass : public QObject {
 
 protected:
   /**
+   * @brief Application settings snapshot injected at init() time.
+   *
+   * Populated by init(AppSettings) and valid for the lifetime of this backend
+   * instance. Subclasses read it in place of calling QtPassSettings directly.
+   */
+  AppSettings m_settings;
+  /**
    * @brief Internal command executor for queuing and running subprocesses.
    */
   Executor exec;
@@ -71,19 +79,22 @@ public:
    */
   Pass();
   /**
-   * @brief Initialize the Pass instance.
+   * @brief Initialize the Pass instance with a settings snapshot.
+   * @param settings Application settings to use for this backend lifetime.
    */
-  void init();
+  void init(const AppSettings &settings);
   /**
    * @brief Check if GPG supports Ed25519 encryption.
+   * @param gpgExecutable Path to the gpg binary (defaults to "gpg").
    * @return true if Ed25519 is supported.
    */
-  static bool gpgSupportsEd25519();
+  static bool gpgSupportsEd25519(const QString &gpgExecutable = {});
   /**
    * @brief Get default key template for new GPG keys.
+   * @param gpgExecutable Path to the gpg binary (defaults to "gpg").
    * @return Default template string.
    */
-  static QString getDefaultKeyTemplate();
+  static QString getDefaultKeyTemplate(const QString &gpgExecutable = {});
 
   ~Pass() override = default;
 

--- a/src/passbackendfactory.cpp
+++ b/src/passbackendfactory.cpp
@@ -25,7 +25,7 @@ auto PassBackendFactory::getPass() -> Pass * {
     // Ensure store directory exists (first-run side effect — load() normalises
     // the path but does not create the directory).
     if (!QDir(s.passStore).exists())
-      QDir().mkdir(s.passStore);
+      QDir().mkpath(s.passStore);
     if (s.usePass) {
       pass = getRealPass();
     } else {

--- a/src/passbackendfactory.cpp
+++ b/src/passbackendfactory.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "passbackendfactory.h"
+#include "appsettings.h"
 #include "pass.h"
 #include "qtpasssettings.h"
 
@@ -18,13 +19,15 @@ QScopedPointer<ImitatePass> PassBackendFactory::imitatePass;
 
 auto PassBackendFactory::getPass() -> Pass * {
   if (!pass) {
-    if (QtPassSettings::isUsePass()) {
+    AppSettings s = QtPassSettings::load();
+    s.passStore = QtPassSettings::getPassStore();
+    if (s.usePass) {
       pass = getRealPass();
     } else {
       pass = getImitatePass();
     }
     if (pass) {
-      pass->init();
+      pass->init(s);
     }
   }
   return pass;

--- a/src/passbackendfactory.cpp
+++ b/src/passbackendfactory.cpp
@@ -13,6 +13,8 @@
 #include "pass.h"
 #include "qtpasssettings.h"
 
+#include <QDir>
+
 Pass *PassBackendFactory::pass = nullptr;
 QScopedPointer<RealPass> PassBackendFactory::realPass;
 QScopedPointer<ImitatePass> PassBackendFactory::imitatePass;
@@ -20,7 +22,10 @@ QScopedPointer<ImitatePass> PassBackendFactory::imitatePass;
 auto PassBackendFactory::getPass() -> Pass * {
   if (!pass) {
     AppSettings s = QtPassSettings::load();
-    s.passStore = QtPassSettings::getPassStore();
+    // Ensure store directory exists (first-run side effect — load() normalises
+    // the path but does not create the directory).
+    if (!QDir(s.passStore).exists())
+      QDir().mkdir(s.passStore);
     if (s.usePass) {
       pass = getRealPass();
     } else {

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -57,7 +57,7 @@ auto QtPassSettings::getInstance() -> QtPassSettings * {
 auto QtPassSettings::load() -> AppSettings {
   AppSettings s = SettingsSerializer::load(*getInstance());
   if (!s.passStore.isEmpty()) {
-    s.passStore = QDir(s.passStore).absolutePath();
+    s.passStore = QDir::cleanPath(QDir(s.passStore).absolutePath());
     if (!s.passStore.endsWith('/'))
       s.passStore += '/';
   }

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -55,7 +55,13 @@ auto QtPassSettings::getInstance() -> QtPassSettings * {
 }
 
 auto QtPassSettings::load() -> AppSettings {
-  return SettingsSerializer::load(*getInstance());
+  AppSettings s = SettingsSerializer::load(*getInstance());
+  if (!s.passStore.isEmpty()) {
+    s.passStore = QDir(s.passStore).absolutePath();
+    if (!s.passStore.endsWith('/'))
+      s.passStore += '/';
+  }
+  return s;
 }
 
 void QtPassSettings::save(const AppSettings &settings) {

--- a/src/realpass.cpp
+++ b/src/realpass.cpp
@@ -102,7 +102,17 @@ void RealPass::Init(QString path, const QList<UserInfo> &users) {
   // remove the passStore directory otherwise,
   // pass would create a passStore/passStore/dir
   // but you want passStore/dir
-  QString dirWithoutPassdir = path.remove(0, m_settings.passStore.size());
+  QString normalizedPath = QDir::cleanPath(path);
+  QString normalizedStore = QDir::cleanPath(m_settings.passStore);
+  QString dirWithoutPassdir;
+  if (normalizedPath.startsWith(normalizedStore)) {
+    dirWithoutPassdir = normalizedPath.mid(normalizedStore.size());
+    if (dirWithoutPassdir.startsWith('/')) {
+      dirWithoutPassdir.remove(0, 1);
+    }
+  } else {
+    dirWithoutPassdir = normalizedPath;
+  }
   QStringList args = {"init", "--path=" + dirWithoutPassdir};
   foreach (const UserInfo &user, users) {
     if (user.enabled) {
@@ -153,10 +163,12 @@ void RealPass::passMoveOrCopy(PROCESS id, const QString &subcommand,
     return;
   }
 
-  QString passSrc =
-      QDir(m_settings.passStore).relativeFilePath(QDir(src).absolutePath());
-  QString passDest =
-      QDir(m_settings.passStore).relativeFilePath(QDir(dest).absolutePath());
+  QString normalizedStore = QDir::cleanPath(m_settings.passStore);
+  QString normalizedSrc = QDir::cleanPath(QDir(src).absolutePath());
+  QString normalizedDest = QDir::cleanPath(QDir(dest).absolutePath());
+
+  QString passSrc = QDir(normalizedStore).relativeFilePath(normalizedSrc);
+  QString passDest = QDir(normalizedStore).relativeFilePath(normalizedDest);
 
   // remove the .gpg because pass will not work
   if (srcFileInfo.isFile() && srcFileInfo.suffix() == "gpg") {

--- a/src/realpass.cpp
+++ b/src/realpass.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "realpass.h"
 #include "debughelper.h"
-#include "qtpasssettings.h"
 #include "util.h"
 
 #include <QDir>
@@ -34,8 +33,8 @@ void RealPass::GitInit() { executePass(GIT_INIT, {"git", "init"}); }
  *                          finishes
  */
 void RealPass::GitPull_b() {
-  int result = Executor::executeBlocking(QtPassSettings::getPassExecutable(),
-                                         {"git", "pull"});
+  int result =
+      Executor::executeBlocking(m_settings.passExecutable, {"git", "pull"});
   if (result != 0) {
 #ifdef QT_DEBUG
     dbg() << "Git pull failed with code:" << result;
@@ -103,8 +102,7 @@ void RealPass::Init(QString path, const QList<UserInfo> &users) {
   // remove the passStore directory otherwise,
   // pass would create a passStore/passStore/dir
   // but you want passStore/dir
-  QString dirWithoutPassdir =
-      path.remove(0, QtPassSettings::getPassStore().size());
+  QString dirWithoutPassdir = path.remove(0, m_settings.passStore.size());
   QStringList args = {"init", "--path=" + dirWithoutPassdir};
   foreach (const UserInfo &user, users) {
     if (user.enabled) {
@@ -155,10 +153,10 @@ void RealPass::passMoveOrCopy(PROCESS id, const QString &subcommand,
     return;
   }
 
-  QString passSrc = QDir(QtPassSettings::getPassStore())
-                        .relativeFilePath(QDir(src).absolutePath());
-  QString passDest = QDir(QtPassSettings::getPassStore())
-                         .relativeFilePath(QDir(dest).absolutePath());
+  QString passSrc =
+      QDir(m_settings.passStore).relativeFilePath(QDir(src).absolutePath());
+  QString passDest =
+      QDir(m_settings.passStore).relativeFilePath(QDir(dest).absolutePath());
 
   // remove the .gpg because pass will not work
   if (srcFileInfo.isFile() && srcFileInfo.suffix() == "gpg") {
@@ -205,6 +203,6 @@ void RealPass::Grep(QString pattern, bool caseInsensitive) {
  */
 void RealPass::executePass(PROCESS id, const QStringList &args, QString input,
                            bool readStdout, bool readStderr) {
-  executeWrapper(id, QtPassSettings::getPassExecutable(), args,
-                 std::move(input), readStdout, readStderr);
+  executeWrapper(id, m_settings.passExecutable, args, std::move(input),
+                 readStdout, readStderr);
 }

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -155,7 +155,6 @@ class tst_integration : public QObject {
   // Initialize a Pass object with the test keyring and store.
   static void setupPass(Pass &pass) {
     AppSettings s = QtPassSettings::load();
-    s.passStore = QtPassSettings::getPassStore();
     pass.init(s);
     pass.updateEnv();
   }
@@ -176,7 +175,6 @@ class tst_integration : public QObject {
         return QStringLiteral("failed to write .gpg-id");
     }
     AppSettings s = QtPassSettings::load();
-    s.passStore = QtPassSettings::getPassStore();
     pass.init(s);
     pass.updateEnv();
     return QString();

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -154,7 +154,9 @@ class tst_integration : public QObject {
 
   // Initialize a Pass object with the test keyring and store.
   static void setupPass(Pass &pass) {
-    pass.init();
+    AppSettings s = QtPassSettings::load();
+    s.passStore = QtPassSettings::getPassStore();
+    pass.init(s);
     pass.updateEnv();
   }
 
@@ -173,7 +175,9 @@ class tst_integration : public QObject {
       if (bytesWritten != payload.size())
         return QStringLiteral("failed to write .gpg-id");
     }
-    pass.init();
+    AppSettings s = QtPassSettings::load();
+    s.passStore = QtPassSettings::getPassStore();
+    pass.init(s);
     pass.updateEnv();
     return QString();
   }

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1724,6 +1724,9 @@ void tst_util::updateEnvSetsExpectedVars() {
   QVERIFY(tmpDir.isValid());
   PassStoreGuard storeGuard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(tmpDir.path());
+  AppSettings s = QtPassSettings::load();
+  s.passStore = QtPassSettings::getPassStore();
+  pass.init(s);
 
   const QProcessEnvironment env = pass.environment();
   QVERIFY2(env.contains(QStringLiteral("PASSWORD_STORE_DIR")),
@@ -1748,6 +1751,9 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
   config.selected = PasswordConfiguration::CUSTOM;
   config.Characters[PasswordConfiguration::CUSTOM] = QString();
   QtPassSettings::setPasswordConfiguration(config);
+  AppSettings s = QtPassSettings::load();
+  s.passStore = QtPassSettings::getPassStore();
+  pass.init(s);
 
   const QProcessEnvironment env = pass.environment();
   QVERIFY2(
@@ -1759,6 +1765,9 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
 
 void tst_util::updateEnvWslenvContainsRequiredVars() {
   TestPass pass;
+  AppSettings s = QtPassSettings::load();
+  s.passStore = QtPassSettings::getPassStore();
+  pass.init(s);
   const QProcessEnvironment env = pass.environment();
   QVERIFY2(env.contains(QStringLiteral("WSLENV")),
            "At least one WSLENV entry expected after Pass construction");

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1725,7 +1725,6 @@ void tst_util::updateEnvSetsExpectedVars() {
   PassStoreGuard storeGuard(QtPassSettings::getPassStore());
   QtPassSettings::setPassStore(tmpDir.path());
   AppSettings s = QtPassSettings::load();
-  s.passStore = QtPassSettings::getPassStore();
   pass.init(s);
 
   const QProcessEnvironment env = pass.environment();
@@ -1752,7 +1751,6 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
   config.Characters[PasswordConfiguration::CUSTOM] = QString();
   QtPassSettings::setPasswordConfiguration(config);
   AppSettings s = QtPassSettings::load();
-  s.passStore = QtPassSettings::getPassStore();
   pass.init(s);
 
   const QProcessEnvironment env = pass.environment();
@@ -1766,7 +1764,6 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
 void tst_util::updateEnvWslenvContainsRequiredVars() {
   TestPass pass;
   AppSettings s = QtPassSettings::load();
-  s.passStore = QtPassSettings::getPassStore();
   pass.init(s);
   const QProcessEnvironment env = pass.environment();
   QVERIFY2(env.contains(QStringLiteral("WSLENV")),


### PR DESCRIPTION
## Summary

- **`Pass::init(AppSettings)`** replaces no-arg `init()`; backends store `m_settings` and read executables/paths from it instead of calling individual `QtPassSettings::getX()` at runtime.
- **`ImitatePass`**: `pgit`/`pgpg` converted from static free functions to `const` member functions that read `m_settings.gitExecutable`/`m_settings.gpgExecutable`; the static `grepMatchFile` inlines the wslpath check using its own `gpgExe` parameter.
- **`PassBackendFactory::getPass()`** loads an `AppSettings` snapshot via `QtPassSettings::load()`, normalises `passStore` via `QtPassSettings::getPassStore()`, then passes the snapshot to `pass->init(s)`.
- `realpass.cpp` and `imitatepass.cpp` no longer `#include "qtpasssettings.h"`.
- Integration test and `tst_util` updated to call `pass.init(s)` after configuring `QtPassSettings`, so `m_settings` is populated before `updateEnv()`.

Two `QtPassSettings::` calls remain in `passbackendfactory.cpp` (`load()` + `getPassStore()`); these are the intended facade entry point until PR C migrates `getGpgIdPath`.

Closes part of #1511.

## Test plan

- [ ] `make check` passes (only pre-existing `getPasswordConfigurationDefault` failure in non-portable mode due to local settings pollution — unrelated)
- [ ] `imitatepass.cpp` and `realpass.cpp` have zero `QtPassSettings::` calls
- [ ] `passbackendfactory.cpp` retains only `QtPassSettings::load()` and `QtPassSettings::getPassStore()` as the facade entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend workflows now use the app’s active configuration snapshot for the password store location, Git/GPG executables, and feature flags.
  * Improved WSL path handling for Git/GPG execution and more consistent gating for Git operations and `.gpg-id` signing/verification.
  * Environment variables and default key-generation templates are now derived from the configured GPG executable; backend initialization now passes settings into the backend.
  * Password store directory is ensured at startup, and real/imitate workflows normalize paths consistently.
* **Tests**
  * Updated integration and utility tests to initialize the password backend with loaded settings before environment and store assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->