### PR TITLE
locale: Chinese fix

### DIFF
--- a/localization/localization_zh_CN.ts
+++ b/localization/localization_zh_CN.ts
@@ -109,7 +109,7 @@
         <location filename="../src/configdialog.ui" line="369"/>
         <location filename="../src/ui_configdialog.h" line="939"/>
         <source>Select character set for password generation</source>
-        <translation>选择密码所用的的字符集</translation>
+        <translation>选择密码所用的字符集</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="373"/>


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Chinese translation text for password generation character set selection message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->