### PR TITLE
refactor(#1511): wire passStore into static chain; parameterise Util::configIsValid/getDir

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -98,7 +98,7 @@ ConfigDialog::ConfigDialog(MainWindow *parent)
     useSelection(s.useSelection);
   }
 
-  if (!Util::configIsValid()) {
+  if (!Util::configIsValid(s)) {
     // Show Programs tab, which is likely
     // what the user needs to fix now.
     ui->tabWidget->setCurrentIndex(1);
@@ -919,7 +919,7 @@ auto ConfigDialog::isPassOtpAvailable() -> bool {
  * @brief ConfigDialog::wizard first-time use wizard.
  */
 void ConfigDialog::wizard() {
-  (void)Util::configIsValid();
+  (void)Util::configIsValid(QtPassSettings::load());
   on_autodetectButton_clicked();
 
   if (!checkGpgExistence()) {

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -137,14 +137,14 @@ void ImitatePass::OtpGenerate(QString file) {
  */
 void ImitatePass::Insert(QString file, QString newValue, bool overwrite) {
   file = file + ".gpg";
-  QString gpgIdPath = Pass::getGpgIdPath(file);
+  QString gpgIdPath = Pass::getGpgIdPath(file, m_settings.passStore);
   if (!verifyGpgIdFile(gpgIdPath)) {
     emit critical(tr("Check .gpg-id file signature!"),
                   tr("Signature for %1 is invalid.").arg(gpgIdPath));
     return;
   }
   transactionHelper trans(this, PASS_INSERT);
-  QStringList recipients = Pass::getRecipientList(file);
+  QStringList recipients = Pass::getRecipientList(file, m_settings.passStore);
   if (recipients.isEmpty()) {
     // Already emit critical signal to notify user of error - no need to throw
     emit critical(tr("Can not edit"),
@@ -501,7 +501,7 @@ auto ImitatePass::removeDir(const QString &dirName) -> bool {
 auto ImitatePass::verifyGpgIdForDir(const QString &file,
                                     QStringList &gpgIdFilesVerified,
                                     QStringList &gpgId) -> bool {
-  QString gpgIdPath = Pass::getGpgIdPath(file);
+  QString gpgIdPath = Pass::getGpgIdPath(file, m_settings.passStore);
   if (gpgIdFilesVerified.contains(gpgIdPath)) {
     return true;
   }
@@ -511,7 +511,7 @@ auto ImitatePass::verifyGpgIdForDir(const QString &file,
     return false;
   }
   gpgIdFilesVerified.append(gpgIdPath);
-  gpgId = getRecipientList(file);
+  gpgId = getRecipientList(file, m_settings.passStore);
   gpgId.sort();
   return true;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -495,7 +495,8 @@ void MainWindow::config() {
       deselect();
       ui->treeView->setCurrentIndex(QModelIndex());
 
-      if (m_qtPass->isFreshStart() && !Util::configIsValid()) {
+      if (m_qtPass->isFreshStart() &&
+          !Util::configIsValid(QtPassSettings::load())) {
         config();
       }
       QtPassSettings::getPass()->updateEnv();
@@ -567,7 +568,7 @@ auto MainWindow::getFile(const QModelIndex &index, bool forPass) -> QString {
 void MainWindow::on_treeView_clicked(const QModelIndex &index) {
   bool cleared = ui->treeView->currentIndex().flags() == Qt::NoItemFlags;
   m_currentDir =
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel);
+      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
   // Clear any previously cached clipped text before showing new password
   m_qtPass->clearClippedText();
   QString file = getFile(index, true);
@@ -1042,7 +1043,7 @@ void MainWindow::setPassword(const QString &file, bool isNew) {
   if (isNew) {
     QString storePath = QtPassSettings::getPassStore();
     QString folder =
-        Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel);
+        Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
     if (folder.isEmpty()) {
       folder = storePath;
     }
@@ -1069,13 +1070,14 @@ void MainWindow::setPassword(const QString &file, bool isNew) {
 void MainWindow::addPassword() {
   bool ok;
   QString dir =
-      Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel);
+      Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel, QtPassSettings::getPassStore());
   QString file =
       QInputDialog::getText(this, tr("New file"),
                             tr("New password file: \n(Will be placed in %1 )")
                                 .arg(QtPassSettings::getPassStore() +
                                      Util::getDir(ui->treeView->currentIndex(),
-                                                  true, model, proxyModel)),
+                                                  true, model, proxyModel,
+                                                  QtPassSettings::getPassStore())),
                             QLineEdit::Normal, "", &ok);
   if (!ok || file.isEmpty()) {
     return;
@@ -1108,7 +1110,7 @@ void MainWindow::onDelete() {
   if (fileOrFolder.isFile()) {
     file = getFile(ui->treeView->currentIndex(), true);
   } else {
-    file = Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel);
+    file = Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel, QtPassSettings::getPassStore());
     isDir = true;
   }
 
@@ -1183,7 +1185,7 @@ void MainWindow::userDialog(const QString &dir) {
 void MainWindow::onUsers() {
   QString dir =
       m_currentDir.isEmpty()
-          ? Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel)
+          ? Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore())
           : m_currentDir;
 
   UsersDialog d(dir, this);
@@ -1435,12 +1437,13 @@ void MainWindow::showContextMenu(const QPoint &pos) {
     connect(deleteItem, &QAction::triggered, this, &MainWindow::onDelete);
     if (fileOrFolder.isDir()) {
       QString dirPath = QDir::cleanPath(
-          Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel));
+          Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore()));
 
       auto *shareMenu = new QMenu(tr("Share"), &contextMenu);
       contextMenu.addMenu(shareMenu);
 
-      QString gpgIdPath = Pass::getGpgIdPath(dirPath);
+      QString gpgIdPath =
+          Pass::getGpgIdPath(dirPath, QtPassSettings::getPassStore());
       bool gpgIdExists = !gpgIdPath.isEmpty() && QFile(gpgIdPath).exists();
 
       QString exePath = QtPassSettings::isUsePass()
@@ -1490,7 +1493,7 @@ void MainWindow::showBrowserContextMenu(const QPoint &pos) {
  */
 void MainWindow::openFolder() {
   QString dir =
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel);
+      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
 
   QString path = QDir::toNativeSeparators(dir);
   QDesktopServices::openUrl(QUrl::fromLocalFile(path));
@@ -1502,13 +1505,14 @@ void MainWindow::openFolder() {
 void MainWindow::addFolder() {
   bool ok;
   QString dir =
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel);
+      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
   QString newdir =
       QInputDialog::getText(this, tr("New file"),
                             tr("New Folder: \n(Will be placed in %1 )")
                                 .arg(QtPassSettings::getPassStore() +
                                      Util::getDir(ui->treeView->currentIndex(),
-                                                  true, model, proxyModel)),
+                                                  true, model, proxyModel,
+                                                  QtPassSettings::getPassStore())),
                             QLineEdit::Normal, "", &ok);
   if (!ok || newdir.isEmpty()) {
     return;
@@ -1551,7 +1555,7 @@ void MainWindow::addFolder() {
 void MainWindow::renameFolder() {
   bool ok;
   QString srcDir = QDir::cleanPath(
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel));
+      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore()));
   QString srcDirName = QDir(srcDir).dirName();
   QString newName =
       QInputDialog::getText(this, tr("Rename file"), tr("Rename Folder To: "),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -567,8 +567,8 @@ auto MainWindow::getFile(const QModelIndex &index, bool forPass) -> QString {
  */
 void MainWindow::on_treeView_clicked(const QModelIndex &index) {
   bool cleared = ui->treeView->currentIndex().flags() == Qt::NoItemFlags;
-  m_currentDir =
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
+  m_currentDir = Util::getDir(ui->treeView->currentIndex(), false, model,
+                              proxyModel, QtPassSettings::getPassStore());
   // Clear any previously cached clipped text before showing new password
   m_qtPass->clearClippedText();
   QString file = getFile(index, true);
@@ -1042,8 +1042,8 @@ void MainWindow::setPassword(const QString &file, bool isNew) {
 
   if (isNew) {
     QString storePath = QtPassSettings::getPassStore();
-    QString folder =
-        Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
+    QString folder = Util::getDir(ui->treeView->currentIndex(), false, model,
+                                  proxyModel, QtPassSettings::getPassStore());
     if (folder.isEmpty()) {
       folder = storePath;
     }
@@ -1069,16 +1069,15 @@ void MainWindow::setPassword(const QString &file, bool isNew) {
  */
 void MainWindow::addPassword() {
   bool ok;
-  QString dir =
-      Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel, QtPassSettings::getPassStore());
-  QString file =
-      QInputDialog::getText(this, tr("New file"),
-                            tr("New password file: \n(Will be placed in %1 )")
-                                .arg(QtPassSettings::getPassStore() +
-                                     Util::getDir(ui->treeView->currentIndex(),
-                                                  true, model, proxyModel,
-                                                  QtPassSettings::getPassStore())),
-                            QLineEdit::Normal, "", &ok);
+  QString dir = Util::getDir(ui->treeView->currentIndex(), true, model,
+                             proxyModel, QtPassSettings::getPassStore());
+  QString file = QInputDialog::getText(
+      this, tr("New file"),
+      tr("New password file: \n(Will be placed in %1 )")
+          .arg(QtPassSettings::getPassStore() +
+               Util::getDir(ui->treeView->currentIndex(), true, model,
+                            proxyModel, QtPassSettings::getPassStore())),
+      QLineEdit::Normal, "", &ok);
   if (!ok || file.isEmpty()) {
     return;
   }
@@ -1110,7 +1109,8 @@ void MainWindow::onDelete() {
   if (fileOrFolder.isFile()) {
     file = getFile(ui->treeView->currentIndex(), true);
   } else {
-    file = Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel, QtPassSettings::getPassStore());
+    file = Util::getDir(ui->treeView->currentIndex(), true, model, proxyModel,
+                        QtPassSettings::getPassStore());
     isDir = true;
   }
 
@@ -1183,10 +1183,10 @@ void MainWindow::userDialog(const QString &dir) {
  * gets lists and opens UserDialog.
  */
 void MainWindow::onUsers() {
-  QString dir =
-      m_currentDir.isEmpty()
-          ? Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore())
-          : m_currentDir;
+  QString dir = m_currentDir.isEmpty()
+                    ? Util::getDir(ui->treeView->currentIndex(), false, model,
+                                   proxyModel, QtPassSettings::getPassStore())
+                    : m_currentDir;
 
   UsersDialog d(dir, this);
   if (!d.exec()) {
@@ -1437,7 +1437,8 @@ void MainWindow::showContextMenu(const QPoint &pos) {
     connect(deleteItem, &QAction::triggered, this, &MainWindow::onDelete);
     if (fileOrFolder.isDir()) {
       QString dirPath = QDir::cleanPath(
-          Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore()));
+          Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel,
+                       QtPassSettings::getPassStore()));
 
       auto *shareMenu = new QMenu(tr("Share"), &contextMenu);
       contextMenu.addMenu(shareMenu);
@@ -1492,8 +1493,8 @@ void MainWindow::showBrowserContextMenu(const QPoint &pos) {
  * @brief MainWindow::openFolder open the folder in the default file manager
  */
 void MainWindow::openFolder() {
-  QString dir =
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
+  QString dir = Util::getDir(ui->treeView->currentIndex(), false, model,
+                             proxyModel, QtPassSettings::getPassStore());
 
   QString path = QDir::toNativeSeparators(dir);
   QDesktopServices::openUrl(QUrl::fromLocalFile(path));
@@ -1504,16 +1505,15 @@ void MainWindow::openFolder() {
  */
 void MainWindow::addFolder() {
   bool ok;
-  QString dir =
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore());
-  QString newdir =
-      QInputDialog::getText(this, tr("New file"),
-                            tr("New Folder: \n(Will be placed in %1 )")
-                                .arg(QtPassSettings::getPassStore() +
-                                     Util::getDir(ui->treeView->currentIndex(),
-                                                  true, model, proxyModel,
-                                                  QtPassSettings::getPassStore())),
-                            QLineEdit::Normal, "", &ok);
+  QString dir = Util::getDir(ui->treeView->currentIndex(), false, model,
+                             proxyModel, QtPassSettings::getPassStore());
+  QString newdir = QInputDialog::getText(
+      this, tr("New file"),
+      tr("New Folder: \n(Will be placed in %1 )")
+          .arg(QtPassSettings::getPassStore() +
+               Util::getDir(ui->treeView->currentIndex(), true, model,
+                            proxyModel, QtPassSettings::getPassStore())),
+      QLineEdit::Normal, "", &ok);
   if (!ok || newdir.isEmpty()) {
     return;
   }
@@ -1554,8 +1554,9 @@ void MainWindow::addFolder() {
  */
 void MainWindow::renameFolder() {
   bool ok;
-  QString srcDir = QDir::cleanPath(
-      Util::getDir(ui->treeView->currentIndex(), false, model, proxyModel, QtPassSettings::getPassStore()));
+  QString srcDir =
+      QDir::cleanPath(Util::getDir(ui->treeView->currentIndex(), false, model,
+                                   proxyModel, QtPassSettings::getPassStore()));
   QString srcDirName = QDir(srcDir).dirName();
   QString newName =
       QInputDialog::getText(this, tr("Rename file"), tr("Rename Folder To: "),

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -842,8 +842,8 @@ void Pass::updateEnv() {
  * @param for_file which file (folder) would you like the gpgid file path for.
  * @return path to the gpgid file.
  */
-auto Pass::getGpgIdPath(const QString &for_file,
-                        const QString &passStore) -> QString {
+auto Pass::getGpgIdPath(const QString &for_file, const QString &passStore)
+    -> QString {
   QString normalizedStore = QDir::fromNativeSeparators(passStore);
   QString normalizedFile = QDir::fromNativeSeparators(for_file);
   QString fullPath = normalizedFile.startsWith(normalizedStore)
@@ -856,8 +856,9 @@ auto Pass::getGpgIdPath(const QString &for_file,
   bool found = false;
   while (gpgIdDir.exists()) {
     QString currentPath = QDir::cleanPath(gpgIdDir.absolutePath());
-    if (currentPath != cleanPassStore &&
-        !currentPath.startsWith(cleanPassStore + "/")) {
+    const QString prefix =
+        cleanPassStore.endsWith('/') ? cleanPassStore : cleanPassStore + "/";
+    if (currentPath != cleanPassStore && !currentPath.startsWith(prefix)) {
       break;
     }
     if (QFile(gpgIdDir.absoluteFilePath(".gpg-id")).exists()) {
@@ -869,7 +870,7 @@ auto Pass::getGpgIdPath(const QString &for_file,
     }
   }
   return found ? gpgIdDir.absoluteFilePath(".gpg-id")
-               : QDir(passStore).filePath(".gpg-id");
+               : QDir(normalizedStore).filePath(".gpg-id");
 }
 
 /**
@@ -877,8 +878,8 @@ auto Pass::getGpgIdPath(const QString &for_file,
  * @param for_file which file (folder) would you like recipients for
  * @return recipients gpg-id contents
  */
-auto Pass::getRecipientList(const QString &for_file,
-                            const QString &passStore) -> QStringList {
+auto Pass::getRecipientList(const QString &for_file, const QString &passStore)
+    -> QStringList {
   QFile gpgId(getGpgIdPath(for_file, passStore));
   if (!gpgId.open(QIODevice::ReadOnly | QIODevice::Text)) {
     return {};
@@ -901,10 +902,9 @@ auto Pass::getRecipientList(const QString &for_file,
  * @param count
  * @return recipient string
  */
-auto Pass::getRecipientString(const QString &for_file,
-                              const QString &passStore,
-                              const QString &separator,
-                              int *count) -> QStringList {
+auto Pass::getRecipientString(const QString &for_file, const QString &passStore,
+                              const QString &separator, int *count)
+    -> QStringList {
   Q_UNUSED(separator)
   QStringList recipients = Pass::getRecipientList(for_file, passStore);
   if (count) {

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "pass.h"
 #include "gpgkeystate.h"
-#include "qtpasssettings.h" // TODO(#1511): remove once static getGpgIdPath chain is migrated
 #include "util.h"
 #include <QCoreApplication>
 #include <QDebug>
@@ -843,17 +842,17 @@ void Pass::updateEnv() {
  * @param for_file which file (folder) would you like the gpgid file path for.
  * @return path to the gpgid file.
  */
-auto Pass::getGpgIdPath(const QString &for_file) -> QString {
-  QString passStore =
-      QDir::fromNativeSeparators(QtPassSettings::getPassStore());
+auto Pass::getGpgIdPath(const QString &for_file,
+                        const QString &passStore) -> QString {
+  QString normalizedStore = QDir::fromNativeSeparators(passStore);
   QString normalizedFile = QDir::fromNativeSeparators(for_file);
-  QString fullPath = normalizedFile.startsWith(passStore)
+  QString fullPath = normalizedFile.startsWith(normalizedStore)
                          ? normalizedFile
-                         : passStore + "/" + normalizedFile;
+                         : normalizedStore + "/" + normalizedFile;
   QDir gpgIdDir(QFileInfo(fullPath).absoluteDir());
   // QDir::cleanPath() always normalises to forward slashes, so use '/'
   // here rather than QDir::separator() (which returns '\\' on Windows).
-  QString cleanPassStore = QDir::cleanPath(passStore);
+  QString cleanPassStore = QDir::cleanPath(normalizedStore);
   bool found = false;
   while (gpgIdDir.exists()) {
     QString currentPath = QDir::cleanPath(gpgIdDir.absolutePath());
@@ -869,11 +868,8 @@ auto Pass::getGpgIdPath(const QString &for_file) -> QString {
       break;
     }
   }
-  QString gpgIdPath(
-      found ? gpgIdDir.absoluteFilePath(".gpg-id")
-            : QDir(QtPassSettings::getPassStore()).filePath(".gpg-id"));
-
-  return gpgIdPath;
+  return found ? gpgIdDir.absoluteFilePath(".gpg-id")
+               : QDir(passStore).filePath(".gpg-id");
 }
 
 /**
@@ -881,8 +877,9 @@ auto Pass::getGpgIdPath(const QString &for_file) -> QString {
  * @param for_file which file (folder) would you like recipients for
  * @return recipients gpg-id contents
  */
-auto Pass::getRecipientList(const QString &for_file) -> QStringList {
-  QFile gpgId(getGpgIdPath(for_file));
+auto Pass::getRecipientList(const QString &for_file,
+                            const QString &passStore) -> QStringList {
+  QFile gpgId(getGpgIdPath(for_file, passStore));
   if (!gpgId.open(QIODevice::ReadOnly | QIODevice::Text)) {
     return {};
   }
@@ -904,10 +901,12 @@ auto Pass::getRecipientList(const QString &for_file) -> QStringList {
  * @param count
  * @return recipient string
  */
-auto Pass::getRecipientString(const QString &for_file, const QString &separator,
+auto Pass::getRecipientString(const QString &for_file,
+                              const QString &passStore,
+                              const QString &separator,
                               int *count) -> QStringList {
   Q_UNUSED(separator)
-  QStringList recipients = Pass::getRecipientList(for_file);
+  QStringList recipients = Pass::getRecipientList(for_file, passStore);
   if (count) {
     *count = static_cast<int>(recipients.size());
   }

--- a/src/pass.h
+++ b/src/pass.h
@@ -231,8 +231,8 @@ public:
    * @param passStore Root directory of the password store.
    * @return Path to .gpg-id file.
    */
-  static auto getGpgIdPath(const QString &for_file,
-                            const QString &passStore) -> QString;
+  static auto getGpgIdPath(const QString &for_file, const QString &passStore)
+      -> QString;
   /**
    * @brief Get list of recipients for a password file.
    * @param for_file Path to password file.

--- a/src/pass.h
+++ b/src/pass.h
@@ -228,23 +228,29 @@ public:
   /**
    * @brief Get .gpg-id file path for a password file.
    * @param for_file Path to password file.
+   * @param passStore Root directory of the password store.
    * @return Path to .gpg-id file.
    */
-  static auto getGpgIdPath(const QString &for_file) -> QString;
+  static auto getGpgIdPath(const QString &for_file,
+                            const QString &passStore) -> QString;
   /**
    * @brief Get list of recipients for a password file.
    * @param for_file Path to password file.
+   * @param passStore Root directory of the password store.
    * @return List of recipient key IDs.
    */
-  static auto getRecipientList(const QString &for_file) -> QStringList;
+  static auto getRecipientList(const QString &for_file,
+                               const QString &passStore) -> QStringList;
   /**
    * @brief Get recipients as string.
    * @param for_file Path to password file.
+   * @param passStore Root directory of the password store.
    * @param separator Separator between recipients.
    * @param count Pointer to store recipient count.
    * @return List of recipient key IDs.
    */
   static auto getRecipientString(const QString &for_file,
+                                 const QString &passStore,
                                  const QString &separator = " ",
                                  int *count = nullptr) -> QStringList;
 

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -99,9 +99,9 @@ auto QtPass::init() -> bool {
 
   QtPassSettings::setVersion(VERSION);
 
-  if (!Util::configIsValid()) {
+  if (!Util::configIsValid(QtPassSettings::load())) {
     m_mainWindow->config();
-    if (freshStart && !Util::configIsValid()) {
+    if (freshStart && !Util::configIsValid(QtPassSettings::load())) {
       return false;
     }
   }

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "usersdialog.h"
 #include "importkeydialog.h"
+#include "pass.h"
 #include "qtpasssettings.h"
 #include "ui_usersdialog.h"
 #include <QApplication>
@@ -101,8 +102,9 @@ void UsersDialog::markSecretKeys(QList<UserInfo> &users) {
 
 void UsersDialog::loadRecipients() {
   int count = 0;
-  QStringList recipients = QtPassSettings::getPass()->getRecipientString(
-      m_dir.isEmpty() ? "" : m_dir, " ", &count);
+  QStringList recipients = Pass::getRecipientString(
+      m_dir.isEmpty() ? "" : m_dir, QtPassSettings::getPassStore(), " ",
+      &count);
 
   QList<UserInfo> selectedUsers =
       QtPassSettings::getPass()->listKeys(recipients);
@@ -117,8 +119,8 @@ void UsersDialog::loadRecipients() {
   }
 
   if (count > selectedUsers.size()) {
-    QStringList allRecipients = QtPassSettings::getPass()->getRecipientList(
-        m_dir.isEmpty() ? "" : m_dir);
+    QStringList allRecipients = Pass::getRecipientList(
+        m_dir.isEmpty() ? "" : m_dir, QtPassSettings::getPassStore());
 
     // Use bulk lookup to resolve all recipients at once (single gpg call)
     // This preserves the original email/UID resolution behavior

--- a/src/usersdialog.cpp
+++ b/src/usersdialog.cpp
@@ -102,9 +102,9 @@ void UsersDialog::markSecretKeys(QList<UserInfo> &users) {
 
 void UsersDialog::loadRecipients() {
   int count = 0;
-  QStringList recipients = Pass::getRecipientString(
-      m_dir.isEmpty() ? "" : m_dir, QtPassSettings::getPassStore(), " ",
-      &count);
+  QStringList recipients =
+      Pass::getRecipientString(m_dir.isEmpty() ? "" : m_dir,
+                               QtPassSettings::getPassStore(), " ", &count);
 
   QList<UserInfo> selectedUsers =
       QtPassSettings::getPass()->listKeys(recipients);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -211,10 +211,12 @@ auto Util::findBinaryInPath(const QString &binary) -> QString {
 /**
  * @brief Checks whether the current QtPass configuration is valid.
  * @example
- * bool result = Util::configIsValid();
+ * AppSettings s = QtPassSettings::load();
+ * bool result = Util::configIsValid(s);
  * std::cout << std::boolalpha << result << std::endl; // Expected output: true
  * or false
  *
+ * @param s Application settings snapshot to validate.
  * @return bool - True if the configuration file exists and the required
  * executable is available; otherwise false.
  */
@@ -224,8 +226,7 @@ auto Util::configIsValid(const AppSettings &s) -> bool {
     return false;
   }
 
-  const QString executable =
-      s.usePass ? s.passExecutable : s.gpgExecutable;
+  const QString executable = s.usePass ? s.passExecutable : s.gpgExecutable;
 
   if (executable.startsWith(QStringLiteral("wsl "))) {
     // Probe WSL once per session — availability doesn't change at runtime
@@ -249,18 +250,17 @@ auto Util::configIsValid(const AppSettings &s) -> bool {
  * @brief Returns a directory path derived from a model index, optionally
  * relative to the pass store.
  * @example
- * QString result = Util::getDir(index, true, model, storeModel);
+ * QString result = Util::getDir(index, true, model, storeModel, passStore);
  * std::cout << result.toStdString() << std::endl; // Expected output: relative
  * directory path with trailing separator
  *
- * @param QModelIndex &index - Source index used to resolve the file or
- * directory path.
- * @param bool forPass - If true, returns a path relative to the pass store;
+ * @param index Source index used to resolve the file or directory path.
+ * @param forPass If true, returns a path relative to the pass store;
  * otherwise returns an absolute path.
- * @param QFileSystemModel &model - File system model used to obtain file
- * information.
- * @param StoreModel &storeModel - Proxy model used to map the provided index to
- * the source model.
+ * @param model File system model used to obtain file information.
+ * @param storeModel Proxy model used to map the provided index to the source
+ * model.
+ * @param passStore Absolute path to the password store root directory.
  * @return QString - The resolved directory path, always ending with the
  * platform's directory separator.
  */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "util.h"
+#include "appsettings.h"
 #include "executor.h"
 #include <QDebug>
 #include <QDir>
@@ -24,7 +25,6 @@
 #else
 #include <sys/time.h>
 #endif
-#include "qtpasssettings.h"
 
 #ifdef QT_DEBUG
 #include "debughelper.h"
@@ -218,16 +218,14 @@ auto Util::findBinaryInPath(const QString &binary) -> QString {
  * @return bool - True if the configuration file exists and the required
  * executable is available; otherwise false.
  */
-auto Util::configIsValid() -> bool {
-  const QString configFilePath =
-      QDir(QtPassSettings::getPassStore()).filePath(".gpg-id");
+auto Util::configIsValid(const AppSettings &s) -> bool {
+  const QString configFilePath = QDir(s.passStore).filePath(".gpg-id");
   if (!QFile(configFilePath).exists()) {
     return false;
   }
 
-  const QString executable = QtPassSettings::isUsePass()
-                                 ? QtPassSettings::getPassExecutable()
-                                 : QtPassSettings::getGpgExecutable();
+  const QString executable =
+      s.usePass ? s.passExecutable : s.gpgExecutable;
 
   if (executable.startsWith(QStringLiteral("wsl "))) {
     // Probe WSL once per session — availability doesn't change at runtime
@@ -267,10 +265,9 @@ auto Util::configIsValid() -> bool {
  * platform's directory separator.
  */
 auto Util::getDir(const QModelIndex &index, bool forPass,
-                  const QFileSystemModel &model, const StoreModel &storeModel)
-    -> QString {
-  QString abspath =
-      QDir(QtPassSettings::getPassStore()).absolutePath() + QDir::separator();
+                  const QFileSystemModel &model, const StoreModel &storeModel,
+                  const QString &passStore) -> QString {
+  QString abspath = QDir(passStore).absolutePath() + QDir::separator();
   if (!index.isValid()) {
     return forPass ? "" : abspath;
   }

--- a/src/util.h
+++ b/src/util.h
@@ -3,6 +3,7 @@
 #ifndef SRC_UTIL_H_
 #define SRC_UTIL_H_
 
+#include "appsettings.h"
 #include "storemodel.h"
 #include <QFileSystemModel>
 #include <QProcessEnvironment>
@@ -43,11 +44,12 @@ public:
   static auto normalizeFolderPath(const QString &path) -> QString;
   /**
    * @brief Verify that the required configuration is complete.
+   * @param s Application settings snapshot (passStore, usePass, executables).
    * @return bool `true` if the password store's `.gpg-id` exists AND the
    * configured executable (pass or gpg, depending on settings) exists or is a
    * WSL wrapper; `false` otherwise.
    */
-  static auto configIsValid() -> bool;
+  static auto configIsValid(const AppSettings &s) -> bool;
   /**
    * @brief Get the selected folder path, either relative to the configured pass
    * store or absolute.
@@ -57,13 +59,15 @@ public:
    * @param model Filesystem model used to resolve the index.
    * @param storeModel StoreModel used to map view indexes to the filesystem
    * model.
+   * @param passStore Root directory of the password store.
    * @return QString Folder path that always ends with the native directory
    * separator. Returns an empty string when `index` is invalid and `forPass` is
    * true; otherwise returns the pass store root.
    */
   static auto getDir(const QModelIndex &index, bool forPass,
                      const QFileSystemModel &model,
-                     const StoreModel &storeModel) -> QString;
+                     const StoreModel &storeModel,
+                     const QString &passStore) -> QString;
   /**
    * @brief Returns a regex to match .gpg file extensions.
    * @return Reference to static regex

--- a/src/util.h
+++ b/src/util.h
@@ -66,8 +66,8 @@ public:
    */
   static auto getDir(const QModelIndex &index, bool forPass,
                      const QFileSystemModel &model,
-                     const StoreModel &storeModel,
-                     const QString &passStore) -> QString;
+                     const StoreModel &storeModel, const QString &passStore)
+      -> QString;
   /**
    * @brief Returns a regex to match .gpg file extensions.
    * @return Reference to static regex

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1283,9 +1283,11 @@ void tst_util::getGpgIdPathSubfolder() {
   file.write("ABCDEF12\n");
   file.close();
 
-  QString path = Pass::getGpgIdPath(subfolder + "/password.gpg", passStore);
-  QVERIFY2(path == gpgIdFile,
-           qPrintable(QString("Expected %1, got %2").arg(gpgIdFile, path)));
+  QString path = QDir::cleanPath(
+      Pass::getGpgIdPath(subfolder + "/password.gpg", passStore));
+  QString expected = QDir::cleanPath(gpgIdFile);
+  QVERIFY2(path == expected,
+           qPrintable(QString("Expected %1, got %2").arg(expected, path)));
 }
 
 void tst_util::getGpgIdPathNotFound() {

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -827,7 +827,7 @@ void tst_util::configIsValid() {
 
   // No .gpg-id in this store => config must be invalid.
   QtPassSettings::setPassStore(tempDir.path());
-  bool isValid = Util::configIsValid();
+  bool isValid = Util::configIsValid(QtPassSettings::load());
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id is missing");
 
   // Create .gpg-id, then force invalid executable configuration.
@@ -841,13 +841,13 @@ void tst_util::configIsValid() {
   SettingGuard<QString, QtPassSettings::setGpgExecutable> gpgGuard{
       QtPassSettings::getGpgExecutable(), QString()};
 
-  isValid = Util::configIsValid();
+  isValid = Util::configIsValid(QtPassSettings::load());
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is missing");
 
   QtPassSettings::setGpgExecutable(
       QStringLiteral("definitely_nonexistent_gpg_binary_12345"));
-  isValid = Util::configIsValid();
+  isValid = Util::configIsValid(QtPassSettings::load());
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is invalid");
 }
@@ -866,11 +866,9 @@ void tst_util::getDirBasic() {
            "Store path should match the set value");
   QModelIndex rootIndex = fileSystemModel.index(tempDir.path());
   QVERIFY2(rootIndex.isValid(), "Filesystem model root index should be valid");
-  const QString originalStore = QtPassSettings::getPassStore();
-  QtPassSettings::setPassStore(tempDir.path());
 
-  QString result =
-      Util::getDir(QModelIndex(), false, fileSystemModel, storeModel);
+  QString result = Util::getDir(QModelIndex(), false, fileSystemModel,
+                                storeModel, tempDir.path());
   QString expectedDir = QDir(tempDir.path()).absolutePath();
   if (!expectedDir.endsWith(QDir::separator())) {
     expectedDir += QDir::separator();
@@ -878,7 +876,6 @@ void tst_util::getDirBasic() {
   QVERIFY2(
       result == expectedDir,
       qPrintable(QString("Expected '%1', got '%2'").arg(expectedDir, result)));
-  QtPassSettings::setPassStore(originalStore);
 }
 
 void tst_util::getDirWithIndex() {
@@ -899,10 +896,6 @@ void tst_util::getDirWithIndex() {
            "Failed to write test data to file in temporary directory");
   file.close();
 
-  const QString originalPassStore = QtPassSettings::getPassStore();
-  PassStoreGuard passStoreGuard(originalPassStore);
-  QtPassSettings::setPassStore(dirPath);
-
   QFileSystemModel fileSystemModel;
   fileSystemModel.setRootPath(dirPath);
 
@@ -918,7 +911,8 @@ void tst_util::getDirWithIndex() {
   QVERIFY2(fileIndex.isValid(),
            "Proxy index should be valid for the test file");
 
-  QString result = Util::getDir(fileIndex, false, fileSystemModel, storeModel);
+  QString result =
+      Util::getDir(fileIndex, false, fileSystemModel, storeModel, dirPath);
   QVERIFY2(!result.isEmpty(),
            "getDir should return a non-empty directory for a valid index");
   QVERIFY(result.endsWith(QDir::separator()));
@@ -934,7 +928,7 @@ void tst_util::getDirWithIndex() {
 
   QModelIndex invalidIndex;
   QString invalidResult =
-      Util::getDir(invalidIndex, false, fileSystemModel, storeModel);
+      Util::getDir(invalidIndex, false, fileSystemModel, storeModel, dirPath);
   QString expectedForInvalid = dirPath;
   if (!expectedForInvalid.endsWith(QDir::separator())) {
     expectedForInvalid += QDir::separator();
@@ -1143,9 +1137,7 @@ void tst_util::getRecipientListBasic() {
   file.write("ABCDEF12\n34567890\n");
   file.close();
 
-  PassStoreGuard guard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(passStore);
-  QStringList recipients = Pass::getRecipientList(passStore);
+  QStringList recipients = Pass::getRecipientList(passStore, passStore);
   QCOMPARE(recipients.size(), 2);
   QCOMPARE(recipients[0], QString("ABCDEF12"));
   QCOMPARE(recipients[1], QString("34567890"));
@@ -1160,9 +1152,7 @@ void tst_util::getRecipientListEmpty() {
   QVERIFY(file.open(QIODevice::WriteOnly));
   file.close();
 
-  PassStoreGuard guard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(passStore);
-  QStringList recipients = Pass::getRecipientList(passStore);
+  QStringList recipients = Pass::getRecipientList(passStore, passStore);
   QVERIFY(recipients.isEmpty());
 }
 
@@ -1176,9 +1166,7 @@ void tst_util::getRecipientListWithComments() {
   file.write("ABCDEF12\n# comment\n34567890\n");
   file.close();
 
-  PassStoreGuard guard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(passStore);
-  QStringList recipients = Pass::getRecipientList(passStore);
+  QStringList recipients = Pass::getRecipientList(passStore, passStore);
   QCOMPARE(recipients.size(), 2);
   QVERIFY(!recipients.contains("# comment"));
   QVERIFY(!recipients.contains("comment"));
@@ -1195,10 +1183,7 @@ void tst_util::getRecipientListInvalidKeyId() {
              "example.org\n");
   file.close();
 
-  const QString originalPassStore = QtPassSettings::getPassStore();
-  PassStoreGuard originalGuard(originalPassStore);
-  QtPassSettings::setPassStore(passStore);
-  QStringList recipients = Pass::getRecipientList(passStore);
+  QStringList recipients = Pass::getRecipientList(passStore, passStore);
   QVERIFY(!recipients.contains("invalid"));
   QVERIFY(recipients.contains("ABCDEF12"));
   QVERIFY(recipients.contains("0xABCDEF123456789012"));
@@ -1249,13 +1234,11 @@ void tst_util::getRecipientStringCount() {
   file.write("ABCDEF12\n34567890\n");
   file.close();
 
-  const QString originalPassStore = QtPassSettings::getPassStore();
-  PassStoreGuard originalGuard(originalPassStore);
-  QtPassSettings::setPassStore(passStore);
   int count = 0;
   QStringList parsedRecipients =
-      Pass::getRecipientString(passStore, " ", &count);
-  QStringList recipientsNoCount = Pass::getRecipientString(passStore, " ");
+      Pass::getRecipientString(passStore, passStore, " ", &count);
+  QStringList recipientsNoCount =
+      Pass::getRecipientString(passStore, passStore, " ");
 
   QStringList expectedRecipients = {"ABCDEF12", "34567890"};
   // Verify count matches the expected number of parsed recipients.
@@ -1282,9 +1265,7 @@ void tst_util::getGpgIdPathBasic() {
   file.write("ABCDEF12\n");
   file.close();
 
-  PassStoreGuard guard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(passStore);
-  QString path = QDir::cleanPath(Pass::getGpgIdPath(passStore));
+  QString path = QDir::cleanPath(Pass::getGpgIdPath(passStore, passStore));
   QString expected = QDir::cleanPath(gpgIdFile);
   QVERIFY2(path == expected,
            qPrintable(QString("Expected %1, got %2").arg(expected, path)));
@@ -1302,9 +1283,7 @@ void tst_util::getGpgIdPathSubfolder() {
   file.write("ABCDEF12\n");
   file.close();
 
-  PassStoreGuard guard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(passStore);
-  QString path = Pass::getGpgIdPath(subfolder + "/password.gpg");
+  QString path = Pass::getGpgIdPath(subfolder + "/password.gpg", passStore);
   QVERIFY2(path == gpgIdFile,
            qPrintable(QString("Expected %1, got %2").arg(gpgIdFile, path)));
 }
@@ -1313,10 +1292,8 @@ void tst_util::getGpgIdPathNotFound() {
   QTemporaryDir tempDir;
   QString passStore = tempDir.path();
 
-  PassStoreGuard guard(QtPassSettings::getPassStore());
-  QtPassSettings::setPassStore(passStore);
-  QString path =
-      QDir::cleanPath(Pass::getGpgIdPath(passStore + "/nonexistent"));
+  QString path = QDir::cleanPath(
+      Pass::getGpgIdPath(passStore + "/nonexistent", passStore));
   QString expected = QDir::cleanPath(passStore + "/.gpg-id");
   QVERIFY2(path == expected,
            qPrintable(QString("Expected %1, got %2").arg(expected, path)));


### PR DESCRIPTION
## Summary

Part D of issue #1511 — remove singleton reads from `pass.cpp` and `util.cpp` by pushing explicit parameters down the static call chain.

- `Pass::getGpgIdPath` / `getRecipientList` / `getRecipientString` now take an explicit `passStore` parameter — `qtpasssettings.h` removed from `pass.cpp`
- `Util::configIsValid(const AppSettings &s)` and `Util::getDir(..., const QString &passStore)` — `qtpasssettings.h` removed from `util.cpp`
- `imitatepass.cpp`: 4 call sites use `m_settings.passStore`
- `mainwindow.cpp`, `configdialog.cpp`, `qtpass.cpp`, `usersdialog.cpp`: all affected call sites updated; callers still read `QtPassSettings::getPassStore()` / `QtPassSettings::load()` (those files are candidates for PR E)
- `tst_util.cpp`: `PassStoreGuard` + `setPassStore` boilerplate removed from static-chain tests; `passStore` passed directly; `configIsValid` / `getDir` calls use explicit `AppSettings` / `passStore` args

## Test plan

- [ ] `QT_QPA_PLATFORM=offscreen ./tests/auto/util/tst_util` — 138 passed, 0 failed
- [ ] `make -j4` — clean build, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now uses the currently loaded settings snapshot for more reliable initial setup and “fresh start” behavior.
  * Password-store–aware path resolution is now consistently applied across directory selection and add/edit/delete and folder actions.
  * Sharing and recipient resolution now correctly derive `.gpg-id` and recipient lists relative to the active password store, including in the users dialog.
* **Tests**
  * Updated unit tests to reflect the revised configuration and password-store–aware path/recipient APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->