### PR TITLE
refactor(#1511): snapshot AppSettings in QtPass destructor and init()

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -50,9 +50,9 @@ QtPass::QtPass(MainWindow *mainWindow) : m_mainWindow(mainWindow) {
  */
 QtPass::~QtPass() {
 #ifdef Q_OS_WIN
-  if (QtPassSettings::isUseWebDav())
-    WNetCancelConnection2A(QtPassSettings::getPassStore().toUtf8().constData(),
-                           0, 1);
+  const AppSettings s = QtPassSettings::load();
+  if (s.useWebDav)
+    WNetCancelConnection2A(s.passStore.toUtf8().constData(), 0, 1);
 #else
   if (fusedav.state() == QProcess::Running) {
     fusedav.terminate();
@@ -78,22 +78,18 @@ auto QtPass::init() -> bool {
 #ifdef QT_DEBUG
     dbg() << "assuming fresh install";
 #endif
-
-    if (QtPassSettings::getAutoclearSeconds() < 5) {
+    const AppSettings s = QtPassSettings::load();
+    if (s.autoclearSeconds < 5) {
       QtPassSettings::setAutoclearSeconds(10);
     }
-    if (QtPassSettings::getAutoclearPanelSeconds() < 5) {
+    if (s.autoclearPanelSeconds < 5) {
       QtPassSettings::setAutoclearPanelSeconds(10);
     }
-    if (!QtPassSettings::getPwgenExecutable().isEmpty()) {
-      QtPassSettings::setUsePwgen(true);
-    } else {
-      QtPassSettings::setUsePwgen(false);
-    }
-    QtPassSettings::setPassTemplate("login\nurl");
+    QtPassSettings::setUsePwgen(!s.pwgenExecutable.isEmpty());
+    QtPassSettings::setPassTemplate(QStringLiteral("login\nurl"));
   } else {
     if (QtPassSettings::getPassTemplate().isEmpty()) {
-      QtPassSettings::setPassTemplate("login\nurl");
+      QtPassSettings::setPassTemplate(QStringLiteral("login\nurl"));
     }
   }
 


### PR DESCRIPTION
## Summary

Two multi-field read sites in `src/qtpass.cpp` were missed in PR G (#1559):

- **`~QtPass()` (Windows path)**: read `isUseWebDav()` and `getPassStore()` (2 fields) — replaced with a single `AppSettings` snapshot
- **`QtPass::init()` fresh-install migration block**: read `getAutoclearSeconds()`, `getAutoclearPanelSeconds()`, `getPwgenExecutable()` (3 fields) — replaced with a single snapshot; the `usePwgen` if/else collapses to one call

Single-field reads kept as-is per the P2 rule:
- `getPassStore(Util::findPasswordStore())` at line 69 (single read with default, immediately written back)
- `getPassTemplate()` in the else branch (single read)
- `isUseWebDav()` at line 111 (single read guarding `mountWebDav()`)
- `isAutoPush()` and `getAutoclearSeconds()` (already reverted to getters in PR G review)

Part of issue #1511 — replacing `QtPassSettings::getX()` singleton boilerplate with `AppSettings` struct snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal configuration initialization and settings management for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->