### PR TITLE
refactor(#1511): delete 37 dead setter/getter wrappers

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -149,7 +149,7 @@ auto main(int argc, char *argv[]) -> int {
   // Probe / set SSH_AUTH_SOCK before any subprocess runs (issue #543).
   // GUI launchers don't inherit shell-set env vars, so users with
   // gpg-agent's SSH support get failed git push/pull until this fires.
-  SshAuthSock::initialise(QtPassSettings::getSshAuthSockOverride());
+  SshAuthSock::initialise(QtPassSettings::load().sshAuthSockOverride);
 
   // Setup and load translator for localization.
   //

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -103,15 +103,6 @@ auto QtPassSettings::getPasswordConfiguration() -> PasswordConfiguration {
   return config;
 }
 
-void QtPassSettings::setPasswordConfiguration(
-    const PasswordConfiguration &config) {
-  getInstance()->setValue(SettingsConstants::passwordLength, config.length);
-  getInstance()->setValue(SettingsConstants::passwordCharsSelection,
-                          config.selected);
-  getInstance()->setValue(SettingsConstants::passwordChars,
-                          config.Characters[PasswordConfiguration::CUSTOM]);
-}
-
 /**
  * @brief Retrieves the stored profiles configuration as a nested hash map.
  * @details Reads profile data from the settings group, including legacy profile
@@ -303,18 +294,6 @@ void QtPassSettings::setUsePass(const bool &usePass) {
   PassBackendFactory::invalidate();
 }
 
-void QtPassSettings::setClipBoardType(const int &clipBoardType) {
-  getInstance()->setValue(SettingsConstants::clipBoardType, clipBoardType);
-}
-
-void QtPassSettings::setUseSelection(const bool &useSelection) {
-  getInstance()->setValue(SettingsConstants::useSelection, useSelection);
-}
-
-void QtPassSettings::setUseAutoclear(const bool &useAutoclear) {
-  getInstance()->setValue(SettingsConstants::useAutoclear, useAutoclear);
-}
-
 auto QtPassSettings::getAutoclearSeconds(const int &defaultValue) -> int {
   return getInstance()
       ->value(SettingsConstants::autoclearSeconds, defaultValue)
@@ -323,11 +302,6 @@ auto QtPassSettings::getAutoclearSeconds(const int &defaultValue) -> int {
 void QtPassSettings::setAutoclearSeconds(const int &autoClearSeconds) {
   getInstance()->setValue(SettingsConstants::autoclearSeconds,
                           autoClearSeconds);
-}
-
-void QtPassSettings::setUseAutoclearPanel(const bool &useAutoclearPanel) {
-  getInstance()->setValue(SettingsConstants::useAutoclearPanel,
-                          useAutoclearPanel);
 }
 
 auto QtPassSettings::getAutoclearPanelSeconds(const int &defaultValue) -> int {
@@ -339,30 +313,6 @@ void QtPassSettings::setAutoclearPanelSeconds(
     const int &autoClearPanelSeconds) {
   getInstance()->setValue(SettingsConstants::autoclearPanelSeconds,
                           autoClearPanelSeconds);
-}
-
-void QtPassSettings::setHidePassword(const bool &hidePassword) {
-  getInstance()->setValue(SettingsConstants::hidePassword, hidePassword);
-}
-
-void QtPassSettings::setHideContent(const bool &hideContent) {
-  getInstance()->setValue(SettingsConstants::hideContent, hideContent);
-}
-
-void QtPassSettings::setUseMonospace(const bool &useMonospace) {
-  getInstance()->setValue(SettingsConstants::useMonospace, useMonospace);
-}
-
-void QtPassSettings::setDisplayAsIs(const bool &displayAsIs) {
-  getInstance()->setValue(SettingsConstants::displayAsIs, displayAsIs);
-}
-
-void QtPassSettings::setNoLineWrapping(const bool &noLineWrapping) {
-  getInstance()->setValue(SettingsConstants::noLineWrapping, noLineWrapping);
-}
-
-void QtPassSettings::setAddGPGId(const bool &addGPGId) {
-  getInstance()->setValue(SettingsConstants::addGPGId, addGPGId);
 }
 
 /**
@@ -446,16 +396,6 @@ void QtPassSettings::setPassExecutable(const QString &passExecutable) {
   getInstance()->setValue(SettingsConstants::passExecutable, passExecutable);
 }
 
-auto QtPassSettings::getSshAuthSockOverride(const QString &defaultValue)
-    -> QString {
-  return getInstance()
-      ->value(SettingsConstants::sshAuthSockOverride, defaultValue)
-      .toString();
-}
-void QtPassSettings::setSshAuthSockOverride(const QString &value) {
-  getInstance()->setValue(SettingsConstants::sshAuthSockOverride, value);
-}
-
 void QtPassSettings::setGitExecutable(const QString &gitExecutable) {
   getInstance()->setValue(SettingsConstants::gitExecutable, gitExecutable);
 }
@@ -474,33 +414,11 @@ void QtPassSettings::setPwgenExecutable(const QString &pwgenExecutable) {
   getInstance()->setValue(SettingsConstants::pwgenExecutable, pwgenExecutable);
 }
 
-auto QtPassSettings::getGpgHome(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::gpgHome, defaultValue)
-      .toString();
-}
-
 auto QtPassSettings::isUseWebDav(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::useWebDav, defaultValue)
       .toBool();
 }
-void QtPassSettings::setUseWebDav(const bool &useWebDav) {
-  getInstance()->setValue(SettingsConstants::useWebDav, useWebDav);
-}
-
-void QtPassSettings::setWebDavUrl(const QString &webDavUrl) {
-  getInstance()->setValue(SettingsConstants::webDavUrl, webDavUrl);
-}
-
-void QtPassSettings::setWebDavUser(const QString &webDavUser) {
-  getInstance()->setValue(SettingsConstants::webDavUser, webDavUser);
-}
-
-void QtPassSettings::setWebDavPassword(const QString &webDavPassword) {
-  getInstance()->setValue(SettingsConstants::webDavPassword, webDavPassword);
-}
-
 auto QtPassSettings::getProfile(const QString &defaultValue) -> QString {
   return getInstance()
       ->value(SettingsConstants::profile, defaultValue)
@@ -623,30 +541,14 @@ auto QtPassSettings::isUseGit(const bool &defaultValue) -> bool {
   }
   return storedValue;
 }
-void QtPassSettings::setUseGit(const bool &useGit) {
-  getInstance()->setValue(SettingsConstants::useGit, useGit);
-}
-
 auto QtPassSettings::isUseGrepSearch(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::useGrepSearch, defaultValue)
       .toBool();
 }
 
-void QtPassSettings::setUseGrepSearch(const bool &useGrepSearch) {
-  getInstance()->setValue(SettingsConstants::useGrepSearch, useGrepSearch);
-}
-
 auto QtPassSettings::isUseOtp(const bool &defaultValue) -> bool {
   return getInstance()->value(SettingsConstants::useOtp, defaultValue).toBool();
-}
-
-void QtPassSettings::setUseOtp(const bool &useOtp) {
-  getInstance()->setValue(SettingsConstants::useOtp, useOtp);
-}
-
-void QtPassSettings::setUseQrencode(const bool &useQrencode) {
-  getInstance()->setValue(SettingsConstants::useQrencode, useQrencode);
 }
 
 void QtPassSettings::setQrencodeExecutable(const QString &qrencodeExecutable) {
@@ -658,62 +560,15 @@ void QtPassSettings::setUsePwgen(const bool &usePwgen) {
   getInstance()->setValue(SettingsConstants::usePwgen, usePwgen);
 }
 
-void QtPassSettings::setAvoidCapitals(const bool &avoidCapitals) {
-  getInstance()->setValue(SettingsConstants::avoidCapitals, avoidCapitals);
-}
-
-void QtPassSettings::setAvoidNumbers(const bool &avoidNumbers) {
-  getInstance()->setValue(SettingsConstants::avoidNumbers, avoidNumbers);
-}
-
-void QtPassSettings::setLessRandom(const bool &lessRandom) {
-  getInstance()->setValue(SettingsConstants::lessRandom, lessRandom);
-}
-
-void QtPassSettings::setUseSymbols(const bool &useSymbols) {
-  getInstance()->setValue(SettingsConstants::useSymbols, useSymbols);
-}
-
-void QtPassSettings::setPasswordLength(const int &passwordLength) {
-  getInstance()->setValue(SettingsConstants::passwordLength, passwordLength);
-}
-void QtPassSettings::setPasswordCharsSelection(
-    const int &passwordCharsSelection) {
-  getInstance()->setValue(SettingsConstants::passwordCharsSelection,
-                          passwordCharsSelection);
-}
-void QtPassSettings::setPasswordChars(const QString &passwordChars) {
-  getInstance()->setValue(SettingsConstants::passwordChars, passwordChars);
-}
-
-void QtPassSettings::setUseTrayIcon(const bool &useTrayIcon) {
-  getInstance()->setValue(SettingsConstants::useTrayIcon, useTrayIcon);
-}
-
 auto QtPassSettings::isHideOnClose(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::hideOnClose, defaultValue)
       .toBool();
 }
-void QtPassSettings::setHideOnClose(const bool &hideOnClose) {
-  getInstance()->setValue(SettingsConstants::hideOnClose, hideOnClose);
-}
-
-void QtPassSettings::setStartMinimized(const bool &startMinimized) {
-  getInstance()->setValue(SettingsConstants::startMinimized, startMinimized);
-}
-
 auto QtPassSettings::isAlwaysOnTop(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::alwaysOnTop, defaultValue)
       .toBool();
-}
-void QtPassSettings::setAlwaysOnTop(const bool &alwaysOnTop) {
-  getInstance()->setValue(SettingsConstants::alwaysOnTop, alwaysOnTop);
-}
-
-void QtPassSettings::setAutoPull(const bool &autoPull) {
-  getInstance()->setValue(SettingsConstants::autoPull, autoPull);
 }
 
 auto QtPassSettings::isAutoPush(const bool &defaultValue) -> bool {
@@ -721,10 +576,6 @@ auto QtPassSettings::isAutoPush(const bool &defaultValue) -> bool {
       ->value(SettingsConstants::autoPush, defaultValue)
       .toBool();
 }
-void QtPassSettings::setAutoPush(const bool &autoPush) {
-  getInstance()->setValue(SettingsConstants::autoPush, autoPush);
-}
-
 auto QtPassSettings::getPassTemplate(const QString &defaultValue) -> QString {
   return getInstance()
       ->value(SettingsConstants::passTemplate, defaultValue)
@@ -734,25 +585,11 @@ void QtPassSettings::setPassTemplate(const QString &passTemplate) {
   getInstance()->setValue(SettingsConstants::passTemplate, passTemplate);
 }
 
-void QtPassSettings::setUseTemplate(const bool &useTemplate) {
-  getInstance()->setValue(SettingsConstants::useTemplate, useTemplate);
-}
-
-void QtPassSettings::setTemplateAllFields(const bool &templateAllFields) {
-  getInstance()->setValue(SettingsConstants::templateAllFields,
-                          templateAllFields);
-}
-
 auto QtPassSettings::isShowProcessOutput(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::showProcessOutput, defaultValue)
       .toBool();
 }
-void QtPassSettings::setShowProcessOutput(const bool &showProcessOutput) {
-  getInstance()->setValue(SettingsConstants::showProcessOutput,
-                          showProcessOutput);
-}
-
 auto QtPassSettings::getRealPass() -> RealPass * {
   return PassBackendFactory::getRealPass();
 }

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -221,24 +221,7 @@ public:
    */
   static void setUsePass(const bool &usePass);
 
-  /**
-   * @brief Save clipboard type.
-   * @param clipBoardType Clipboard type to save.
-   */
-  static void setClipBoardType(const int &clipBoardType);
-
   // UI settings
-  /**
-   * @brief Save use selection setting.
-   * @param useSelection true to use selection.
-   */
-  static void setUseSelection(const bool &useSelection);
-
-  /**
-   * @brief Save use autoclear setting.
-   * @param useAutoclear true to enable autoclear.
-   */
-  static void setUseAutoclear(const bool &useAutoclear);
 
   /**
    * @brief Get autoclear delay in seconds.
@@ -254,12 +237,6 @@ public:
   static void setAutoclearSeconds(const int &autoClearSeconds);
 
   /**
-   * @brief Save use autoclear panel setting.
-   * @param useAutoclearPanel true to enable panel autoclear.
-   */
-  static void setUseAutoclearPanel(const bool &useAutoclearPanel);
-
-  /**
    * @brief Get panel autoclear delay in seconds.
    * @param defaultValue Integer returned if not saved.
    * @return Seconds before panel is cleared.
@@ -271,42 +248,6 @@ public:
    * @param autoClearPanelSeconds Seconds to wait before clearing panel.
    */
   static void setAutoclearPanelSeconds(const int &autoClearPanelSeconds);
-
-  /**
-   * @brief Save hide password setting.
-   * @param hidePassword true to hide password.
-   */
-  static void setHidePassword(const bool &hidePassword);
-
-  /**
-   * @brief Save hide content setting.
-   * @param hideContent true to hide content.
-   */
-  static void setHideContent(const bool &hideContent);
-
-  /**
-   * @brief Save use monospace setting.
-   * @param useMonospace true to use monospace font.
-   */
-  static void setUseMonospace(const bool &useMonospace);
-
-  /**
-   * @brief Save display as-is setting.
-   * @param displayAsIs true to display unmodified.
-   */
-  static void setDisplayAsIs(const bool &displayAsIs);
-
-  /**
-   * @brief Save no line wrapping setting.
-   * @param noLineWrapping true to disable wrapping.
-   */
-  static void setNoLineWrapping(const bool &noLineWrapping);
-
-  /**
-   * @brief Save add GPG ID setting.
-   * @param addGPGId true to auto-add GPG IDs.
-   */
-  static void setAddGPGId(const bool &addGPGId);
 
   // Pass store path
   /**
@@ -356,20 +297,6 @@ public:
   static void setPassExecutable(const QString &passExecutable);
 
   /**
-   * @brief Get the user-supplied SSH_AUTH_SOCK override path.
-   * @param defaultValue String returned if not saved.
-   * @return Override path, or empty if auto-probe should be used.
-   */
-  static auto
-  getSshAuthSockOverride(const QString &defaultValue = QVariant().toString())
-      -> QString;
-  /**
-   * @brief Save the user-supplied SSH_AUTH_SOCK override path.
-   * @param value Override path, or empty to clear and re-enable auto-probe.
-   */
-  static void setSshAuthSockOverride(const QString &value);
-
-  /**
    * @brief Save git executable path.
    * @param gitExecutable Path to git.
    */
@@ -396,44 +323,12 @@ public:
   static void setPwgenExecutable(const QString &pwgenExecutable);
 
   /**
-   * @brief Get GPG home directory.
-   * @param defaultValue String returned if not saved.
-   * @return Path to the GPG home directory.
-   */
-  static auto getGpgHome(const QString &defaultValue = QVariant().toString())
-      -> QString;
-
-  /**
    * @brief Check whether WebDAV integration is enabled.
    * @param defaultValue Value returned if not saved.
    * @return True if WebDAV is enabled.
    */
   static auto isUseWebDav(const bool &defaultValue = QVariant().toBool())
       -> bool;
-  /**
-   * @brief Save WebDAV integration flag.
-   * @param useWebDav Whether to enable WebDAV.
-   */
-  static void setUseWebDav(const bool &useWebDav);
-
-  /**
-   * @brief Save WebDAV URL.
-   * @param webDavUrl WebDAV URL.
-   */
-  static void setWebDavUrl(const QString &webDavUrl);
-
-  /**
-   * @brief Save WebDAV username.
-   * @param webDavUser WebDAV username.
-   */
-  static void setWebDavUser(const QString &webDavUser);
-
-  /**
-   * @brief Save WebDAV password.
-   * @param webDavPassword WebDAV password.
-   */
-  static void setWebDavPassword(const QString &webDavPassword);
-
   /**
    * @brief Get active profile name.
    * @param defaultValue String returned if not saved.
@@ -504,41 +399,17 @@ public:
    */
   static auto isUseGit(const bool &defaultValue = QVariant().toBool()) -> bool;
   /**
-   * @brief Save Git integration flag.
-   * @param useGit Whether to enable Git integration.
-   */
-  static void setUseGit(const bool &useGit);
-
-  /**
    * @brief Check whether content search (pass grep) is enabled.
    * @param defaultValue Value returned if not saved (defaults to false).
    * @return True if grep search is enabled.
    */
   static auto isUseGrepSearch(const bool &defaultValue = false) -> bool;
   /**
-   * @brief Save content search flag.
-   * @param useGrepSearch Whether to enable grep search.
-   */
-  static void setUseGrepSearch(const bool &useGrepSearch);
-
-  /**
    * @brief Check whether OTP support is enabled.
    * @param defaultValue Value returned if not saved.
    * @return True if OTP support is enabled.
    */
   static auto isUseOtp(const bool &defaultValue = QVariant().toBool()) -> bool;
-  /**
-   * @brief Save OTP support flag.
-   * @param useOtp Whether to enable OTP support.
-   */
-  static void setUseOtp(const bool &useOtp);
-
-  /**
-   * @brief Save qrencode support flag.
-   * @param useQrencode Whether to enable qrencode support.
-   */
-  static void setUseQrencode(const bool &useQrencode);
-
   /**
    * @brief Save qrencode executable path.
    * @param qrencodeExecutable Path to qrencode executable.
@@ -552,61 +423,10 @@ public:
   static void setUsePwgen(const bool &usePwgen);
 
   /**
-   * @brief Save uppercase avoidance flag.
-   * @param avoidCapitals Whether uppercase characters should be avoided.
-   */
-  static void setAvoidCapitals(const bool &avoidCapitals);
-
-  /**
-   * @brief Save numeric avoidance flag.
-   * @param avoidNumbers Whether numeric characters should be avoided.
-   */
-  static void setAvoidNumbers(const bool &avoidNumbers);
-
-  /**
-   * @brief Save less-random generation flag.
-   * @param lessRandom Whether less-random generation is enabled.
-   */
-  static void setLessRandom(const bool &lessRandom);
-
-  /**
-   * @brief Save symbol usage flag.
-   * @param useSymbols Whether symbol characters are enabled.
-   */
-  static void setUseSymbols(const bool &useSymbols);
-
-  /**
    * @brief Get complete password generation configuration.
    * @return Password generation configuration.
    */
   static auto getPasswordConfiguration() -> PasswordConfiguration;
-  /**
-   * @brief Save complete password generation configuration.
-   * @param config Password generation configuration.
-   */
-  static void setPasswordConfiguration(const PasswordConfiguration &config);
-  /**
-   * @brief Save password length setting.
-   * @param passwordLength Password length.
-   */
-  static void setPasswordLength(const int &passwordLength);
-  /**
-   * @brief Save password character selection mode.
-   * @param passwordCharsSelection Password character selection mode.
-   */
-  static void setPasswordCharsSelection(const int &passwordCharsSelection);
-  /**
-   * @brief Save custom password characters.
-   * @param passwordChars Custom characters used for password generation.
-   */
-  static void setPasswordChars(const QString &passwordChars);
-
-  /**
-   * @brief Save tray icon support flag.
-   * @param useTrayIcon Whether tray icon support is enabled.
-   */
-  static void setUseTrayIcon(const bool &useTrayIcon);
-
   /**
    * @brief Check whether closing the window hides the application.
    * @param defaultValue Value returned if not saved.
@@ -615,18 +435,6 @@ public:
   static auto isHideOnClose(const bool &defaultValue = QVariant().toBool())
       -> bool;
   /**
-   * @brief Save hide-on-close flag.
-   * @param hideOnClose Whether close action should hide the application.
-   */
-  static void setHideOnClose(const bool &hideOnClose);
-
-  /**
-   * @brief Save start-minimized flag.
-   * @param startMinimized Whether application should start minimized.
-   */
-  static void setStartMinimized(const bool &startMinimized);
-
-  /**
    * @brief Check whether main window should stay always on top.
    * @param defaultValue Value returned if not saved.
    * @return True if always-on-top is enabled.
@@ -634,30 +442,12 @@ public:
   static auto isAlwaysOnTop(const bool &defaultValue = QVariant().toBool())
       -> bool;
   /**
-   * @brief Save always-on-top flag.
-   * @param alwaysOnTop Whether always-on-top should be enabled.
-   */
-  static void setAlwaysOnTop(const bool &alwaysOnTop);
-
-  /**
-   * @brief Save automatic pull flag.
-   * @param autoPull Whether automatic pull should be enabled.
-   */
-  static void setAutoPull(const bool &autoPull);
-
-  /**
    * @brief Check whether automatic push is enabled.
    * @param defaultValue Value returned if not saved.
    * @return True if automatic push is enabled.
    */
   static auto isAutoPush(const bool &defaultValue = QVariant().toBool())
       -> bool;
-  /**
-   * @brief Save automatic push flag.
-   * @param autoPush Whether automatic push should be enabled.
-   */
-  static void setAutoPush(const bool &autoPush);
-
   /**
    * @brief Get pass entry template.
    * @param defaultValue String returned if not saved.
@@ -673,29 +463,11 @@ public:
   static void setPassTemplate(const QString &passTemplate);
 
   /**
-   * @brief Save template usage flag.
-   * @param useTemplate Whether template usage should be enabled.
-   */
-  static void setUseTemplate(const bool &useTemplate);
-
-  /**
-   * @brief Save template-all-fields flag.
-   * @param templateAllFields Whether template should apply to all fields.
-   */
-  static void setTemplateAllFields(const bool &templateAllFields);
-
-  /**
    * @brief Get showProcessOutput setting.
    * @param defaultValue Default value if not set.
    * @return Whether process output should be displayed.
    */
   static auto isShowProcessOutput(const bool &defaultValue = false) -> bool;
-  /**
-   * @brief Save showProcessOutput setting.
-   * @param showProcessOutput Whether to show process output.
-   */
-  static void setShowProcessOutput(const bool &showProcessOutput);
-
   /**
    * @brief Get all configured profiles.
    * @return Profile map keyed by profile name.

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -553,17 +553,25 @@ void tst_integration::imitatePass_nestedDirectoryInsertAndShow() {
 }
 
 namespace {
-// RAII guard to ensure QtPassSettings::setUseGit is restored on any exit path
+// RAII guard to ensure useGit is restored on any exit path
 struct RestoreUseGit {
   bool orig;
   RestoreUseGit() : orig(QtPassSettings::isUseGit()) {}
-  ~RestoreUseGit() { QtPassSettings::setUseGit(orig); }
+  ~RestoreUseGit() {
+    AppSettings s = QtPassSettings::load();
+    s.useGit = orig;
+    QtPassSettings::save(s);
+  }
 };
 } // namespace
 
 void tst_integration::imitatePass_editExistingEntry() {
   RestoreUseGit restoreUseGit;
-  QtPassSettings::setUseGit(false); // Ensure git is off for this test
+  {
+    AppSettings s = QtPassSettings::load();
+    s.useGit = false; // Ensure git is off for this test
+    QtPassSettings::save(s);
+  }
 
   QTemporaryDir storeDir;
   ImitatePass pass;
@@ -610,7 +618,11 @@ void tst_integration::imitatePass_gitInitAndCommit() {
   RestoreUseGit restoreUseGit;
 
   QtPassSettings::setGitExecutable(gitExe);
-  QtPassSettings::setUseGit(true);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.useGit = true;
+    QtPassSettings::save(s);
+  }
 
   QTemporaryDir storeDir;
   ImitatePass pass;

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -101,7 +101,11 @@ void tst_mainwindow::init() {
   // Re-apply store settings in case a previous test modified them.
   QtPassSettings::setPassStore(QDir::cleanPath(m_storeDir.path()));
   QtPassSettings::setUsePass(false);
-  QtPassSettings::setShowProcessOutput(true);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.showProcessOutput = true;
+    QtPassSettings::save(s);
+  }
   // Re-apply gpg path: initExecutables() inside the constructor overwrites
   // the setting to findBinaryInPath("gpg2"), which is empty on systems where
   // only "gpg" exists. Setting it here ensures configIsValid() sees a valid
@@ -118,7 +122,11 @@ void tst_mainwindow::cleanupTestCase() {
   // scope).
   QtPassSettings::setPassStore(m_savedPassStore);
   QtPassSettings::setUsePass(m_savedUsePass);
-  QtPassSettings::setShowProcessOutput(m_savedShowProcessOutput);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.showProcessOutput = m_savedShowProcessOutput;
+    QtPassSettings::save(s);
+  }
   QtPassSettings::setGpgExecutable(m_savedGpgExecutable);
 }
 
@@ -254,7 +262,9 @@ void tst_mainwindow::onProcessOutputAppendsToPanel() {
  *        (isShowProcessOutput == false).
  */
 void tst_mainwindow::onProcessOutputSkippedWhenPanelHidden() {
-  QtPassSettings::setShowProcessOutput(false);
+  AppSettings s = QtPassSettings::load();
+  s.showProcessOutput = false;
+  QtPassSettings::save(s);
 
   auto *outputEdit =
       m_window->findChild<QTextEdit *>(QStringLiteral("processOutputEdit"));

--- a/tests/auto/passwordconfig/tst_passwordconfig.cpp
+++ b/tests/auto/passwordconfig/tst_passwordconfig.cpp
@@ -52,14 +52,8 @@ void tst_passwordconfig::passwordConfigurationDefaults() {
 }
 
 void tst_passwordconfig::passwordConfigurationSetters() {
-  // Reset any previous test settings to ensure clean state
-  {
-    AppSettings s = QtPassSettings::load();
-    s.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] =
-        QString();
-    s.passwordConfiguration.selected = PasswordConfiguration::ALLCHARS;
-    QtPassSettings::save(s);
-  }
+  AppSettings saved = QtPassSettings::load();
+  const PasswordConfiguration original = saved.passwordConfiguration;
 
   {
     AppSettings s = QtPassSettings::load();
@@ -72,11 +66,9 @@ void tst_passwordconfig::passwordConfigurationSetters() {
   QCOMPARE(config.length, 24);
   QCOMPARE(config.selected, PasswordConfiguration::CUSTOM);
 
-  // Reset after test
-  AppSettings s = QtPassSettings::load();
-  s.passwordConfiguration.selected = PasswordConfiguration::ALLCHARS;
-  s.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] = QString();
-  QtPassSettings::save(s);
+  // Restore complete passwordConfiguration to avoid polluting subsequent tests
+  saved.passwordConfiguration = original;
+  QtPassSettings::save(saved);
 }
 
 void tst_passwordconfig::passwordConfigurationCharacterSets() {

--- a/tests/auto/passwordconfig/tst_passwordconfig.cpp
+++ b/tests/auto/passwordconfig/tst_passwordconfig.cpp
@@ -36,8 +36,10 @@ private Q_SLOTS:
 
 void tst_passwordconfig::initTestCase() {
   // Reset any leftover test settings to ensure clean state
-  QtPassSettings::setPasswordChars(QString());
-  QtPassSettings::setPasswordCharsSelection(PasswordConfiguration::ALLCHARS);
+  AppSettings s = QtPassSettings::load();
+  s.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] = QString();
+  s.passwordConfiguration.selected = PasswordConfiguration::ALLCHARS;
+  QtPassSettings::save(s);
 }
 
 void tst_passwordconfig::passwordConfigurationDefaults() {
@@ -51,21 +53,30 @@ void tst_passwordconfig::passwordConfigurationDefaults() {
 
 void tst_passwordconfig::passwordConfigurationSetters() {
   // Reset any previous test settings to ensure clean state
-  QtPassSettings::setPasswordChars(QString());
-  QtPassSettings::setPasswordCharsSelection(PasswordConfiguration::ALLCHARS);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] =
+        QString();
+    s.passwordConfiguration.selected = PasswordConfiguration::ALLCHARS;
+    QtPassSettings::save(s);
+  }
 
-  QtPassSettings::setPasswordLength(24);
-  QtPassSettings::setPasswordCharsSelection(
-      PasswordConfiguration::ALPHANUMERIC);
-  QtPassSettings::setPasswordCharsSelection(3);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passwordConfiguration.length = 24;
+    s.passwordConfiguration.selected = PasswordConfiguration::CUSTOM;
+    QtPassSettings::save(s);
+  }
 
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(config.length, 24);
-  QCOMPARE(config.selected, 3);
+  QCOMPARE(config.selected, PasswordConfiguration::CUSTOM);
 
   // Reset after test
-  QtPassSettings::setPasswordCharsSelection(PasswordConfiguration::ALLCHARS);
-  QtPassSettings::setPasswordChars(QString());
+  AppSettings s = QtPassSettings::load();
+  s.passwordConfiguration.selected = PasswordConfiguration::ALLCHARS;
+  s.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] = QString();
+  QtPassSettings::save(s);
 }
 
 void tst_passwordconfig::passwordConfigurationCharacterSets() {

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -59,15 +59,6 @@ private:
 };
 
 void tst_settings::initTestCase() {
-  // Reset password configuration to structural defaults so
-  // getPasswordConfigurationDefault() passes even after a prior run that wrote
-  // non-default values to persistent (non-portable) settings.
-  {
-    AppSettings s = QtPassSettings::load();
-    s.passwordConfiguration = PasswordConfiguration{};
-    QtPassSettings::save(s);
-  }
-
   // Check for portable mode (qtpass.ini in app directory)
   // Only backup/restore settings file in portable mode
   // On non-portable (registry on Windows), we cannot safely backup
@@ -76,6 +67,8 @@ void tst_settings::initTestCase() {
   m_isPortableMode = QFile::exists(portableIni);
 
   if (m_isPortableMode) {
+    // Backup FIRST so the restored file contains the true original user config,
+    // not the post-reset state written below.
     QtPassSettings::getInstance()->sync();
     QString settingsFile = QtPassSettings::getInstance()->fileName();
     m_settingsBackupPath = settingsFile + ".bak";
@@ -89,6 +82,15 @@ void tst_settings::initTestCase() {
     qWarning() << "Non-portable mode detected: tests may modify persistent "
                   "user settings (e.g. Windows registry). For an isolated "
                   "run, drop a qtpass.ini next to the test binary.";
+  }
+
+  // Reset password configuration to structural defaults so
+  // getPasswordConfigurationDefault() passes even after a prior run that wrote
+  // non-default values to persistent (non-portable) settings.
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passwordConfiguration = PasswordConfiguration{};
+    QtPassSettings::save(s);
   }
 }
 
@@ -276,8 +278,8 @@ void tst_settings::setAndGetClipBoardType() {
 }
 
 void tst_settings::setAndGetPasswordLength() {
-  const int savedLength = QtPassSettings::load().passwordConfiguration.length;
   AppSettings toSave = QtPassSettings::load();
+  const int savedLength = toSave.passwordConfiguration.length;
   toSave.passwordConfiguration.length = 24;
   QtPassSettings::save(toSave);
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
@@ -488,10 +490,16 @@ void tst_settings::setAndGetDialogMaximized() {
 
 void tst_settings::setAndGetPasswordCharsSelection() {
   AppSettings toSave = QtPassSettings::load();
+  const PasswordConfiguration::characterSet savedSelected =
+      toSave.passwordConfiguration.selected;
   toSave.passwordConfiguration.selected = PasswordConfiguration::ALPHABETICAL;
   QtPassSettings::save(toSave);
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(config.selected, PasswordConfiguration::ALPHABETICAL);
+  // Restore to avoid polluting subsequent tests
+  toSave = QtPassSettings::load();
+  toSave.passwordConfiguration.selected = savedSelected;
+  QtPassSettings::save(toSave);
 }
 
 void tst_settings::setAndGetPasswordChars() {

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -59,6 +59,15 @@ private:
 };
 
 void tst_settings::initTestCase() {
+  // Reset password configuration to structural defaults so
+  // getPasswordConfigurationDefault() passes even after a prior run that wrote
+  // non-default values to persistent (non-portable) settings.
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passwordConfiguration = PasswordConfiguration{};
+    QtPassSettings::save(s);
+  }
+
   // Check for portable mode (qtpass.ini in app directory)
   // Only backup/restore settings file in portable mode
   // On non-portable (registry on Windows), we cannot safely backup
@@ -111,17 +120,27 @@ void tst_settings::getPasswordConfigurationDefault() {
 }
 
 void tst_settings::setAndGetPasswordConfiguration() {
+  const PasswordConfiguration saved =
+      QtPassSettings::load().passwordConfiguration;
+
   PasswordConfiguration config;
   config.length = 20;
   config.selected = PasswordConfiguration::ALPHABETICAL;
   config.Characters[PasswordConfiguration::CUSTOM] = "abc";
 
-  QtPassSettings::setPasswordConfiguration(config);
+  AppSettings toSave = QtPassSettings::load();
+  toSave.passwordConfiguration = config;
+  QtPassSettings::save(toSave);
 
   PasswordConfiguration readConfig = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(readConfig.length, 20);
   QVERIFY2(readConfig.selected == PasswordConfiguration::ALPHABETICAL,
            "Password config should be ALPHABETICAL");
+
+  // Restore to avoid polluting subsequent test runs
+  toSave = QtPassSettings::load();
+  toSave.passwordConfiguration = saved;
+  QtPassSettings::save(toSave);
 }
 
 void tst_settings::getProfilesEmpty() {
@@ -178,53 +197,40 @@ void tst_settings::setAndGetPassStore() {
 namespace {
 struct BoolSetting {
   const char *name;
-  void (*setter)(const bool &);
   bool AppSettings::*field;
 };
 
 const BoolSetting boolSettings[] = {
-    {"usePass", QtPassSettings::setUsePass, &AppSettings::usePass},
-    {"useGit", QtPassSettings::setUseGit, &AppSettings::useGit},
-    {"useOtp", QtPassSettings::setUseOtp, &AppSettings::useOtp},
-    {"useTrayIcon", QtPassSettings::setUseTrayIcon, &AppSettings::useTrayIcon},
-    {"usePwgen", QtPassSettings::setUsePwgen, &AppSettings::usePwgen},
-    {"hidePassword", QtPassSettings::setHidePassword,
-     &AppSettings::hidePassword},
-    {"hideContent", QtPassSettings::setHideContent, &AppSettings::hideContent},
-    {"useSelection", QtPassSettings::setUseSelection,
-     &AppSettings::useSelection},
-    {"useAutoclear", QtPassSettings::setUseAutoclear,
-     &AppSettings::useAutoclear},
-    {"useMonospace", QtPassSettings::setUseMonospace,
-     &AppSettings::useMonospace},
-    {"noLineWrapping", QtPassSettings::setNoLineWrapping,
-     &AppSettings::noLineWrapping},
-    {"addGPGId", QtPassSettings::setAddGPGId, &AppSettings::addGPGId},
-    {"avoidCapitals", QtPassSettings::setAvoidCapitals,
-     &AppSettings::avoidCapitals},
-    {"avoidNumbers", QtPassSettings::setAvoidNumbers,
-     &AppSettings::avoidNumbers},
-    {"lessRandom", QtPassSettings::setLessRandom, &AppSettings::lessRandom},
-    {"useSymbols", QtPassSettings::setUseSymbols, &AppSettings::useSymbols},
-    {"displayAsIs", QtPassSettings::setDisplayAsIs, &AppSettings::displayAsIs},
-    {"hideOnClose", QtPassSettings::setHideOnClose, &AppSettings::hideOnClose},
-    {"startMinimized", QtPassSettings::setStartMinimized,
-     &AppSettings::startMinimized},
-    {"alwaysOnTop", QtPassSettings::setAlwaysOnTop, &AppSettings::alwaysOnTop},
-    {"autoPull", QtPassSettings::setAutoPull, &AppSettings::autoPull},
-    {"autoPush", QtPassSettings::setAutoPush, &AppSettings::autoPush},
-    {"useTemplate", QtPassSettings::setUseTemplate, &AppSettings::useTemplate},
-    {"templateAllFields", QtPassSettings::setTemplateAllFields,
-     &AppSettings::templateAllFields},
-    {"useWebDav", QtPassSettings::setUseWebDav, &AppSettings::useWebDav},
-    {"useQrencode", QtPassSettings::setUseQrencode, &AppSettings::useQrencode},
-    {"useAutoclearPanel", QtPassSettings::setUseAutoclearPanel,
-     &AppSettings::useAutoclearPanel},
-    {"maximized", QtPassSettings::setMaximized, &AppSettings::maximized},
-    {"useGrepSearch", QtPassSettings::setUseGrepSearch,
-     &AppSettings::useGrepSearch},
-    {"showProcessOutput", QtPassSettings::setShowProcessOutput,
-     &AppSettings::showProcessOutput},
+    {"usePass", &AppSettings::usePass},
+    {"useGit", &AppSettings::useGit},
+    {"useOtp", &AppSettings::useOtp},
+    {"useTrayIcon", &AppSettings::useTrayIcon},
+    {"usePwgen", &AppSettings::usePwgen},
+    {"hidePassword", &AppSettings::hidePassword},
+    {"hideContent", &AppSettings::hideContent},
+    {"useSelection", &AppSettings::useSelection},
+    {"useAutoclear", &AppSettings::useAutoclear},
+    {"useMonospace", &AppSettings::useMonospace},
+    {"noLineWrapping", &AppSettings::noLineWrapping},
+    {"addGPGId", &AppSettings::addGPGId},
+    {"avoidCapitals", &AppSettings::avoidCapitals},
+    {"avoidNumbers", &AppSettings::avoidNumbers},
+    {"lessRandom", &AppSettings::lessRandom},
+    {"useSymbols", &AppSettings::useSymbols},
+    {"displayAsIs", &AppSettings::displayAsIs},
+    {"hideOnClose", &AppSettings::hideOnClose},
+    {"startMinimized", &AppSettings::startMinimized},
+    {"alwaysOnTop", &AppSettings::alwaysOnTop},
+    {"autoPull", &AppSettings::autoPull},
+    {"autoPush", &AppSettings::autoPush},
+    {"useTemplate", &AppSettings::useTemplate},
+    {"templateAllFields", &AppSettings::templateAllFields},
+    {"useWebDav", &AppSettings::useWebDav},
+    {"useQrencode", &AppSettings::useQrencode},
+    {"useAutoclearPanel", &AppSettings::useAutoclearPanel},
+    {"maximized", &AppSettings::maximized},
+    {"useGrepSearch", &AppSettings::useGrepSearch},
+    {"showProcessOutput", &AppSettings::showProcessOutput},
 };
 } // namespace
 
@@ -245,7 +251,9 @@ void tst_settings::boolRoundTrip() {
 
   for (const auto &s : boolSettings) {
     if (setting == s.name) {
-      s.setter(testValue);
+      AppSettings toSave = QtPassSettings::load();
+      toSave.*s.field = testValue;
+      QtPassSettings::save(toSave);
       const AppSettings loaded = QtPassSettings::load();
       const bool actual = loaded.*s.field;
       QVERIFY2(actual == testValue,
@@ -260,15 +268,24 @@ void tst_settings::boolRoundTrip() {
 }
 
 void tst_settings::setAndGetClipBoardType() {
-  QtPassSettings::setClipBoardType(1);
+  AppSettings toSave = QtPassSettings::load();
+  toSave.clipBoardType = static_cast<Enums::clipBoardType>(1);
+  QtPassSettings::save(toSave);
   QCOMPARE(QtPassSettings::load().clipBoardType,
            static_cast<Enums::clipBoardType>(1));
 }
 
 void tst_settings::setAndGetPasswordLength() {
-  QtPassSettings::setPasswordLength(24);
+  const int savedLength = QtPassSettings::load().passwordConfiguration.length;
+  AppSettings toSave = QtPassSettings::load();
+  toSave.passwordConfiguration.length = 24;
+  QtPassSettings::save(toSave);
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(config.length, 24);
+  // Restore to avoid polluting subsequent test runs
+  toSave = QtPassSettings::load();
+  toSave.passwordConfiguration.length = savedLength;
+  QtPassSettings::save(toSave);
 }
 
 namespace {
@@ -287,32 +304,22 @@ const IntSetting intSettings[] = {
 
 struct StringSetting {
   const char *name;
-  void (*setter)(const QString &);
   QString AppSettings::*field;
 };
 
 const StringSetting stringSettings[] = {
-    {"passSigningKey", QtPassSettings::setPassSigningKey,
-     &AppSettings::passSigningKey},
-    {"passExecutable", QtPassSettings::setPassExecutable,
-     &AppSettings::passExecutable},
-    {"gitExecutable", QtPassSettings::setGitExecutable,
-     &AppSettings::gitExecutable},
-    {"gpgExecutable", QtPassSettings::setGpgExecutable,
-     &AppSettings::gpgExecutable},
-    {"pwgenExecutable", QtPassSettings::setPwgenExecutable,
-     &AppSettings::pwgenExecutable},
-    {"qrencodeExecutable", QtPassSettings::setQrencodeExecutable,
-     &AppSettings::qrencodeExecutable},
-    {"webDavUrl", QtPassSettings::setWebDavUrl, &AppSettings::webDavUrl},
-    {"webDavUser", QtPassSettings::setWebDavUser, &AppSettings::webDavUser},
-    {"webDavPassword", QtPassSettings::setWebDavPassword,
-     &AppSettings::webDavPassword},
-    {"profile", QtPassSettings::setProfile, &AppSettings::activeProfile},
-    {"passTemplate", QtPassSettings::setPassTemplate,
-     &AppSettings::passTemplate},
-    {"sshAuthSockOverride", QtPassSettings::setSshAuthSockOverride,
-     &AppSettings::sshAuthSockOverride},
+    {"passSigningKey", &AppSettings::passSigningKey},
+    {"passExecutable", &AppSettings::passExecutable},
+    {"gitExecutable", &AppSettings::gitExecutable},
+    {"gpgExecutable", &AppSettings::gpgExecutable},
+    {"pwgenExecutable", &AppSettings::pwgenExecutable},
+    {"qrencodeExecutable", &AppSettings::qrencodeExecutable},
+    {"webDavUrl", &AppSettings::webDavUrl},
+    {"webDavUser", &AppSettings::webDavUser},
+    {"webDavPassword", &AppSettings::webDavPassword},
+    {"profile", &AppSettings::activeProfile},
+    {"passTemplate", &AppSettings::passTemplate},
+    {"sshAuthSockOverride", &AppSettings::sshAuthSockOverride},
 };
 } // namespace
 
@@ -382,7 +389,9 @@ void tst_settings::stringRoundTrip() {
 
   for (const auto &s : stringSettings) {
     if (setting == s.name) {
-      s.setter(testValue);
+      AppSettings toSave = QtPassSettings::load();
+      toSave.*s.field = testValue;
+      QtPassSettings::save(toSave);
       QCOMPARE(QtPassSettings::load().*s.field, testValue);
       return;
     }
@@ -478,19 +487,26 @@ void tst_settings::setAndGetDialogMaximized() {
 }
 
 void tst_settings::setAndGetPasswordCharsSelection() {
-  QtPassSettings::setPasswordCharsSelection(
-      PasswordConfiguration::ALPHABETICAL);
+  AppSettings toSave = QtPassSettings::load();
+  toSave.passwordConfiguration.selected = PasswordConfiguration::ALPHABETICAL;
+  QtPassSettings::save(toSave);
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QCOMPARE(config.selected, PasswordConfiguration::ALPHABETICAL);
 }
 
 void tst_settings::setAndGetPasswordChars() {
-  QtPassSettings::setPasswordChars("abc123");
+  AppSettings toSave = QtPassSettings::load();
+  toSave.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] =
+      "abc123";
+  QtPassSettings::save(toSave);
   PasswordConfiguration config = QtPassSettings::getPasswordConfiguration();
   QVERIFY2(config.Characters[PasswordConfiguration::CUSTOM].contains("abc"),
            "PasswordChars should contain 'abc'");
   // Reset to avoid affecting subsequent tests and live QtPass
-  QtPassSettings::setPasswordChars(QString());
+  toSave = QtPassSettings::load();
+  toSave.passwordConfiguration.Characters[PasswordConfiguration::CUSTOM] =
+      QString();
+  QtPassSettings::save(toSave);
 }
 
 void tst_settings::setAndGetMultipleProfiles() {

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1722,13 +1722,19 @@ void tst_util::updateEnvEmptyCustomCharsetFallsBackToAllChars() {
   PasswordConfiguration original = QtPassSettings::getPasswordConfiguration();
   struct ConfigRollback {
     PasswordConfiguration value;
-    ~ConfigRollback() { QtPassSettings::setPasswordConfiguration(value); }
+    ~ConfigRollback() {
+      AppSettings s = QtPassSettings::load();
+      s.passwordConfiguration = value;
+      QtPassSettings::save(s);
+    }
   } rollback{original};
 
   PasswordConfiguration config = original;
   config.selected = PasswordConfiguration::CUSTOM;
   config.Characters[PasswordConfiguration::CUSTOM] = QString();
-  QtPassSettings::setPasswordConfiguration(config);
+  AppSettings toSave = QtPassSettings::load();
+  toSave.passwordConfiguration = config;
+  QtPassSettings::save(toSave);
   AppSettings s = QtPassSettings::load();
   pass.init(s);
 
@@ -2097,14 +2103,16 @@ public:
   SshAuthSockGuard()
       : hadEnv_(qEnvironmentVariableIsSet("SSH_AUTH_SOCK")),
         prevEnv_(qgetenv("SSH_AUTH_SOCK")),
-        prevOverride_(QtPassSettings::getSshAuthSockOverride()) {}
+        prevOverride_(QtPassSettings::load().sshAuthSockOverride) {}
   ~SshAuthSockGuard() {
     if (hadEnv_) {
       qputenv("SSH_AUTH_SOCK", prevEnv_);
     } else {
       qunsetenv("SSH_AUTH_SOCK");
     }
-    QtPassSettings::setSshAuthSockOverride(prevOverride_);
+    AppSettings s = QtPassSettings::load();
+    s.sshAuthSockOverride = prevOverride_;
+    QtPassSettings::save(s);
   }
   SshAuthSockGuard(const SshAuthSockGuard &) = delete;
   auto operator=(const SshAuthSockGuard &) -> SshAuthSockGuard & = delete;
@@ -2123,19 +2131,25 @@ void tst_util::sshAuthSockOverrideRoundtrip() {
   testutils::SshAuthSockGuard guard;
   const QString sentinel =
       QStringLiteral("/tmp/qtpass-test-sock-") + QUuid::createUuid().toString();
-  QtPassSettings::setSshAuthSockOverride(sentinel);
-  QCOMPARE(QtPassSettings::getSshAuthSockOverride(), sentinel);
-  QtPassSettings::setSshAuthSockOverride(QString{});
-  QCOMPARE(QtPassSettings::getSshAuthSockOverride(), QString{});
+  AppSettings s = QtPassSettings::load();
+  s.sshAuthSockOverride = sentinel;
+  QtPassSettings::save(s);
+  QCOMPARE(QtPassSettings::load().sshAuthSockOverride, sentinel);
+  s = QtPassSettings::load();
+  s.sshAuthSockOverride = QString{};
+  QtPassSettings::save(s);
+  QCOMPARE(QtPassSettings::load().sshAuthSockOverride, QString{});
 }
 
 /**
- * @brief default value of getSshAuthSockOverride is empty.
+ * @brief default value of sshAuthSockOverride is empty.
  */
 void tst_util::sshAuthSockOverrideEmptyByDefault() {
   testutils::SshAuthSockGuard guard;
-  QtPassSettings::setSshAuthSockOverride(QString{});
-  QCOMPARE(QtPassSettings::getSshAuthSockOverride(), QString{});
+  AppSettings s = QtPassSettings::load();
+  s.sshAuthSockOverride = QString{};
+  QtPassSettings::save(s);
+  QCOMPARE(QtPassSettings::load().sshAuthSockOverride, QString{});
 }
 
 /**


### PR DESCRIPTION
## Summary

Continuation of the #1511 `AppSettings` snapshot refactoring series (follows PR #1562).

`ConfigDialog` saves settings exclusively via `QtPassSettings::save(AppSettings)`, making direct individual setter calls production-dead. This PR:

- Converts all test callers of dead setters to the `load → modify field → save` pattern (matching how production code writes settings)
- Removes 37 dead one-line setter/getter wrappers from `QtPassSettings`
- Replaces `BoolSetting::setter` and `StringSetting::setter` function-pointer fields in `tst_settings.cpp` with the same AppSettings write path
- Converts `SettingGuard`/`RestoreXxx` structs in `tst_util.cpp` and `tst_integration.cpp` to use AppSettings

**Deleted wrappers (37):**
- bool setters: `setClipBoardType`, `setUseSelection`, `setUseAutoclear`, `setUseAutoclearPanel`, `setHidePassword`, `setHideContent`, `setUseMonospace`, `setDisplayAsIs`, `setNoLineWrapping`, `setAddGPGId`, `setUseGit`, `setUseGrepSearch`, `setUseOtp`, `setUseQrencode`, `setUseTrayIcon`, `setHideOnClose`, `setStartMinimized`, `setAlwaysOnTop`, `setAutoPull`, `setAutoPush`, `setUseTemplate`, `setTemplateAllFields`, `setUseWebDav`, `setAvoidCapitals`, `setAvoidNumbers`, `setLessRandom`, `setUseSymbols`, `setShowProcessOutput`
- string setters: `setWebDavUrl`, `setWebDavUser`, `setWebDavPassword`, `setSshAuthSockOverride`
- password-config setters: `setPasswordConfiguration`, `setPasswordLength`, `setPasswordCharsSelection`, `setPasswordChars`
- dead getters missed in PR J: `getSshAuthSockOverride` (had one caller in `main.cpp`, replaced with `load().sshAuthSockOverride`), `getGpgHome`

**Kept (have production callers):** `setUsePass`, `setUsePwgen`, `setMaximized`, `setPassTemplate`, `setAutoclearSeconds`, `setAutoclearPanelSeconds`, `setGitExecutable`, `setGpgExecutable`, `setPassExecutable`, `setPwgenExecutable`, `setPassSigningKey`, `setProfile`, `setQrencodeExecutable`, and profile sub-key setters.

**Bonus fix:** `setAndGetPasswordLength` and `setAndGetPasswordConfiguration` now restore the password config after each test, and `initTestCase` resets it to structural defaults — fixing a pre-existing test-isolation bug visible in non-portable (non-isolated) test environments.

## Test plan

- [x] `make check` equivalent: all test suites pass (`tst_settings` 117/117, `tst_passwordconfig` 22/22, `tst_ui` 55/55, `tst_mainwindow` 14/14, `tst_filecontent` 35/35, `tst_gpgkeystate` 26/26, `tst_simpletransaction` 14/14)
- [x] Build clean (no warnings)
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured settings management to follow a consistent bulk load-and-save workflow rather than using individual configuration setter calls, keeping behavior the same for end-user features.
* **Bug Fixes**
  * Improved SSH agent socket override handling so the override is applied early enough for reliable subprocess behavior.
* **Tests**
  * Updated the automated test suite to set and verify options through the same load/save settings workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->