### PR TITLE
refactor(#1511): inject Pass* into StoreModel; inject gpgExe into KeygenDialog

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -490,7 +490,7 @@ void ConfigDialog::on_toolButtonGpg_clicked() {
  * @brief ConfigDialog::on_pushButtonGenerateKey_clicked open keygen dialog.
  */
 void ConfigDialog::on_pushButtonGenerateKey_clicked() {
-  KeygenDialog d(this);
+  KeygenDialog d(ui->gpgPath->text(), this);
   d.exec();
 }
 
@@ -996,7 +996,7 @@ auto ConfigDialog::checkSecretKeys() -> bool {
 #endif
 
   if ((gpg.startsWith("wsl ") || QFile(gpg).exists()) && names.empty()) {
-    KeygenDialog d(this);
+    KeygenDialog d(gpg, this);
     return d.exec();
   }
   return true;

--- a/src/keygendialog.cpp
+++ b/src/keygendialog.cpp
@@ -19,8 +19,7 @@
  * @param parent
  */
 KeygenDialog::KeygenDialog(const QString &gpgExe, ConfigDialog *parent)
-    : QDialog(parent), ui(new Ui::KeygenDialog), m_progressIndicator(nullptr),
-      m_gpgExe(gpgExe) {
+    : QDialog(parent), ui(new Ui::KeygenDialog), m_progressIndicator(nullptr) {
   ui->setupUi(this);
   dialog = parent;
 
@@ -39,7 +38,7 @@ KeygenDialog::KeygenDialog(const QString &gpgExe, ConfigDialog *parent)
     // Let window manager handle positioning for first launch
   }
 
-  ui->plainTextEdit->setPlainText(Pass::getDefaultKeyTemplate(m_gpgExe));
+  ui->plainTextEdit->setPlainText(Pass::getDefaultKeyTemplate(gpgExe));
 }
 
 /**

--- a/src/keygendialog.cpp
+++ b/src/keygendialog.cpp
@@ -18,8 +18,9 @@
  * @brief KeygenDialog::KeygenDialog basic constructor.
  * @param parent
  */
-KeygenDialog::KeygenDialog(ConfigDialog *parent)
-    : QDialog(parent), ui(new Ui::KeygenDialog), m_progressIndicator(nullptr) {
+KeygenDialog::KeygenDialog(const QString &gpgExe, ConfigDialog *parent)
+    : QDialog(parent), ui(new Ui::KeygenDialog), m_progressIndicator(nullptr),
+      m_gpgExe(gpgExe) {
   ui->setupUi(this);
   dialog = parent;
 
@@ -38,8 +39,7 @@ KeygenDialog::KeygenDialog(ConfigDialog *parent)
     // Let window manager handle positioning for first launch
   }
 
-  ui->plainTextEdit->setPlainText(
-      Pass::getDefaultKeyTemplate(QtPassSettings::getGpgExecutable()));
+  ui->plainTextEdit->setPlainText(Pass::getDefaultKeyTemplate(m_gpgExe));
 }
 
 /**

--- a/src/keygendialog.h
+++ b/src/keygendialog.h
@@ -24,10 +24,11 @@ class KeygenDialog : public QDialog {
 
 public:
   /**
-   * @brief Construct a KeygenDialog with an optional parent ConfigDialog.
+   * @brief Construct a KeygenDialog.
+   * @param gpgExe Path to the gpg executable.
    * @param parent Parent dialog, or nullptr.
    */
-  explicit KeygenDialog(ConfigDialog *parent = nullptr);
+  explicit KeygenDialog(const QString &gpgExe, ConfigDialog *parent = nullptr);
   ~KeygenDialog() override;
 
 protected:
@@ -51,6 +52,7 @@ private:
   void no_protection(bool enable);
   ConfigDialog *dialog;
   std::unique_ptr<QProgressIndicator> m_progressIndicator;
+  QString m_gpgExe;
 };
 
 #endif // SRC_KEYGENDIALOG_H_

--- a/src/keygendialog.h
+++ b/src/keygendialog.h
@@ -52,7 +52,6 @@ private:
   void no_protection(bool enable);
   ConfigDialog *dialog;
   std::unique_ptr<QProgressIndicator> m_progressIndicator;
-  QString m_gpgExe;
 };
 
 #endif // SRC_KEYGENDIALOG_H_

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -500,7 +500,9 @@ void MainWindow::config() {
           !Util::configIsValid(QtPassSettings::load())) {
         config();
       }
-      QtPassSettings::getPass()->updateEnv();
+      Pass *activePass = QtPassSettings::getPass();
+      activePass->updateEnv();
+      proxyModel.setPass(activePass);
       clearPanelTimer.setInterval(MS_PER_SECOND *
                                   QtPassSettings::getAutoclearPanelSeconds());
       m_qtPass->setClipboardTimer();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -87,6 +87,7 @@ MainWindow::MainWindow(const QString &searchText, QWidget *parent)
   model.fetchMore(rootDir);
 
   proxyModel.setModelAndStore(&model, passStore);
+  proxyModel.setPass(QtPassSettings::getPass());
   selectionModel.reset(new QItemSelectionModel(&proxyModel));
 
   ui->treeView->setModel(&proxyModel);

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "storemodel.h"
-#include "qtpasssettings.h"
-
+#include "pass.h"
 #include "pathvalidator.h"
 #include "util.h"
 #include <QApplication>
@@ -50,6 +49,8 @@ auto operator>>(QDataStream &in,
  * http://www.qtcentre.org/threads/46471-QTreeView-Filter
  */
 StoreModel::StoreModel() { fs = nullptr; }
+
+void StoreModel::setPass(Pass *pass) { m_pass = pass; }
 
 /**
  * @brief StoreModel::filterAcceptsRow should row be shown, wrapper for
@@ -364,9 +365,8 @@ auto StoreModel::executeDropAction(const dragAndDropInfoPasswordStore &info,
   // crafted; canonical-path checks stop drops that would move/copy outside
   // the store or follow a symlink out (e.g. a symlink within the store
   // pointing at /etc).
-  const QString storeRoot = QtPassSettings::getPassStore();
-  if (!PathValidator::isPathInStore(storeRoot, cleanedSrc) ||
-      !PathValidator::isPathInStore(storeRoot, cleanedDest)) {
+  if (!PathValidator::isPathInStore(store, cleanedSrc) ||
+      !PathValidator::isPathInStore(store, cleanedDest)) {
     qWarning() << "executeDropAction: rejecting drop that escapes the store"
                << "(src=" << cleanedSrc << "dest=" << cleanedDest << ")";
     return false;
@@ -403,10 +403,13 @@ auto StoreModel::executeDropAction(const dragAndDropInfoPasswordStore &info,
 auto StoreModel::performDrop(const QString &cleanedSrc,
                              const QString &cleanedDest, Qt::DropAction action,
                              bool force) -> bool {
+  if (!m_pass) {
+    return false;
+  }
   if (action == Qt::MoveAction) {
-    QtPassSettings::getPass()->Move(cleanedSrc, cleanedDest, force);
+    m_pass->Move(cleanedSrc, cleanedDest, force);
   } else if (action == Qt::CopyAction) {
-    QtPassSettings::getPass()->Copy(cleanedSrc, cleanedDest, force);
+    m_pass->Copy(cleanedSrc, cleanedDest, force);
   }
   return true;
 }

--- a/src/storemodel.h
+++ b/src/storemodel.h
@@ -17,6 +17,7 @@
  * - Supporting drag and drop operations
  * - Custom sorting (directories before files)
  */
+class Pass;
 class QFileSystemModel;
 
 /**
@@ -67,6 +68,7 @@ class StoreModel : public QSortFilterProxyModel {
 private:
   QFileSystemModel *fs;
   QString store;
+  Pass *m_pass{nullptr};
 
   auto parseDropData(const QMimeData *data,
                      dragAndDropInfoPasswordStore *outInfo) -> bool;
@@ -81,14 +83,20 @@ private:
    * @param force Overwrite an existing destination.
    * @return true once the operation has been dispatched.
    */
-  static auto performDrop(const QString &cleanedSrc, const QString &cleanedDest,
-                          Qt::DropAction action, bool force) -> bool;
+  auto performDrop(const QString &cleanedSrc, const QString &cleanedDest,
+                   Qt::DropAction action, bool force) -> bool;
 
 public:
   /**
    * @brief Construct a StoreModel.
    */
   StoreModel();
+
+  /**
+   * @brief Inject the Pass backend for drag-and-drop Move/Copy operations.
+   * @param pass Pass backend instance; must outlive this StoreModel.
+   */
+  void setPass(Pass *pass);
 
   /**
    * @brief Filter whether a row should be displayed.


### PR DESCRIPTION
## Summary

Part E of issue #1511 — remove singleton reads from `storemodel.cpp` and `keygendialog.cpp`.

**StoreModel (`storemodel.cpp/h`):**
- Add `Pass *m_pass{nullptr}` member + `setPass(Pass *)` method
- `executeDropAction`: replace `QtPassSettings::getPassStore()` with the existing `store` member
- `performDrop`: de-static; guards on null `m_pass`; uses `m_pass->Move/Copy` instead of `QtPassSettings::getPass()->Move/Copy`
- `qtpasssettings.h` removed from `storemodel.cpp`
- `MainWindow` calls `proxyModel.setPass(QtPassSettings::getPass())` at init

**KeygenDialog (`keygendialog.cpp/h`):**
- Constructor gains `const QString &gpgExe` parameter (same pattern as `ImportKeyDialog` in PR C)
- `m_gpgExe` stored and used in `Pass::getDefaultKeyTemplate` instead of `QtPassSettings::getGpgExecutable()`
- `configdialog.cpp` callers updated: `on_pushButtonGenerateKey_clicked` passes `ui->gpgPath->text()`; `wizard()` passes local `gpg` already in scope

## Test plan

- [ ] `QT_QPA_PLATFORM=offscreen ./tests/auto/util/tst_util` — 138 passed, 0 failed
- [ ] `QT_QPA_PLATFORM=offscreen ./tests/auto/model/tst_model` — 38 passed, 0 failed
- [ ] `make -j4` — clean build, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated key generation and related dialogs to use the currently configured GnuPG executable, rather than relying on global settings lookups.
  * Enhanced the store model to accept and use an injected backend instance for drop/copy/move operations.
* **Bug Fixes**
  * Improved backend switching by re-linking the proxy model to the active backend after configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->