### PR TITLE
refactor(#1511): wire AppSettings into ConfigDialog + SshAuthSock (PR B)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "mainwindow.h"
+#include "qtpasssettings.h"
 #include "sshauthsock.h"
 #if SINGLE_APP
 #include "singleapplication.h"
@@ -148,7 +149,7 @@ auto main(int argc, char *argv[]) -> int {
   // Probe / set SSH_AUTH_SOCK before any subprocess runs (issue #543).
   // GUI launchers don't inherit shell-set env vars, so users with
   // gpg-agent's SSH support get failed git push/pull until this fires.
-  SshAuthSock::initialise();
+  SshAuthSock::initialise(QtPassSettings::getSshAuthSockOverride());
 
   // Setup and load translator for localization.
   //

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -47,7 +47,8 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
     // Let window manager handle positioning for first launch
   }
 
-  applySettings(QtPassSettings::load());
+  const AppSettings s = QtPassSettings::load();
+  applySettings(s);
 
   if (!QSystemTrayIcon::isSystemTrayAvailable()) {
     ui->checkBoxUseTrayIcon->setEnabled(false);
@@ -85,7 +86,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
   ui->comboBoxClipboard->addItem(tr("Always copy to clipboard"));
   ui->comboBoxClipboard->addItem(tr("On-demand copy to clipboard"));
 
-  int currentIndex = QtPassSettings::getClipBoardTypeRaw();
+  int currentIndex = static_cast<int>(s.clipBoardType);
   ui->comboBoxClipboard->setCurrentIndex(currentIndex);
   on_comboBoxClipboard_activated(currentIndex);
 
@@ -94,7 +95,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
     useSelection(false);
     ui->checkBoxSelection->setVisible(false);
   } else {
-    useSelection(QtPassSettings::isUseSelection());
+    useSelection(s.useSelection);
   }
 
   if (!Util::configIsValid()) {
@@ -212,14 +213,9 @@ auto ConfigDialog::readSettings() -> AppSettings {
 }
 
 /**
- * @brief ConfigDialog::~ConfigDialog config destructor, makes sure the
- * mainWindow knows about git, gpg and pass executables.
+ * @brief ConfigDialog::~ConfigDialog config destructor.
  */
-ConfigDialog::~ConfigDialog() {
-  QtPassSettings::setGitExecutable(ui->gitPath->text());
-  QtPassSettings::setGpgExecutable(ui->gpgPath->text());
-  QtPassSettings::setPassExecutable(ui->passPath->text());
-}
+ConfigDialog::~ConfigDialog() = default;
 
 /**
  * @brief ConfigDialog::setGitPath set the git executable path.

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "pass.h"
 #include "gpgkeystate.h"
-#include "qtpasssettings.h" // TODO(#1511 PR-C): remove once getGpgIdPath is migrated
+#include "qtpasssettings.h" // TODO(#1511): remove once static getGpgIdPath chain is migrated
 #include "util.h"
 #include <QCoreApplication>
 #include <QDebug>

--- a/src/sshauthsock.cpp
+++ b/src/sshauthsock.cpp
@@ -88,8 +88,8 @@ auto SshAuthSock::overrideStatus(const QString &path) -> OverrideStatus {
  * @brief Probe and set SSH_AUTH_SOCK if missing — see header for full rules.
  *
  * Implementation notes:
- * - Reads QtPassSettings::getSshAuthSockOverride() for the manual override
- *   path; if non-empty, uses it verbatim (no validation — explicit override).
+ * - Receives the manual override path as the @p override parameter; if
+ *   non-empty, uses it verbatim (no validation — explicit override).
  * - Otherwise runs `gpgconf --list-dirs agent-ssh-socket` (gpg-agent's
  *   canonical socket reporter). On macOS, additionally tries `launchctl
  *   getenv SSH_AUTH_SOCK`.

--- a/src/sshauthsock.cpp
+++ b/src/sshauthsock.cpp
@@ -10,7 +10,6 @@
 
 #include "sshauthsock.h"
 #include "executor.h"
-#include "qtpasssettings.h"
 #include <QFileInfo>
 #include <QProcessEnvironment>
 #ifndef Q_OS_WIN
@@ -101,7 +100,7 @@ auto SshAuthSock::overrideStatus(const QString &path) -> OverrideStatus {
  *   subprocess executions; any failure is silently absorbed (the user just
  *   doesn't get the auto-fix).
  */
-void SshAuthSock::initialise() {
+void SshAuthSock::initialise(const QString &override) {
   // Honour any value already in the environment — terminal launches,
   // explicit `.desktop` Exec= overrides, and parent-process exports must win.
   if (!qgetenv("SSH_AUTH_SOCK").isEmpty()) {
@@ -109,7 +108,6 @@ void SshAuthSock::initialise() {
   }
 
   // Manual override from settings takes precedence over auto-probe.
-  const QString override = QtPassSettings::getSshAuthSockOverride();
   if (!override.isEmpty()) {
     qputenv("SSH_AUTH_SOCK", override.toUtf8());
 #ifdef QT_DEBUG

--- a/src/sshauthsock.h
+++ b/src/sshauthsock.h
@@ -69,8 +69,10 @@ public:
    *    `ssh-add -l` validation.
    *
    * Sets the variable via qputenv so child processes inherit it.
+   *
+   * @param override Manual override path from settings (empty → auto-probe).
    */
-  static void initialise();
+  static void initialise(const QString &override = {});
 
 private:
   SshAuthSock() = default;

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -2167,10 +2167,8 @@ void tst_util::initialiseSshAuthSockHonoursExistingEnv() {
   testutils::SshAuthSockGuard guard;
   const QByteArray existing("/tmp/qtpass-existing-sock");
   qputenv("SSH_AUTH_SOCK", existing);
-  // Even if an override is configured, the existing env wins.
-  QtPassSettings::setSshAuthSockOverride(
-      QStringLiteral("/tmp/qtpass-override-sock"));
-  SshAuthSock::initialise();
+  // Even if an override is supplied, the existing env wins.
+  SshAuthSock::initialise(QStringLiteral("/tmp/qtpass-override-sock"));
   QCOMPARE(qgetenv("SSH_AUTH_SOCK"), existing);
 }
 
@@ -2182,8 +2180,7 @@ void tst_util::initialiseSshAuthSockUsesOverride() {
   testutils::SshAuthSockGuard guard;
   qunsetenv("SSH_AUTH_SOCK");
   const QString override = QStringLiteral("/tmp/qtpass-override-sock");
-  QtPassSettings::setSshAuthSockOverride(override);
-  SshAuthSock::initialise();
+  SshAuthSock::initialise(override);
   QCOMPARE(qgetenv("SSH_AUTH_SOCK"), override.toUtf8());
 }
 
@@ -2196,7 +2193,6 @@ void tst_util::initialiseSshAuthSockUsesOverride() {
 void tst_util::initialiseSshAuthSockNoOverrideNoEnvProbes() {
   testutils::SshAuthSockGuard guard;
   qunsetenv("SSH_AUTH_SOCK");
-  QtPassSettings::setSshAuthSockOverride(QString{});
   SshAuthSock::initialise();
   // Either gpgconf set it (non-empty), or it stayed empty. Both fine.
   // The contract is: never crash, never set garbage.
@@ -2223,8 +2219,7 @@ void tst_util::initialiseSshAuthSockOverrideSkipsAgentValidation() {
   const QString deadSocket =
       QStringLiteral("/tmp/qtpass-deliberately-dead-sock-") +
       QUuid::createUuid().toString();
-  QtPassSettings::setSshAuthSockOverride(deadSocket);
-  SshAuthSock::initialise();
+  SshAuthSock::initialise(deadSocket);
   QCOMPARE(qgetenv("SSH_AUTH_SOCK"), deadSocket.toUtf8());
 }
 
@@ -2235,7 +2230,6 @@ void tst_util::initialiseSshAuthSockOverrideSkipsAgentValidation() {
 void tst_util::initialiseSshAuthSockEmptyOverrideFallsThrough() {
   testutils::SshAuthSockGuard guard;
   qunsetenv("SSH_AUTH_SOCK");
-  QtPassSettings::setSshAuthSockOverride(QString{});
   SshAuthSock::initialise();
   // After calling: SSH_AUTH_SOCK is either set by gpgconf probe or unset.
   // Both are acceptable; importantly, it must NOT be set to the empty string.


### PR DESCRIPTION
## Summary

Part of #1511 (AppSettings injection series). Follows #1551 (PR A — Pass hierarchy).

### ConfigDialog constructor

Load `AppSettings` once (`const AppSettings s = QtPassSettings::load()`) and reuse it — removes two extra `getClipBoardTypeRaw()` / `isUseSelection()` calls that duplicated the load already done by `applySettings()`.

### ConfigDialog destructor

Removes three individual `setGitExecutable` / `setGpgExecutable` / `setPassExecutable` calls that were:
- **Redundant** on accept — `on_accepted()` already calls `QtPassSettings::save(readSettings())`
- **Wrong on cancel** — they persisted changes even when the user dismissed the dialog

Destructor is now `= default`.

### `SshAuthSock::initialise()`

Accepts the override path as an explicit parameter (`const QString &override = {}`) instead of calling `QtPassSettings::getSshAuthSockOverride()` internally:
- Removes the `qtpasssettings` dependency from `sshauthsock.cpp`
- Caller (`main/main.cpp`) passes `QtPassSettings::getSshAuthSockOverride()` — data-flow is visible at the call site
- Five SSH test functions updated to pass the override directly

## What's deferred

- `Pass::getGpgIdPath` static chain (`getGpgIdPath` → `getRecipientList` → `getRecipientString`) — all three are static; threading `passStore` through requires updating `imitatepass.cpp`, `mainwindow.cpp`, and tests together. Deferred to the mainwindow PR.
- `PasswordDialog`, `PasswordDisplayPanel`, `util.cpp` (`configIsValid`, `getDir`) — next PR.
- `mainwindow.cpp` bulk — separate PR.
- Boilerplate deletion — final PR.

## Test plan

- `tst_util`: 138/138 passed (SSH tests updated and passing)
- `tst_settings`: 116/116 (1 pre-existing `getPasswordConfigurationDefault` failure unrelated to this PR)
- `tst_integration`: 20/20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH authentication socket now supports a manual override path for environments where automatic discovery isn’t suitable.

* **Improvements**
  * Configuration dialog now loads persisted settings once and applies them consistently, reducing redundant reads during initialization.
  * Executable path settings are no longer updated on dialog close; changes persist only when confirmed.

* **Tests**
  * Updated unit tests to pass the SSH auth socket override directly to initialization instead of modifying persisted override state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->