### PR TITLE
refactor(#1511): inject Pass*/AppSettings into dialog layer

### DIFF
--- a/src/importkeydialog.cpp
+++ b/src/importkeydialog.cpp
@@ -3,7 +3,6 @@
 #include "importkeydialog.h"
 
 #include "executor.h"
-#include "qtpasssettings.h"
 #include "ui_importkeydialog.h"
 
 #include <QApplication>
@@ -25,8 +24,8 @@ static const QRegularExpression
 static const QRegularExpression KEY_IMPORTED_FALLBACK(
     QStringLiteral(R"(gpg: key ([0-9A-Fa-f]{40}|[0-9A-Fa-f]{16}):.*imported)"));
 
-ImportKeyDialog::ImportKeyDialog(QWidget *parent)
-    : QDialog(parent), ui(new Ui::ImportKeyDialog) {
+ImportKeyDialog::ImportKeyDialog(const QString &gpgExe, QWidget *parent)
+    : QDialog(parent), ui(new Ui::ImportKeyDialog), m_gpgExe(gpgExe) {
   ui->setupUi(this);
   ui->importButton->setEnabled(false);
 }
@@ -102,10 +101,7 @@ void ImportKeyDialog::on_inputTextEdit_textChanged() {
 }
 
 bool ImportKeyDialog::importFromString(const QString &input) {
-  QString gpgExe = QtPassSettings::getGpgExecutable();
-  if (gpgExe.isEmpty()) {
-    gpgExe = "gpg";
-  }
+  QString gpgExe = m_gpgExe.isEmpty() ? QStringLiteral("gpg") : m_gpgExe;
   QStringList args = {"--status-fd", "1", "--import", "--batch", "--yes"};
 
   QString stdOut;

--- a/src/importkeydialog.h
+++ b/src/importkeydialog.h
@@ -23,9 +23,10 @@ class ImportKeyDialog : public QDialog {
 public:
   /**
    * @brief Construct an ImportKeyDialog.
+   * @param gpgExe Path to the gpg executable (falls back to "gpg" if empty).
    * @param parent Optional parent widget.
    */
-  explicit ImportKeyDialog(QWidget *parent = nullptr);
+  explicit ImportKeyDialog(const QString &gpgExe, QWidget *parent = nullptr);
   ~ImportKeyDialog() override;
 
   /**
@@ -71,6 +72,7 @@ private slots:
 private:
   Ui::ImportKeyDialog *ui;
   QString m_importedKeyId;
+  QString m_gpgExe;
 
   auto importFromString(const QString &input) -> bool;
   void showError(const QString &message);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -648,7 +648,8 @@ void MainWindow::passShowHandler(const QString &p_output) {
   if (QtPassSettings::isHideContent()) {
     output = "***" + tr("Content hidden") + "***";
   } else if (!QtPassSettings::isDisplayAsIs()) {
-    m_displayPanel->displayFields(password, fileContent.getNamedValues());
+    m_displayPanel->displayFields(password, fileContent.getNamedValues(),
+                                  QtPassSettings::load());
     output = fileContent.getRemainingDataForDisplay();
   }
 
@@ -672,7 +673,8 @@ void MainWindow::passShowHandler(const QString &p_output) {
  */
 void MainWindow::passOtpHandler(const QString &p_output) {
   if (!p_output.isEmpty()) {
-    m_displayPanel->appendField(tr("OTP Code"), p_output);
+    m_displayPanel->appendField(tr("OTP Code"), p_output,
+                                QtPassSettings::load());
     m_qtPass->copyTextToClipboard(p_output);
     showStatusMessage(tr("OTP code copied to clipboard"));
   } else {
@@ -1036,7 +1038,8 @@ auto MainWindow::confirmPathInStore(const QString &candidate) -> bool {
  * @param isNew insert (not update)
  */
 void MainWindow::setPassword(const QString &file, bool isNew) {
-  PasswordDialog d(file, isNew, this);
+  PasswordDialog d(QtPassSettings::getPass(), QtPassSettings::load(), file,
+                   isNew, this);
 
   if (isNew) {
     QString storePath = QtPassSettings::getPassStore();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -629,11 +629,10 @@ void MainWindow::executeWrapperStarted() {
  * @return void - This function does not return a value.
  */
 void MainWindow::passShowHandler(const QString &p_output) {
-  QStringList templ = QtPassSettings::isUseTemplate()
-                          ? QtPassSettings::getPassTemplate().split("\n")
-                          : QStringList();
-  bool allFields =
-      QtPassSettings::isUseTemplate() && QtPassSettings::isTemplateAllFields();
+  const AppSettings s = QtPassSettings::load();
+  QStringList templ =
+      s.useTemplate ? s.passTemplate.split("\n") : QStringList();
+  bool allFields = s.useTemplate && s.templateAllFields;
   FileContent fileContent = FileContent::parse(p_output, templ, allFields);
   QString output = p_output;
   QString password = fileContent.getPassword();
@@ -645,15 +644,14 @@ void MainWindow::passShowHandler(const QString &p_output) {
   m_displayPanel->clear();
 
   // show what is needed:
-  if (QtPassSettings::isHideContent()) {
+  if (s.hideContent) {
     output = "***" + tr("Content hidden") + "***";
-  } else if (!QtPassSettings::isDisplayAsIs()) {
-    m_displayPanel->displayFields(password, fileContent.getNamedValues(),
-                                  QtPassSettings::load());
+  } else if (!s.displayAsIs) {
+    m_displayPanel->displayFields(password, fileContent.getNamedValues(), s);
     output = fileContent.getRemainingDataForDisplay();
   }
 
-  if (QtPassSettings::isUseAutoclearPanel()) {
+  if (s.useAutoclearPanel) {
     clearPanelTimer.start();
   }
 

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -27,7 +27,7 @@
 PasswordDialog::PasswordDialog(PasswordConfiguration passConfig,
                                QWidget *parent)
     : QDialog(parent), ui(new Ui::PasswordDialog),
-      m_passConfig(std::move(passConfig)) {
+      m_passConfig(std::move(passConfig)), m_pass(QtPassSettings::getPass()) {
   m_templating = false;
   m_isNew = false;
 
@@ -35,8 +35,7 @@ PasswordDialog::PasswordDialog(PasswordConfiguration passConfig,
   setLength(m_passConfig.length);
   setPasswordCharTemplate(m_passConfig.selected);
 
-  connect(QtPassSettings::getPass(), &Pass::finishedShow, this,
-          &PasswordDialog::setPass);
+  connect(m_pass, &Pass::finishedShow, this, &PasswordDialog::setPass);
 }
 
 /**
@@ -45,29 +44,27 @@ PasswordDialog::PasswordDialog(PasswordConfiguration passConfig,
  * @param isNew
  * @param parent pointer
  */
-PasswordDialog::PasswordDialog(QString file, const bool &isNew, QWidget *parent)
-    : QDialog(parent), ui(new Ui::PasswordDialog), m_file(std::move(file)),
-      m_isNew(isNew) {
+PasswordDialog::PasswordDialog(Pass *pass, const AppSettings &s, QString file,
+                               const bool &isNew, QWidget *parent)
+    : QDialog(parent), ui(new Ui::PasswordDialog), m_pass(pass),
+      m_file(std::move(file)), m_isNew(isNew) {
 
   if (!isNew) {
-    QtPassSettings::getPass()->Show(m_file);
+    m_pass->Show(m_file);
   }
 
   ui->setupUi(this);
 
   setWindowTitle(this->windowTitle() + " " + m_file);
-  m_passConfig = QtPassSettings::getPasswordConfiguration();
-  usePwgen(QtPassSettings::isUsePwgen());
-  setTemplate(QtPassSettings::getPassTemplate(),
-              QtPassSettings::isUseTemplate());
+  m_passConfig = s.passwordConfiguration;
+  usePwgen(s.usePwgen);
+  setTemplate(s.passTemplate, s.useTemplate);
 
   setLength(m_passConfig.length);
   setPasswordCharTemplate(m_passConfig.selected);
 
-  connect(QtPassSettings::getPass(), &Pass::finishedShow, this,
-          &PasswordDialog::setPass);
-  connect(QtPassSettings::getPass(), &Pass::processErrorExit, this,
-          &PasswordDialog::close);
+  connect(m_pass, &Pass::finishedShow, this, &PasswordDialog::setPass);
+  connect(m_pass, &Pass::processErrorExit, this, &PasswordDialog::close);
   connect(this, &PasswordDialog::accepted, this, &PasswordDialog::on_accepted);
   connect(this, &PasswordDialog::rejected, this, &PasswordDialog::on_rejected);
 }
@@ -102,7 +99,7 @@ void PasswordDialog::on_createPasswordButton_clicked() {
     return;
   }
 
-  QString newPass = QtPassSettings::getPass()->generatePassword(
+  QString newPass = m_pass->generatePassword(
       static_cast<unsigned int>(ui->spinBox_pwdLength->value()),
       m_passConfig.Characters[static_cast<PasswordConfiguration::characterSet>(
           currentIndex)]);
@@ -125,7 +122,7 @@ void PasswordDialog::on_accepted() {
     newValue += "\n";
   }
 
-  QtPassSettings::getPass()->Insert(m_file, newValue, !m_isNew);
+  m_pass->Insert(m_file, newValue, !m_isNew);
 }
 
 /**

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -28,6 +28,9 @@ PasswordDialog::PasswordDialog(PasswordConfiguration passConfig,
                                QWidget *parent)
     : QDialog(parent), ui(new Ui::PasswordDialog),
       m_passConfig(std::move(passConfig)), m_pass(QtPassSettings::getPass()) {
+  // m_pass is captured once from the singleton here. This constructor is
+  // only reached from tests; production always uses the two-arg overload
+  // that receives an explicit Pass* with a stable, caller-controlled lifetime.
   m_templating = false;
   m_isNew = false;
 

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -3,13 +3,15 @@
 #ifndef SRC_PASSWORDDIALOG_H_
 #define SRC_PASSWORDDIALOG_H_
 
-#include "passwordconfiguration.h"
+#include "appsettings.h"
+
 #include <QDialog>
 
 namespace Ui {
 class PasswordDialog;
 }
 
+class Pass;
 class QLineEdit;
 class QWidget;
 
@@ -33,11 +35,14 @@ public:
                           QWidget *parent = nullptr);
   /**
    * @brief Construct a PasswordDialog for editing an existing password file.
+   * @param pass Backend used to show, insert, and generate passwords.
+   * @param s Application settings snapshot (password config, template, pwgen).
    * @param file Path to the password file being edited.
    * @param isNew true if creating a new entry, false if editing existing.
    * @param parent Optional parent widget.
    */
-  PasswordDialog(QString file, const bool &isNew, QWidget *parent = nullptr);
+  PasswordDialog(Pass *pass, const AppSettings &s, QString file,
+                 const bool &isNew, QWidget *parent = nullptr);
   ~PasswordDialog() override;
 
   /**
@@ -108,6 +113,7 @@ private slots:
 private:
   Ui::PasswordDialog *ui;
   PasswordConfiguration m_passConfig;
+  Pass *m_pass{nullptr};
   QStringList m_fields;
   QString m_file;
   bool m_templating{};

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -9,10 +9,10 @@
  */
 
 #include "passworddisplaypanel.h"
+#include "appsettings.h"
 #include "qpushbuttonasqrcode.h"
 #include "qpushbuttonshowpassword.h"
 #include "qpushbuttonwithclipboard.h"
-#include "qtpasssettings.h"
 #include "util.h"
 
 #include <QBoxLayout>
@@ -45,27 +45,30 @@ void PasswordDisplayPanel::clear() {
 }
 
 void PasswordDisplayPanel::displayFields(const QString &password,
-                                         const NamedValues &namedValues) {
+                                         const NamedValues &namedValues,
+                                         const AppSettings &s) {
   if (!password.isEmpty()) {
     // The password is hidden in addField when needed.
-    addField(0, QObject::tr("Password"), password);
+    addField(0, QObject::tr("Password"), password, s);
   }
   for (int j = 0; j < namedValues.length(); ++j) {
     const NamedValue &nv = namedValues.at(j);
-    addField(j + 1, nv.name, nv.value);
+    addField(j + 1, nv.name, nv.value, s);
   }
   m_container->setSpacing(m_grid->count() == 0 ? 0 : 6);
 }
 
 void PasswordDisplayPanel::appendField(const QString &field,
-                                       const QString &value) {
+                                       const QString &value,
+                                       const AppSettings &s) {
   // Each row is two grid items (label + value frame), so the next free row is
   // count() / 2 — the same sequential scheme displayFields() uses.
-  addField(m_grid->count() / 2, field, value);
+  addField(m_grid->count() / 2, field, value, s);
 }
 
 void PasswordDisplayPanel::addField(int position, const QString &field,
-                                    const QString &value) {
+                                    const QString &value,
+                                    const AppSettings &s) {
   QString trimmedField = field.trimmed();
   QString trimmedValue = value.trimmed();
 
@@ -79,7 +82,7 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
   ly->setContentsMargins(5, 2, 2, 2);
   ly->setSpacing(0);
   frame->setLayout(ly);
-  if (QtPassSettings::getClipBoardType() != Enums::CLIPBOARD_NEVER) {
+  if (s.clipBoardType != Enums::CLIPBOARD_NEVER) {
     auto *fieldLabel =
         new QPushButtonWithClipboard(trimmedValue, m_widgetParent);
     connect(fieldLabel, &QPushButtonWithClipboard::clicked, this,
@@ -89,7 +92,7 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
     frame->layout()->addWidget(fieldLabel);
   }
 
-  if (QtPassSettings::isUseQrencode()) {
+  if (s.useQrencode) {
     auto *qrbutton = new QPushButtonAsQRCode(trimmedValue, m_widgetParent);
     connect(qrbutton, &QPushButtonAsQRCode::clicked, this,
             &PasswordDisplayPanel::qrRequested);
@@ -124,13 +127,12 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
 
   // set the echo mode to password, if the field is "password"
   const QString lineStyle =
-      QtPassSettings::isUseMonospace()
+      s.useMonospace
           ? "border-style: none; background: transparent; font-family: "
             "monospace;"
           : "border-style: none; background: transparent;";
 
-  if (QtPassSettings::isHidePassword() &&
-      trimmedField == QObject::tr("Password")) {
+  if (s.hidePassword && trimmedField == QObject::tr("Password")) {
     auto *line = new QLineEdit();
     line->setObjectName(trimmedField);
     line->setText(trimmedValue);

--- a/src/passworddisplaypanel.h
+++ b/src/passworddisplaypanel.h
@@ -8,6 +8,8 @@
 #include <QObject>
 #include <QString>
 
+struct AppSettings;
+
 class QGridLayout;
 class QBoxLayout;
 class QWidget;
@@ -50,15 +52,20 @@ public:
    * @brief Render the password and template fields of a decrypted entry.
    * @param password Password value (row 0); skipped when empty.
    * @param namedValues Template/named fields to render below the password.
+   * @param s AppSettings snapshot supplying display settings (clipboard,
+   *        monospace, hide-password, qrencode).
    */
-  void displayFields(const QString &password, const NamedValues &namedValues);
+  void displayFields(const QString &password, const NamedValues &namedValues,
+                     const AppSettings &s);
 
   /**
    * @brief Append a single field row below the existing ones (e.g. OTP code).
    * @param field Field label.
    * @param value Field value.
+   * @param s AppSettings snapshot supplying display settings.
    */
-  void appendField(const QString &field, const QString &value);
+  void appendField(const QString &field, const QString &value,
+                   const AppSettings &s);
 
 signals:
   /**
@@ -73,7 +80,8 @@ signals:
   void qrRequested(const QString &text);
 
 private:
-  void addField(int position, const QString &field, const QString &value);
+  void addField(int position, const QString &field, const QString &value,
+                const AppSettings &s);
 
   QGridLayout *m_grid;
   QBoxLayout *m_container;

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -358,7 +358,7 @@ void UsersDialog::on_lineEdit_textChanged(const QString &filter) {
 void UsersDialog::on_checkBox_clicked() { populateList(ui->lineEdit->text()); }
 
 void UsersDialog::on_importKeyButton_clicked() {
-  ImportKeyDialog dialog(this);
+  ImportKeyDialog dialog(QtPassSettings::getGpgExecutable(), this);
   if (dialog.exec() != QDialog::Accepted) {
     return;
   }

--- a/tests/auto/importkeydialog/tst_importkeydialog.cpp
+++ b/tests/auto/importkeydialog/tst_importkeydialog.cpp
@@ -131,12 +131,12 @@ void tst_importkeydialog::parseGpgImportOutputPrefersImportOkOverImported() {
 }
 
 void tst_importkeydialog::initialKeyIdEmpty() {
-  ImportKeyDialog dialog;
+  ImportKeyDialog dialog(QString{});
   QVERIFY(dialog.importedKeyId().isEmpty());
 }
 
 void tst_importkeydialog::importButtonStartsDisabled() {
-  ImportKeyDialog dialog;
+  ImportKeyDialog dialog(QString{});
   auto *button =
       dialog.findChild<QPushButton *>(QStringLiteral("importButton"));
   QVERIFY(button != nullptr);
@@ -237,7 +237,7 @@ void tst_importkeydialog::parseGpgImportOutputImportResWithoutImportOk() {
 
 void tst_importkeydialog::importButtonEnabledAfterTextInput() {
   // Simulating on_inputTextEdit_textChanged via the text edit widget.
-  ImportKeyDialog dialog;
+  ImportKeyDialog dialog(QString{});
   auto *button =
       dialog.findChild<QPushButton *>(QStringLiteral("importButton"));
   auto *edit =
@@ -255,7 +255,7 @@ void tst_importkeydialog::importButtonEnabledAfterTextInput() {
 
 void tst_importkeydialog::importButtonDisabledForWhitespaceOnlyInput() {
   // Whitespace-only content trims to empty; the button must stay disabled.
-  ImportKeyDialog dialog;
+  ImportKeyDialog dialog(QString{});
   auto *button =
       dialog.findChild<QPushButton *>(QStringLiteral("importButton"));
   auto *edit =
@@ -282,7 +282,7 @@ void tst_importkeydialog::pasteButtonSetsTextFromClipboard() {
     QSKIP("Clipboard is not functional on this platform");
   }
 
-  ImportKeyDialog dialog;
+  ImportKeyDialog dialog(QString{});
   auto *edit =
       dialog.findChild<QPlainTextEdit *>(QStringLiteral("inputTextEdit"));
   QVERIFY(edit != nullptr);

--- a/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
+++ b/tests/auto/passworddisplaypanel/tst_passworddisplaypanel.cpp
@@ -6,6 +6,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+#include "../../../src/appsettings.h"
 #include "../../../src/filecontent.h"
 #include "../../../src/passworddisplaypanel.h"
 
@@ -44,28 +45,32 @@ void tst_passworddisplaypanel::cleanup() {
 }
 
 void tst_passworddisplaypanel::displayFieldsAddsRows() {
+  AppSettings s;
   m_panel->displayFields(QStringLiteral("secret"),
-                         NamedValues{{"url", "https://example.org"}});
+                         NamedValues{{"url", "https://example.org"}}, s);
   // Two fields (password + url), each a label + value widget => 4 grid items.
   QCOMPARE(m_grid->count(), 4);
 }
 
 void tst_passworddisplaypanel::displayFieldsSkipsEmptyPassword() {
-  m_panel->displayFields(QString(), NamedValues{});
+  AppSettings s;
+  m_panel->displayFields(QString(), NamedValues{}, s);
   QVERIFY2(m_grid->count() == 0,
            "An empty password with no fields must leave the grid empty");
 }
 
 void tst_passworddisplaypanel::clearRemovesAllRows() {
-  m_panel->displayFields(QStringLiteral("secret"), NamedValues{});
+  AppSettings s;
+  m_panel->displayFields(QStringLiteral("secret"), NamedValues{}, s);
   QVERIFY2(m_grid->count() > 0, "precondition: grid populated");
   m_panel->clear();
   QVERIFY2(m_grid->count() == 0, "clear() must remove every grid row");
 }
 
 void tst_passworddisplaypanel::appendFieldAddsOneRow() {
+  AppSettings s;
   const int before = m_grid->count();
-  m_panel->appendField(QStringLiteral("OTP Code"), QStringLiteral("123456"));
+  m_panel->appendField(QStringLiteral("OTP Code"), QStringLiteral("123456"), s);
   QCOMPARE(m_grid->count(), before + 2);
 }
 


### PR DESCRIPTION
## Summary

Part of the #1511 AppSettings injection series — PR C (dialog layer).

- **`ImportKeyDialog`**: constructor takes `const QString &gpgExe`; `importFromString()` uses `m_gpgExe` instead of `QtPassSettings::getGpgExecutable()`. Removes `qtpasssettings.h` dependency. Call site in `usersdialog.cpp` updated to pass `QtPassSettings::getGpgExecutable()`.

- **`PasswordDisplayPanel`**: `displayFields()` and `appendField()` now take `const AppSettings &s`; private `addField()` receives it transitively. Replaces four `QtPassSettings::` reads (`clipBoardType`, `useQrencode`, `useMonospace`, `hidePassword`) with struct fields. Removes `qtpasssettings.h` dependency. `mainwindow.cpp` call sites updated to pass `QtPassSettings::load()`.

- **`PasswordDialog`** (second constructor only): signature changed to `(Pass*, const AppSettings&, QString, bool, QWidget*)`. Settings injected at construction; `m_pass` stored as member so `on_createPasswordButton_clicked()` and `on_accepted()` also use it instead of `QtPassSettings::getPass()`. First constructor keeps `QtPassSettings::getPass()` for test-compat.

- Tests updated: `tst_passworddisplaypanel` passes `AppSettings{}`, `tst_importkeydialog` passes `QString{}`.

## Test plan

- [x] `tst_passworddisplaypanel`: 6 passed
- [x] `tst_importkeydialog`: 33 passed
- [x] `tst_ui` (PasswordDialog first constructor): 55 passed
- [x] Full build clean
- [x] Doxygen: no new symbol warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency in how password and OTP views apply your current display settings (such as masking the password and showing related controls), by using one shared settings snapshot during rendering.

* **Bug Fixes**
  * Key import now reliably uses the configured GPG executable when importing keys.

* **Tests**
  * Updated automated UI component tests to match the revised dialog/panel construction and rendering flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->