### PR TITLE
refactor(#1511): delete 30 dead getter wrappers from QtPassSettings

### DIFF
--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -248,11 +248,6 @@ void QtPassSettings::setSize(const QSize &size) {
   getInstance()->setValue(SettingsConstants::size, size);
 }
 
-auto QtPassSettings::isMaximized(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::maximized, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setMaximized(const bool &maximized) {
   getInstance()->setValue(SettingsConstants::maximized, maximized);
 }
@@ -302,46 +297,20 @@ void QtPassSettings::setDialogMaximized(const QString &key,
                           maximized);
 }
 
-auto QtPassSettings::isUsePass(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::usePass, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUsePass(const bool &usePass) {
   getInstance()->setValue(SettingsConstants::usePass, usePass);
   // Backend selection changed: force re-selection on next getPass().
   PassBackendFactory::invalidate();
 }
 
-auto QtPassSettings::getClipBoardTypeRaw(
-    const Enums::clipBoardType &defaultValue) -> int {
-  return getInstance()
-      ->value(SettingsConstants::clipBoardType, static_cast<int>(defaultValue))
-      .toInt();
-}
-
-auto QtPassSettings::getClipBoardType(const Enums::clipBoardType &defaultValue)
-    -> Enums::clipBoardType {
-  return static_cast<Enums::clipBoardType>(getClipBoardTypeRaw(defaultValue));
-}
 void QtPassSettings::setClipBoardType(const int &clipBoardType) {
   getInstance()->setValue(SettingsConstants::clipBoardType, clipBoardType);
 }
 
-auto QtPassSettings::isUseSelection(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useSelection, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseSelection(const bool &useSelection) {
   getInstance()->setValue(SettingsConstants::useSelection, useSelection);
 }
 
-auto QtPassSettings::isUseAutoclear(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useAutoclear, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseAutoclear(const bool &useAutoclear) {
   getInstance()->setValue(SettingsConstants::useAutoclear, useAutoclear);
 }
@@ -356,11 +325,6 @@ void QtPassSettings::setAutoclearSeconds(const int &autoClearSeconds) {
                           autoClearSeconds);
 }
 
-auto QtPassSettings::isUseAutoclearPanel(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useAutoclearPanel, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseAutoclearPanel(const bool &useAutoclearPanel) {
   getInstance()->setValue(SettingsConstants::useAutoclearPanel,
                           useAutoclearPanel);
@@ -377,56 +341,26 @@ void QtPassSettings::setAutoclearPanelSeconds(
                           autoClearPanelSeconds);
 }
 
-auto QtPassSettings::isHidePassword(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::hidePassword, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setHidePassword(const bool &hidePassword) {
   getInstance()->setValue(SettingsConstants::hidePassword, hidePassword);
 }
 
-auto QtPassSettings::isHideContent(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::hideContent, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setHideContent(const bool &hideContent) {
   getInstance()->setValue(SettingsConstants::hideContent, hideContent);
 }
 
-auto QtPassSettings::isUseMonospace(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useMonospace, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseMonospace(const bool &useMonospace) {
   getInstance()->setValue(SettingsConstants::useMonospace, useMonospace);
 }
 
-auto QtPassSettings::isDisplayAsIs(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::displayAsIs, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setDisplayAsIs(const bool &displayAsIs) {
   getInstance()->setValue(SettingsConstants::displayAsIs, displayAsIs);
 }
 
-auto QtPassSettings::isNoLineWrapping(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::noLineWrapping, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setNoLineWrapping(const bool &noLineWrapping) {
   getInstance()->setValue(SettingsConstants::noLineWrapping, noLineWrapping);
 }
 
-auto QtPassSettings::isAddGPGId(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::addGPGId, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setAddGPGId(const bool &addGPGId) {
   getInstance()->setValue(SettingsConstants::addGPGId, addGPGId);
 }
@@ -489,21 +423,19 @@ void QtPassSettings::setPassSigningKey(const QString &passSigningKey) {
  * @return void - This method does not return a value.
  */
 void QtPassSettings::initExecutables() {
-  QString passExecutable =
-      QtPassSettings::getPassExecutable(Util::findBinaryInPath("pass"));
-  QtPassSettings::setPassExecutable(passExecutable);
-
-  QString gitExecutable =
-      QtPassSettings::getGitExecutable(Util::findBinaryInPath("git"));
-  QtPassSettings::setGitExecutable(gitExecutable);
-
-  QString gpgExecutable =
-      QtPassSettings::getGpgExecutable(Util::findBinaryInPath("gpg2"));
-  QtPassSettings::setGpgExecutable(gpgExecutable);
-
-  QString pwgenExecutable =
-      QtPassSettings::getPwgenExecutable(Util::findBinaryInPath("pwgen"));
-  QtPassSettings::setPwgenExecutable(pwgenExecutable);
+  const AppSettings s = QtPassSettings::load();
+  QtPassSettings::setPassExecutable(s.passExecutable.isEmpty()
+                                        ? Util::findBinaryInPath("pass")
+                                        : s.passExecutable);
+  QtPassSettings::setGitExecutable(s.gitExecutable.isEmpty()
+                                       ? Util::findBinaryInPath("git")
+                                       : s.gitExecutable);
+  QtPassSettings::setGpgExecutable(s.gpgExecutable.isEmpty()
+                                       ? Util::findBinaryInPath("gpg2")
+                                       : s.gpgExecutable);
+  QtPassSettings::setPwgenExecutable(s.pwgenExecutable.isEmpty()
+                                         ? Util::findBinaryInPath("pwgen")
+                                         : s.pwgenExecutable);
 }
 auto QtPassSettings::getPassExecutable(const QString &defaultValue) -> QString {
   return getInstance()
@@ -524,20 +456,10 @@ void QtPassSettings::setSshAuthSockOverride(const QString &value) {
   getInstance()->setValue(SettingsConstants::sshAuthSockOverride, value);
 }
 
-auto QtPassSettings::getGitExecutable(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::gitExecutable, defaultValue)
-      .toString();
-}
 void QtPassSettings::setGitExecutable(const QString &gitExecutable) {
   getInstance()->setValue(SettingsConstants::gitExecutable, gitExecutable);
 }
 
-auto QtPassSettings::getGpgExecutable(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::gpgExecutable, defaultValue)
-      .toString();
-}
 void QtPassSettings::setGpgExecutable(const QString &gpgExecutable) {
   getInstance()->setValue(SettingsConstants::gpgExecutable, gpgExecutable);
 }
@@ -567,29 +489,14 @@ void QtPassSettings::setUseWebDav(const bool &useWebDav) {
   getInstance()->setValue(SettingsConstants::useWebDav, useWebDav);
 }
 
-auto QtPassSettings::getWebDavUrl(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::webDavUrl, defaultValue)
-      .toString();
-}
 void QtPassSettings::setWebDavUrl(const QString &webDavUrl) {
   getInstance()->setValue(SettingsConstants::webDavUrl, webDavUrl);
 }
 
-auto QtPassSettings::getWebDavUser(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::webDavUser, defaultValue)
-      .toString();
-}
 void QtPassSettings::setWebDavUser(const QString &webDavUser) {
   getInstance()->setValue(SettingsConstants::webDavUser, webDavUser);
 }
 
-auto QtPassSettings::getWebDavPassword(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::webDavPassword, defaultValue)
-      .toString();
-}
 void QtPassSettings::setWebDavPassword(const QString &webDavPassword) {
   getInstance()->setValue(SettingsConstants::webDavPassword, webDavPassword);
 }
@@ -738,68 +645,31 @@ void QtPassSettings::setUseOtp(const bool &useOtp) {
   getInstance()->setValue(SettingsConstants::useOtp, useOtp);
 }
 
-auto QtPassSettings::isUseQrencode(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useQrencode, defaultValue)
-      .toBool();
-}
-
 void QtPassSettings::setUseQrencode(const bool &useQrencode) {
   getInstance()->setValue(SettingsConstants::useQrencode, useQrencode);
 }
 
-auto QtPassSettings::getQrencodeExecutable(const QString &defaultValue)
-    -> QString {
-  return getInstance()
-      ->value(SettingsConstants::qrencodeExecutable, defaultValue)
-      .toString();
-}
 void QtPassSettings::setQrencodeExecutable(const QString &qrencodeExecutable) {
   getInstance()->setValue(SettingsConstants::qrencodeExecutable,
                           qrencodeExecutable);
 }
 
-auto QtPassSettings::isUsePwgen(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::usePwgen, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUsePwgen(const bool &usePwgen) {
   getInstance()->setValue(SettingsConstants::usePwgen, usePwgen);
 }
 
-auto QtPassSettings::isAvoidCapitals(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::avoidCapitals, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setAvoidCapitals(const bool &avoidCapitals) {
   getInstance()->setValue(SettingsConstants::avoidCapitals, avoidCapitals);
 }
 
-auto QtPassSettings::isAvoidNumbers(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::avoidNumbers, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setAvoidNumbers(const bool &avoidNumbers) {
   getInstance()->setValue(SettingsConstants::avoidNumbers, avoidNumbers);
 }
 
-auto QtPassSettings::isLessRandom(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::lessRandom, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setLessRandom(const bool &lessRandom) {
   getInstance()->setValue(SettingsConstants::lessRandom, lessRandom);
 }
 
-auto QtPassSettings::isUseSymbols(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useSymbols, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseSymbols(const bool &useSymbols) {
   getInstance()->setValue(SettingsConstants::useSymbols, useSymbols);
 }
@@ -816,11 +686,6 @@ void QtPassSettings::setPasswordChars(const QString &passwordChars) {
   getInstance()->setValue(SettingsConstants::passwordChars, passwordChars);
 }
 
-auto QtPassSettings::isUseTrayIcon(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useTrayIcon, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseTrayIcon(const bool &useTrayIcon) {
   getInstance()->setValue(SettingsConstants::useTrayIcon, useTrayIcon);
 }
@@ -834,11 +699,6 @@ void QtPassSettings::setHideOnClose(const bool &hideOnClose) {
   getInstance()->setValue(SettingsConstants::hideOnClose, hideOnClose);
 }
 
-auto QtPassSettings::isStartMinimized(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::startMinimized, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setStartMinimized(const bool &startMinimized) {
   getInstance()->setValue(SettingsConstants::startMinimized, startMinimized);
 }
@@ -852,11 +712,6 @@ void QtPassSettings::setAlwaysOnTop(const bool &alwaysOnTop) {
   getInstance()->setValue(SettingsConstants::alwaysOnTop, alwaysOnTop);
 }
 
-auto QtPassSettings::isAutoPull(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::autoPull, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setAutoPull(const bool &autoPull) {
   getInstance()->setValue(SettingsConstants::autoPull, autoPull);
 }
@@ -879,20 +734,10 @@ void QtPassSettings::setPassTemplate(const QString &passTemplate) {
   getInstance()->setValue(SettingsConstants::passTemplate, passTemplate);
 }
 
-auto QtPassSettings::isUseTemplate(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::useTemplate, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setUseTemplate(const bool &useTemplate) {
   getInstance()->setValue(SettingsConstants::useTemplate, useTemplate);
 }
 
-auto QtPassSettings::isTemplateAllFields(const bool &defaultValue) -> bool {
-  return getInstance()
-      ->value(SettingsConstants::templateAllFields, defaultValue)
-      .toBool();
-}
 void QtPassSettings::setTemplateAllFields(const bool &templateAllFields) {
   getInstance()->setValue(SettingsConstants::templateAllFields,
                           templateAllFields);

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -143,13 +143,6 @@ public:
   static void setSize(const QSize &size);
 
   /**
-   * @brief Get maximized state.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if window is maximized.
-   */
-  static auto isMaximized(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save maximized state.
    * @param maximized Maximized state to save.
    */
@@ -223,32 +216,11 @@ public:
 
   // Password store settings
   /**
-   * @brief Get whether to use pass (true) or GPG (false).
-   * @param defaultValue Boolean returned if not saved (defaults to false).
-   * @return true if using pass, false if using GPG.
-   */
-  static auto isUsePass(const bool &defaultValue = QVariant().toBool()) -> bool;
-  /**
    * @brief Save use pass setting.
    * @param usePass true to use pass, false for GPG.
    */
   static void setUsePass(const bool &usePass);
 
-  /**
-   * @brief Get clipboard type preference.
-   * @param defaultValue Default value returned if not saved.
-   * @return Clipboard type as Enums::clipBoardType.
-   */
-  static auto getClipBoardTypeRaw(
-      const Enums::clipBoardType &defaultValue = Enums::CLIPBOARD_NEVER) -> int;
-  /**
-   * @brief Get clipboard type as enum.
-   * @param defaultValue Default value returned if not saved.
-   * @return Clipboard type as Enums::clipBoardType.
-   */
-  static auto getClipBoardType(
-      const Enums::clipBoardType &defaultValue = Enums::CLIPBOARD_NEVER)
-      -> Enums::clipBoardType;
   /**
    * @brief Save clipboard type.
    * @param clipBoardType Clipboard type to save.
@@ -257,25 +229,11 @@ public:
 
   // UI settings
   /**
-   * @brief Get whether to use selection (X11) for clipboard.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if using selection.
-   */
-  static auto isUseSelection(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save use selection setting.
    * @param useSelection true to use selection.
    */
   static void setUseSelection(const bool &useSelection);
 
-  /**
-   * @brief Get whether to use autoclear for clipboard.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if autoclear is enabled.
-   */
-  static auto isUseAutoclear(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save use autoclear setting.
    * @param useAutoclear true to enable autoclear.
@@ -296,13 +254,6 @@ public:
   static void setAutoclearSeconds(const int &autoClearSeconds);
 
   /**
-   * @brief Get whether to use panel autoclear.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if panel autoclear is enabled.
-   */
-  static auto
-  isUseAutoclearPanel(const bool &defaultValue = QVariant().toBool()) -> bool;
-  /**
    * @brief Save use autoclear panel setting.
    * @param useAutoclearPanel true to enable panel autoclear.
    */
@@ -322,25 +273,11 @@ public:
   static void setAutoclearPanelSeconds(const int &autoClearPanelSeconds);
 
   /**
-   * @brief Get whether to hide password in UI.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if password is hidden.
-   */
-  static auto isHidePassword(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save hide password setting.
    * @param hidePassword true to hide password.
    */
   static void setHidePassword(const bool &hidePassword);
 
-  /**
-   * @brief Get whether to hide content (password + username).
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if content is hidden.
-   */
-  static auto isHideContent(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save hide content setting.
    * @param hideContent true to hide content.
@@ -348,25 +285,11 @@ public:
   static void setHideContent(const bool &hideContent);
 
   /**
-   * @brief Get whether to use monospace font.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if using monospace font.
-   */
-  static auto isUseMonospace(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save use monospace setting.
    * @param useMonospace true to use monospace font.
    */
   static void setUseMonospace(const bool &useMonospace);
 
-  /**
-   * @brief Get whether to display password as-is (no modification).
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if displaying as-is.
-   */
-  static auto isDisplayAsIs(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save display as-is setting.
    * @param displayAsIs true to display unmodified.
@@ -374,25 +297,11 @@ public:
   static void setDisplayAsIs(const bool &displayAsIs);
 
   /**
-   * @brief Get whether to disable line wrapping.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if line wrapping disabled.
-   */
-  static auto isNoLineWrapping(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save no line wrapping setting.
    * @param noLineWrapping true to disable wrapping.
    */
   static void setNoLineWrapping(const bool &noLineWrapping);
 
-  /**
-   * @brief Get whether to auto-add GPG ID when receiving files.
-   * @param defaultValue Boolean returned if not saved.
-   * @return true if auto-adding is enabled.
-   */
-  static auto isAddGPGId(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save add GPG ID setting.
    * @param addGPGId true to auto-add GPG IDs.
@@ -461,27 +370,11 @@ public:
   static void setSshAuthSockOverride(const QString &value);
 
   /**
-   * @brief Get git executable path.
-   * @param defaultValue String returned if not saved.
-   * @return Path to git executable.
-   */
-  static auto
-  getGitExecutable(const QString &defaultValue = QVariant().toString())
-      -> QString;
-  /**
    * @brief Save git executable path.
    * @param gitExecutable Path to git.
    */
   static void setGitExecutable(const QString &gitExecutable);
 
-  /**
-   * @brief Get GPG executable path.
-   * @param defaultValue String returned if not saved.
-   * @return Path to GPG executable.
-   */
-  static auto
-  getGpgExecutable(const QString &defaultValue = QVariant().toString())
-      -> QString;
   /**
    * @brief Save GPG executable path.
    * @param gpgExecutable Path to GPG executable.
@@ -524,39 +417,17 @@ public:
   static void setUseWebDav(const bool &useWebDav);
 
   /**
-   * @brief Get WebDAV URL.
-   * @param defaultValue String returned if not saved.
-   * @return WebDAV URL.
-   */
-  static auto getWebDavUrl(const QString &defaultValue = QVariant().toString())
-      -> QString;
-  /**
    * @brief Save WebDAV URL.
    * @param webDavUrl WebDAV URL.
    */
   static void setWebDavUrl(const QString &webDavUrl);
 
   /**
-   * @brief Get WebDAV username.
-   * @param defaultValue String returned if not saved.
-   * @return WebDAV username.
-   */
-  static auto getWebDavUser(const QString &defaultValue = QVariant().toString())
-      -> QString;
-  /**
    * @brief Save WebDAV username.
    * @param webDavUser WebDAV username.
    */
   static void setWebDavUser(const QString &webDavUser);
 
-  /**
-   * @brief Get WebDAV password.
-   * @param defaultValue String returned if not saved.
-   * @return WebDAV password.
-   */
-  static auto
-  getWebDavPassword(const QString &defaultValue = QVariant().toString())
-      -> QString;
   /**
    * @brief Save WebDAV password.
    * @param webDavPassword WebDAV password.
@@ -663,26 +534,11 @@ public:
   static void setUseOtp(const bool &useOtp);
 
   /**
-   * @brief Check whether qrencode support is enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if qrencode support is enabled.
-   */
-  static auto isUseQrencode(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save qrencode support flag.
    * @param useQrencode Whether to enable qrencode support.
    */
   static void setUseQrencode(const bool &useQrencode);
 
-  /**
-   * @brief Get qrencode executable path.
-   * @param defaultValue String returned if not saved.
-   * @return Path to qrencode executable.
-   */
-  static auto
-  getQrencodeExecutable(const QString &defaultValue = QVariant().toString())
-      -> QString;
   /**
    * @brief Save qrencode executable path.
    * @param qrencodeExecutable Path to qrencode executable.
@@ -690,25 +546,11 @@ public:
   static void setQrencodeExecutable(const QString &qrencodeExecutable);
 
   /**
-   * @brief Check whether pwgen support is enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if pwgen support is enabled.
-   */
-  static auto isUsePwgen(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save pwgen support flag.
    * @param usePwgen Whether to enable pwgen support.
    */
   static void setUsePwgen(const bool &usePwgen);
 
-  /**
-   * @brief Check whether uppercase characters should be avoided.
-   * @param defaultValue Value returned if not saved.
-   * @return True if uppercase characters are avoided.
-   */
-  static auto isAvoidCapitals(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save uppercase avoidance flag.
    * @param avoidCapitals Whether uppercase characters should be avoided.
@@ -716,38 +558,17 @@ public:
   static void setAvoidCapitals(const bool &avoidCapitals);
 
   /**
-   * @brief Check whether numeric characters should be avoided.
-   * @param defaultValue Value returned if not saved.
-   * @return True if numeric characters are avoided.
-   */
-  static auto isAvoidNumbers(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save numeric avoidance flag.
    * @param avoidNumbers Whether numeric characters should be avoided.
    */
   static void setAvoidNumbers(const bool &avoidNumbers);
 
   /**
-   * @brief Check whether less random password generation is enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if less random generation is enabled.
-   */
-  static auto isLessRandom(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save less-random generation flag.
    * @param lessRandom Whether less-random generation is enabled.
    */
   static void setLessRandom(const bool &lessRandom);
 
-  /**
-   * @brief Check whether symbol characters are enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if symbol characters are enabled.
-   */
-  static auto isUseSymbols(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save symbol usage flag.
    * @param useSymbols Whether symbol characters are enabled.
@@ -781,13 +602,6 @@ public:
   static void setPasswordChars(const QString &passwordChars);
 
   /**
-   * @brief Check whether tray icon support is enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if tray icon support is enabled.
-   */
-  static auto isUseTrayIcon(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save tray icon support flag.
    * @param useTrayIcon Whether tray icon support is enabled.
    */
@@ -807,13 +621,6 @@ public:
   static void setHideOnClose(const bool &hideOnClose);
 
   /**
-   * @brief Check whether application should start minimized.
-   * @param defaultValue Value returned if not saved.
-   * @return True if application should start minimized.
-   */
-  static auto isStartMinimized(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save start-minimized flag.
    * @param startMinimized Whether application should start minimized.
    */
@@ -832,13 +639,6 @@ public:
    */
   static void setAlwaysOnTop(const bool &alwaysOnTop);
 
-  /**
-   * @brief Check whether automatic pull is enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if automatic pull is enabled.
-   */
-  static auto isAutoPull(const bool &defaultValue = QVariant().toBool())
-      -> bool;
   /**
    * @brief Save automatic pull flag.
    * @param autoPull Whether automatic pull should be enabled.
@@ -873,25 +673,11 @@ public:
   static void setPassTemplate(const QString &passTemplate);
 
   /**
-   * @brief Check whether template usage is enabled.
-   * @param defaultValue Value returned if not saved.
-   * @return True if template usage is enabled.
-   */
-  static auto isUseTemplate(const bool &defaultValue = QVariant().toBool())
-      -> bool;
-  /**
    * @brief Save template usage flag.
    * @param useTemplate Whether template usage should be enabled.
    */
   static void setUseTemplate(const bool &useTemplate);
 
-  /**
-   * @brief Check whether template applies to all fields.
-   * @param defaultValue Value returned if not saved.
-   * @return True if template applies to all fields.
-   */
-  static auto
-  isTemplateAllFields(const bool &defaultValue = QVariant().toBool()) -> bool;
   /**
    * @brief Save template-all-fields flag.
    * @param templateAllFields Whether template should apply to all fields.

--- a/src/settingsserializer.cpp
+++ b/src/settingsserializer.cpp
@@ -63,7 +63,7 @@ auto SettingsSerializer::load(QSettings &qs) -> AppSettings {
       qs.value(SettingsConstants::noLineWrapping, false).toBool();
 
   // Features
-  // Default true: every QtPassSettings::isAddGPGId() call site passes true.
+  // Default true: AppSettings::addGPGId defaults to true.
   s.addGPGId = qs.value(SettingsConstants::addGPGId, true).toBool();
   s.useGit = qs.value(SettingsConstants::useGit, false).toBool();
   s.useGrepSearch = qs.value(SettingsConstants::useGrepSearch, false).toBool();

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -73,9 +73,10 @@ void tst_mainwindow::initTestCase() {
 
   // Save original settings before modifying them
   m_savedPassStore = QtPassSettings::getPassStore();
-  m_savedUsePass = QtPassSettings::load().usePass;
   m_savedShowProcessOutput = QtPassSettings::isShowProcessOutput();
-  m_savedGpgExecutable = QtPassSettings::load().gpgExecutable;
+  const AppSettings savedSettings = QtPassSettings::load();
+  m_savedUsePass = savedSettings.usePass;
+  m_savedGpgExecutable = savedSettings.gpgExecutable;
 
   // Point QtPassSettings at the temp store and use gpg (not pass) mode so
   // configIsValid() only requires the .gpg-id file + a gpg binary.

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -73,9 +73,9 @@ void tst_mainwindow::initTestCase() {
 
   // Save original settings before modifying them
   m_savedPassStore = QtPassSettings::getPassStore();
-  m_savedUsePass = QtPassSettings::isUsePass();
+  m_savedUsePass = QtPassSettings::load().usePass;
   m_savedShowProcessOutput = QtPassSettings::isShowProcessOutput();
-  m_savedGpgExecutable = QtPassSettings::getGpgExecutable();
+  m_savedGpgExecutable = QtPassSettings::load().gpgExecutable;
 
   // Point QtPassSettings at the temp store and use gpg (not pass) mode so
   // configIsValid() only requires the .gpg-id file + a gpg binary.

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -188,17 +188,22 @@ const BoolSetting boolSettings[] = {
     {"useOtp", QtPassSettings::setUseOtp, &AppSettings::useOtp},
     {"useTrayIcon", QtPassSettings::setUseTrayIcon, &AppSettings::useTrayIcon},
     {"usePwgen", QtPassSettings::setUsePwgen, &AppSettings::usePwgen},
-    {"hidePassword", QtPassSettings::setHidePassword, &AppSettings::hidePassword},
+    {"hidePassword", QtPassSettings::setHidePassword,
+     &AppSettings::hidePassword},
     {"hideContent", QtPassSettings::setHideContent, &AppSettings::hideContent},
-    {"useSelection", QtPassSettings::setUseSelection, &AppSettings::useSelection},
-    {"useAutoclear", QtPassSettings::setUseAutoclear, &AppSettings::useAutoclear},
-    {"useMonospace", QtPassSettings::setUseMonospace, &AppSettings::useMonospace},
+    {"useSelection", QtPassSettings::setUseSelection,
+     &AppSettings::useSelection},
+    {"useAutoclear", QtPassSettings::setUseAutoclear,
+     &AppSettings::useAutoclear},
+    {"useMonospace", QtPassSettings::setUseMonospace,
+     &AppSettings::useMonospace},
     {"noLineWrapping", QtPassSettings::setNoLineWrapping,
      &AppSettings::noLineWrapping},
     {"addGPGId", QtPassSettings::setAddGPGId, &AppSettings::addGPGId},
     {"avoidCapitals", QtPassSettings::setAvoidCapitals,
      &AppSettings::avoidCapitals},
-    {"avoidNumbers", QtPassSettings::setAvoidNumbers, &AppSettings::avoidNumbers},
+    {"avoidNumbers", QtPassSettings::setAvoidNumbers,
+     &AppSettings::avoidNumbers},
     {"lessRandom", QtPassSettings::setLessRandom, &AppSettings::lessRandom},
     {"useSymbols", QtPassSettings::setUseSymbols, &AppSettings::useSymbols},
     {"displayAsIs", QtPassSettings::setDisplayAsIs, &AppSettings::displayAsIs},
@@ -242,10 +247,12 @@ void tst_settings::boolRoundTrip() {
     if (setting == s.name) {
       s.setter(testValue);
       const AppSettings loaded = QtPassSettings::load();
-      QVERIFY2(loaded.*s.field == testValue,
-               qPrintable(QString("%1 should be %2")
+      const bool actual = loaded.*s.field;
+      QVERIFY2(actual == testValue,
+               qPrintable(QString("%1 should be %2, got %3")
                               .arg(setting)
-                              .arg(testValue ? "true" : "false")));
+                              .arg(testValue ? "true" : "false")
+                              .arg(actual ? "true" : "false")));
       return;
     }
   }
@@ -302,7 +309,8 @@ const StringSetting stringSettings[] = {
     {"webDavPassword", QtPassSettings::setWebDavPassword,
      &AppSettings::webDavPassword},
     {"profile", QtPassSettings::setProfile, &AppSettings::activeProfile},
-    {"passTemplate", QtPassSettings::setPassTemplate, &AppSettings::passTemplate},
+    {"passTemplate", QtPassSettings::setPassTemplate,
+     &AppSettings::passTemplate},
     {"sshAuthSockOverride", QtPassSettings::setSshAuthSockOverride,
      &AppSettings::sshAuthSockOverride},
 };

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -179,59 +179,47 @@ namespace {
 struct BoolSetting {
   const char *name;
   void (*setter)(const bool &);
-  bool (*getter)(const bool &);
+  bool AppSettings::*field;
 };
 
 const BoolSetting boolSettings[] = {
-    {"usePass", QtPassSettings::setUsePass, QtPassSettings::isUsePass},
-    {"useGit", QtPassSettings::setUseGit, QtPassSettings::isUseGit},
-    {"useOtp", QtPassSettings::setUseOtp, QtPassSettings::isUseOtp},
-    {"useTrayIcon", QtPassSettings::setUseTrayIcon,
-     QtPassSettings::isUseTrayIcon},
-    {"usePwgen", QtPassSettings::setUsePwgen, QtPassSettings::isUsePwgen},
-    {"hidePassword", QtPassSettings::setHidePassword,
-     QtPassSettings::isHidePassword},
-    {"hideContent", QtPassSettings::setHideContent,
-     QtPassSettings::isHideContent},
-    {"useSelection", QtPassSettings::setUseSelection,
-     QtPassSettings::isUseSelection},
-    {"useAutoclear", QtPassSettings::setUseAutoclear,
-     QtPassSettings::isUseAutoclear},
-    {"useMonospace", QtPassSettings::setUseMonospace,
-     QtPassSettings::isUseMonospace},
+    {"usePass", QtPassSettings::setUsePass, &AppSettings::usePass},
+    {"useGit", QtPassSettings::setUseGit, &AppSettings::useGit},
+    {"useOtp", QtPassSettings::setUseOtp, &AppSettings::useOtp},
+    {"useTrayIcon", QtPassSettings::setUseTrayIcon, &AppSettings::useTrayIcon},
+    {"usePwgen", QtPassSettings::setUsePwgen, &AppSettings::usePwgen},
+    {"hidePassword", QtPassSettings::setHidePassword, &AppSettings::hidePassword},
+    {"hideContent", QtPassSettings::setHideContent, &AppSettings::hideContent},
+    {"useSelection", QtPassSettings::setUseSelection, &AppSettings::useSelection},
+    {"useAutoclear", QtPassSettings::setUseAutoclear, &AppSettings::useAutoclear},
+    {"useMonospace", QtPassSettings::setUseMonospace, &AppSettings::useMonospace},
     {"noLineWrapping", QtPassSettings::setNoLineWrapping,
-     QtPassSettings::isNoLineWrapping},
-    {"addGPGId", QtPassSettings::setAddGPGId, QtPassSettings::isAddGPGId},
+     &AppSettings::noLineWrapping},
+    {"addGPGId", QtPassSettings::setAddGPGId, &AppSettings::addGPGId},
     {"avoidCapitals", QtPassSettings::setAvoidCapitals,
-     QtPassSettings::isAvoidCapitals},
-    {"avoidNumbers", QtPassSettings::setAvoidNumbers,
-     QtPassSettings::isAvoidNumbers},
-    {"lessRandom", QtPassSettings::setLessRandom, QtPassSettings::isLessRandom},
-    {"useSymbols", QtPassSettings::setUseSymbols, QtPassSettings::isUseSymbols},
-    {"displayAsIs", QtPassSettings::setDisplayAsIs,
-     QtPassSettings::isDisplayAsIs},
-    {"hideOnClose", QtPassSettings::setHideOnClose,
-     QtPassSettings::isHideOnClose},
+     &AppSettings::avoidCapitals},
+    {"avoidNumbers", QtPassSettings::setAvoidNumbers, &AppSettings::avoidNumbers},
+    {"lessRandom", QtPassSettings::setLessRandom, &AppSettings::lessRandom},
+    {"useSymbols", QtPassSettings::setUseSymbols, &AppSettings::useSymbols},
+    {"displayAsIs", QtPassSettings::setDisplayAsIs, &AppSettings::displayAsIs},
+    {"hideOnClose", QtPassSettings::setHideOnClose, &AppSettings::hideOnClose},
     {"startMinimized", QtPassSettings::setStartMinimized,
-     QtPassSettings::isStartMinimized},
-    {"alwaysOnTop", QtPassSettings::setAlwaysOnTop,
-     QtPassSettings::isAlwaysOnTop},
-    {"autoPull", QtPassSettings::setAutoPull, QtPassSettings::isAutoPull},
-    {"autoPush", QtPassSettings::setAutoPush, QtPassSettings::isAutoPush},
-    {"useTemplate", QtPassSettings::setUseTemplate,
-     QtPassSettings::isUseTemplate},
+     &AppSettings::startMinimized},
+    {"alwaysOnTop", QtPassSettings::setAlwaysOnTop, &AppSettings::alwaysOnTop},
+    {"autoPull", QtPassSettings::setAutoPull, &AppSettings::autoPull},
+    {"autoPush", QtPassSettings::setAutoPush, &AppSettings::autoPush},
+    {"useTemplate", QtPassSettings::setUseTemplate, &AppSettings::useTemplate},
     {"templateAllFields", QtPassSettings::setTemplateAllFields,
-     QtPassSettings::isTemplateAllFields},
-    {"useWebDav", QtPassSettings::setUseWebDav, QtPassSettings::isUseWebDav},
-    {"useQrencode", QtPassSettings::setUseQrencode,
-     QtPassSettings::isUseQrencode},
+     &AppSettings::templateAllFields},
+    {"useWebDav", QtPassSettings::setUseWebDav, &AppSettings::useWebDav},
+    {"useQrencode", QtPassSettings::setUseQrencode, &AppSettings::useQrencode},
     {"useAutoclearPanel", QtPassSettings::setUseAutoclearPanel,
-     QtPassSettings::isUseAutoclearPanel},
-    {"maximized", QtPassSettings::setMaximized, QtPassSettings::isMaximized},
+     &AppSettings::useAutoclearPanel},
+    {"maximized", QtPassSettings::setMaximized, &AppSettings::maximized},
     {"useGrepSearch", QtPassSettings::setUseGrepSearch,
-     QtPassSettings::isUseGrepSearch},
+     &AppSettings::useGrepSearch},
     {"showProcessOutput", QtPassSettings::setShowProcessOutput,
-     QtPassSettings::isShowProcessOutput},
+     &AppSettings::showProcessOutput},
 };
 } // namespace
 
@@ -253,13 +241,11 @@ void tst_settings::boolRoundTrip() {
   for (const auto &s : boolSettings) {
     if (setting == s.name) {
       s.setter(testValue);
-      // Pass !testValue as the getter's default so a missing/unstored value
-      // would surface as a mismatch instead of silently equalling testValue.
-      QVERIFY2(s.getter(!testValue) == testValue,
-               qPrintable(QString("%1 should be %2, got %3")
+      const AppSettings loaded = QtPassSettings::load();
+      QVERIFY2(loaded.*s.field == testValue,
+               qPrintable(QString("%1 should be %2")
                               .arg(setting)
-                              .arg(testValue ? "true" : "false")
-                              .arg(s.getter(!testValue) ? "true" : "false")));
+                              .arg(testValue ? "true" : "false")));
       return;
     }
   }
@@ -268,7 +254,8 @@ void tst_settings::boolRoundTrip() {
 
 void tst_settings::setAndGetClipBoardType() {
   QtPassSettings::setClipBoardType(1);
-  QCOMPARE(QtPassSettings::getClipBoardType(), 1);
+  QCOMPARE(QtPassSettings::load().clipBoardType,
+           static_cast<Enums::clipBoardType>(1));
 }
 
 void tst_settings::setAndGetPasswordLength() {
@@ -281,45 +268,43 @@ namespace {
 struct IntSetting {
   const char *name;
   void (*setter)(const int &);
-  int (*getter)(const int &);
+  int AppSettings::*field;
 };
 
 const IntSetting intSettings[] = {
     {"autoclearSeconds", QtPassSettings::setAutoclearSeconds,
-     QtPassSettings::getAutoclearSeconds},
+     &AppSettings::autoclearSeconds},
     {"autoclearPanelSeconds", QtPassSettings::setAutoclearPanelSeconds,
-     QtPassSettings::getAutoclearPanelSeconds},
+     &AppSettings::autoclearPanelSeconds},
 };
 
 struct StringSetting {
   const char *name;
   void (*setter)(const QString &);
-  QString (*getter)(const QString &);
+  QString AppSettings::*field;
 };
 
 const StringSetting stringSettings[] = {
     {"passSigningKey", QtPassSettings::setPassSigningKey,
-     QtPassSettings::getPassSigningKey},
+     &AppSettings::passSigningKey},
     {"passExecutable", QtPassSettings::setPassExecutable,
-     QtPassSettings::getPassExecutable},
+     &AppSettings::passExecutable},
     {"gitExecutable", QtPassSettings::setGitExecutable,
-     QtPassSettings::getGitExecutable},
+     &AppSettings::gitExecutable},
     {"gpgExecutable", QtPassSettings::setGpgExecutable,
-     QtPassSettings::getGpgExecutable},
+     &AppSettings::gpgExecutable},
     {"pwgenExecutable", QtPassSettings::setPwgenExecutable,
-     QtPassSettings::getPwgenExecutable},
+     &AppSettings::pwgenExecutable},
     {"qrencodeExecutable", QtPassSettings::setQrencodeExecutable,
-     QtPassSettings::getQrencodeExecutable},
-    {"webDavUrl", QtPassSettings::setWebDavUrl, QtPassSettings::getWebDavUrl},
-    {"webDavUser", QtPassSettings::setWebDavUser,
-     QtPassSettings::getWebDavUser},
+     &AppSettings::qrencodeExecutable},
+    {"webDavUrl", QtPassSettings::setWebDavUrl, &AppSettings::webDavUrl},
+    {"webDavUser", QtPassSettings::setWebDavUser, &AppSettings::webDavUser},
     {"webDavPassword", QtPassSettings::setWebDavPassword,
-     QtPassSettings::getWebDavPassword},
-    {"profile", QtPassSettings::setProfile, QtPassSettings::getProfile},
-    {"passTemplate", QtPassSettings::setPassTemplate,
-     QtPassSettings::getPassTemplate},
+     &AppSettings::webDavPassword},
+    {"profile", QtPassSettings::setProfile, &AppSettings::activeProfile},
+    {"passTemplate", QtPassSettings::setPassTemplate, &AppSettings::passTemplate},
     {"sshAuthSockOverride", QtPassSettings::setSshAuthSockOverride,
-     QtPassSettings::getSshAuthSockOverride},
+     &AppSettings::sshAuthSockOverride},
 };
 } // namespace
 
@@ -341,7 +326,7 @@ void tst_settings::intRoundTrip() {
   for (const auto &s : intSettings) {
     if (setting == s.name) {
       s.setter(testValue);
-      QCOMPARE(s.getter(-1), testValue);
+      QCOMPARE(QtPassSettings::load().*s.field, testValue);
       return;
     }
   }
@@ -390,7 +375,7 @@ void tst_settings::stringRoundTrip() {
   for (const auto &s : stringSettings) {
     if (setting == s.name) {
       s.setter(testValue);
-      QCOMPARE(s.getter(QString()), testValue);
+      QCOMPARE(QtPassSettings::load().*s.field, testValue);
       return;
     }
   }

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -672,7 +672,7 @@ void tst_util::createGpgIdFileEmptyKeys() {
 
 void tst_util::generateRandomPassword() {
   SettingGuard<bool, QtPassSettings::setUsePwgen> disablePwgenGuard{
-      QtPassSettings::isUsePwgen(), false};
+      QtPassSettings::load().usePwgen, false};
 
   ImitatePass pass;
   QString charset = "abcdefghijklmnopqrstuvwxyz";
@@ -761,7 +761,7 @@ void tst_util::generateRandomPassword() {
 
 void tst_util::boundedRandom() {
   SettingGuard<bool, QtPassSettings::setUsePwgen> disablePwgenGuard{
-      QtPassSettings::isUsePwgen(), false};
+      QtPassSettings::load().usePwgen, false};
 
   ImitatePass pass;
 
@@ -823,7 +823,7 @@ void tst_util::configIsValid() {
   PassStoreGuard guard(QtPassSettings::getPassStore());
 
   SettingGuard<bool, QtPassSettings::setUsePass> usePassGuard{
-      QtPassSettings::isUsePass(), false};
+      QtPassSettings::load().usePass, false};
 
   // No .gpg-id in this store => config must be invalid.
   QtPassSettings::setPassStore(tempDir.path());
@@ -839,7 +839,7 @@ void tst_util::configIsValid() {
   gpgIdFile.close();
 
   SettingGuard<QString, QtPassSettings::setGpgExecutable> gpgGuard{
-      QtPassSettings::getGpgExecutable(), QString()};
+      QtPassSettings::load().gpgExecutable, QString()};
 
   isValid = Util::configIsValid(QtPassSettings::load());
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "


### PR DESCRIPTION
## Summary

- Replaces getter function-pointers in `tst_settings` with pointer-to-data-member (`bool/int/QString AppSettings::*field`) so round-trip tests read from `QtPassSettings::load()` directly
- Deletes 30 bool/int/string/enum getter declarations from `qtpasssettings.h` and their implementations from `qtpasssettings.cpp`
- Refactors `initExecutables()` to use an `AppSettings` snapshot (4-field multi-read site), eliminating the now-dead `getGitExecutable()` and `getGpgExecutable()` callers there and in two test helpers (`tst_util.cpp`, `tst_mainwindow.cpp`)
- Updates `settingsserializer.cpp` comment to reference `AppSettings::addGPGId` instead of the removed `isAddGPGId()`

Getters with remaining production callers are untouched (e.g. `getPassStore`, `isAutoPush`, `isUseWebDav`, `getAutoclearSeconds`).

Part of #1511.

## Test plan

- [ ] `make check` passes (pre-existing `getPasswordConfigurationDefault` failure unrelated)
- [ ] `make -j4` builds cleanly with no errors or new warnings
- [ ] `clang-format` applied to all changed `.cpp`/`.h` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how external-tool paths and related settings are initialized, preferring saved overrides when present and otherwise using resolved binaries from the system.
  * Streamlined settings access patterns for more consistent configuration loading and persistence.
* **Tests**
  * Updated settings-related and utility tests to validate persisted values via the consolidated settings snapshot.
* **Documentation**
  * Refined an in-code explanation of the default setting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->