### PR TITLE
refactor(#1511): delete 3 dead getter wrappers

### DIFF
--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -303,12 +303,6 @@ void QtPassSettings::setAutoclearSeconds(const int &autoClearSeconds) {
   getInstance()->setValue(SettingsConstants::autoclearSeconds,
                           autoClearSeconds);
 }
-
-auto QtPassSettings::getAutoclearPanelSeconds(const int &defaultValue) -> int {
-  return getInstance()
-      ->value(SettingsConstants::autoclearPanelSeconds, defaultValue)
-      .toInt();
-}
 void QtPassSettings::setAutoclearPanelSeconds(
     const int &autoClearPanelSeconds) {
   getInstance()->setValue(SettingsConstants::autoclearPanelSeconds,
@@ -354,12 +348,6 @@ auto QtPassSettings::getPassStore(const QString &defaultValue) -> QString {
 void QtPassSettings::setPassStore(const QString &passStore) {
   getInstance()->setValue(SettingsConstants::passStore, passStore);
 }
-
-auto QtPassSettings::getPassSigningKey(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::passSigningKey, defaultValue)
-      .toString();
-}
 void QtPassSettings::setPassSigningKey(const QString &passSigningKey) {
   getInstance()->setValue(SettingsConstants::passSigningKey, passSigningKey);
 }
@@ -402,13 +390,6 @@ void QtPassSettings::setGitExecutable(const QString &gitExecutable) {
 
 void QtPassSettings::setGpgExecutable(const QString &gpgExecutable) {
   getInstance()->setValue(SettingsConstants::gpgExecutable, gpgExecutable);
-}
-
-auto QtPassSettings::getPwgenExecutable(const QString &defaultValue)
-    -> QString {
-  return getInstance()
-      ->value(SettingsConstants::pwgenExecutable, defaultValue)
-      .toString();
 }
 void QtPassSettings::setPwgenExecutable(const QString &pwgenExecutable) {
   getInstance()->setValue(SettingsConstants::pwgenExecutable, pwgenExecutable);

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -237,13 +237,6 @@ public:
   static void setAutoclearSeconds(const int &autoClearSeconds);
 
   /**
-   * @brief Get panel autoclear delay in seconds.
-   * @param defaultValue Integer returned if not saved.
-   * @return Seconds before panel is cleared.
-   */
-  static auto
-  getAutoclearPanelSeconds(const int &defaultValue = QVariant().toInt()) -> int;
-  /**
    * @brief Save panel autoclear seconds.
    * @param autoClearPanelSeconds Seconds to wait before clearing panel.
    */
@@ -263,14 +256,6 @@ public:
    */
   static void setPassStore(const QString &passStore);
 
-  /**
-   * @brief Get GPG signing key for pass.
-   * @param defaultValue String returned if not saved.
-   * @return GPG key ID.
-   */
-  static auto
-  getPassSigningKey(const QString &defaultValue = QVariant().toString())
-      -> QString;
   /**
    * @brief Save GPG signing key.
    * @param passSigningKey Key ID to use for signing.
@@ -308,14 +293,6 @@ public:
    */
   static void setGpgExecutable(const QString &gpgExecutable);
 
-  /**
-   * @brief Get pwgen executable path.
-   * @param defaultValue String returned if not saved.
-   * @return Path to pwgen executable.
-   */
-  static auto
-  getPwgenExecutable(const QString &defaultValue = QVariant().toString())
-      -> QString;
   /**
    * @brief Save pwgen executable path.
    * @param pwgenExecutable Path to pwgen.

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -306,7 +306,7 @@ void tst_integration::initTestCase() {
   QtPassSettings::getInstance()->setValue(SettingsConstants::gpgHome,
                                           m_gnupgHome.path());
   QtPassSettings::setGpgExecutable(m_gpgExe);
-  m_originalPassSigningKey = QtPassSettings::getPassSigningKey();
+  m_originalPassSigningKey = QtPassSettings::load().passSigningKey;
   QtPassSettings::setPassSigningKey(QString());
   qRegisterMetaType<GrepResults>("GrepResults");
   qRegisterMetaType<GrepResults>(


### PR DESCRIPTION
## Summary

Continuation of the #1511 `AppSettings` refactoring series (follows PR #1563).

Grep audit of all remaining `is*/get*` declarations in `QtPassSettings` found three with zero or test-only callers:

- **`getAutoclearPanelSeconds`** — zero callers anywhere; deleted
- **`getPwgenExecutable`** — zero callers anywhere; deleted
- **`getPassSigningKey`** — one caller in `tst_integration.cpp:309`; replaced with `QtPassSettings::load().passSigningKey`, then deleted

The `getProfileUseGit`, `getProfileAutoPush`, and `getProfileAutoPull` getters are kept — they read profile sub-keys not represented in `AppSettings` and are still needed by the `profileGitOptions` test.

All remaining production getters have confirmed callers and are untouched.

## Test plan

- [x] All test suites pass (`tst_settings` 117/117, `tst_util` 138/138, `tst_mainwindow` 14/14)
- [x] Build clean
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal settings management by removing redundant settings accessor methods and updating test references to use the updated settings API structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->