### PR TITLE
refactor(#1511): consolidate initExecutables() into one AppSettings save

### DIFF
--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -361,38 +361,21 @@ void QtPassSettings::setPassSigningKey(const QString &passSigningKey) {
  * @return void - This method does not return a value.
  */
 void QtPassSettings::initExecutables() {
-  const AppSettings s = QtPassSettings::load();
-  QtPassSettings::setPassExecutable(s.passExecutable.isEmpty()
-                                        ? Util::findBinaryInPath("pass")
-                                        : s.passExecutable);
-  QtPassSettings::setGitExecutable(s.gitExecutable.isEmpty()
-                                       ? Util::findBinaryInPath("git")
-                                       : s.gitExecutable);
-  QtPassSettings::setGpgExecutable(s.gpgExecutable.isEmpty()
-                                       ? Util::findBinaryInPath("gpg2")
-                                       : s.gpgExecutable);
-  QtPassSettings::setPwgenExecutable(s.pwgenExecutable.isEmpty()
-                                         ? Util::findBinaryInPath("pwgen")
-                                         : s.pwgenExecutable);
+  AppSettings s = QtPassSettings::load();
+  if (s.passExecutable.isEmpty())
+    s.passExecutable = Util::findBinaryInPath("pass");
+  if (s.gitExecutable.isEmpty())
+    s.gitExecutable = Util::findBinaryInPath("git");
+  if (s.gpgExecutable.isEmpty())
+    s.gpgExecutable = Util::findBinaryInPath("gpg2");
+  if (s.pwgenExecutable.isEmpty())
+    s.pwgenExecutable = Util::findBinaryInPath("pwgen");
+  QtPassSettings::save(s);
 }
 auto QtPassSettings::getPassExecutable(const QString &defaultValue) -> QString {
   return getInstance()
       ->value(SettingsConstants::passExecutable, defaultValue)
       .toString();
-}
-void QtPassSettings::setPassExecutable(const QString &passExecutable) {
-  getInstance()->setValue(SettingsConstants::passExecutable, passExecutable);
-}
-
-void QtPassSettings::setGitExecutable(const QString &gitExecutable) {
-  getInstance()->setValue(SettingsConstants::gitExecutable, gitExecutable);
-}
-
-void QtPassSettings::setGpgExecutable(const QString &gpgExecutable) {
-  getInstance()->setValue(SettingsConstants::gpgExecutable, gpgExecutable);
-}
-void QtPassSettings::setPwgenExecutable(const QString &pwgenExecutable) {
-  getInstance()->setValue(SettingsConstants::pwgenExecutable, pwgenExecutable);
 }
 
 auto QtPassSettings::isUseWebDav(const bool &defaultValue) -> bool {

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -276,30 +276,6 @@ public:
   getPassExecutable(const QString &defaultValue = QVariant().toString())
       -> QString;
   /**
-   * @brief Save pass executable path.
-   * @param passExecutable Path to pass.
-   */
-  static void setPassExecutable(const QString &passExecutable);
-
-  /**
-   * @brief Save git executable path.
-   * @param gitExecutable Path to git.
-   */
-  static void setGitExecutable(const QString &gitExecutable);
-
-  /**
-   * @brief Save GPG executable path.
-   * @param gpgExecutable Path to GPG executable.
-   */
-  static void setGpgExecutable(const QString &gpgExecutable);
-
-  /**
-   * @brief Save pwgen executable path.
-   * @param pwgenExecutable Path to pwgen.
-   */
-  static void setPwgenExecutable(const QString &pwgenExecutable);
-
-  /**
    * @brief Check whether WebDAV integration is enabled.
    * @param defaultValue Value returned if not saved.
    * @return True if WebDAV is enabled.

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -305,7 +305,11 @@ void tst_integration::initTestCase() {
   qputenv("GNUPGHOME", m_gnupgHome.path().toLocal8Bit());
   QtPassSettings::getInstance()->setValue(SettingsConstants::gpgHome,
                                           m_gnupgHome.path());
-  QtPassSettings::setGpgExecutable(m_gpgExe);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = m_gpgExe;
+    QtPassSettings::save(s);
+  }
   m_originalPassSigningKey = QtPassSettings::load().passSigningKey;
   QtPassSettings::setPassSigningKey(QString());
   qRegisterMetaType<GrepResults>("GrepResults");
@@ -617,9 +621,9 @@ void tst_integration::imitatePass_gitInitAndCommit() {
 
   RestoreUseGit restoreUseGit;
 
-  QtPassSettings::setGitExecutable(gitExe);
   {
     AppSettings s = QtPassSettings::load();
+    s.gitExecutable = gitExe;
     s.useGit = true;
     QtPassSettings::save(s);
   }
@@ -692,8 +696,12 @@ void tst_integration::realPass_insertAndShow() {
   QVERIFY(storeDir.isValid());
 
   QtPassSettings::setPassStore(storeDir.path());
-  QtPassSettings::setPassExecutable(passExe);
-  QtPassSettings::setGpgExecutable(m_gpgExe);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passExecutable = passExe;
+    s.gpgExecutable = m_gpgExe;
+    QtPassSettings::save(s);
+  }
   QtPassSettings::setUsePass(true);
 
   // Initialise the store via `pass init`.
@@ -733,8 +741,12 @@ void tst_integration::realPass_insertAndGrep() {
   QVERIFY(storeDir.isValid());
 
   QtPassSettings::setPassStore(storeDir.path());
-  QtPassSettings::setPassExecutable(passExe);
-  QtPassSettings::setGpgExecutable(m_gpgExe);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passExecutable = passExe;
+    s.gpgExecutable = m_gpgExe;
+    QtPassSettings::save(s);
+  }
   QtPassSettings::setUsePass(true);
 
   QProcess initProc;
@@ -789,8 +801,12 @@ void tst_integration::imitatePass_otpGenerate() {
   QVERIFY(storeDir.isValid());
 
   QtPassSettings::setPassStore(storeDir.path());
-  QtPassSettings::setPassExecutable(passExe);
-  QtPassSettings::setGpgExecutable(m_gpgExe);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passExecutable = passExe;
+    s.gpgExecutable = m_gpgExe;
+    QtPassSettings::save(s);
+  }
   QtPassSettings::setUsePass(true);
 
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();

--- a/tests/auto/mainwindow/tst_mainwindow.cpp
+++ b/tests/auto/mainwindow/tst_mainwindow.cpp
@@ -94,7 +94,11 @@ void tst_mainwindow::initTestCase() {
     m_gpgPath = Util::findBinaryInPath(QStringLiteral("gpg"));
   if (m_gpgPath.isEmpty())
     QSKIP("gpg not available — skipping MainWindow construction tests");
-  QtPassSettings::setGpgExecutable(m_gpgPath);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = m_gpgPath;
+    QtPassSettings::save(s);
+  }
 }
 
 void tst_mainwindow::init() {
@@ -110,7 +114,11 @@ void tst_mainwindow::init() {
   // the setting to findBinaryInPath("gpg2"), which is empty on systems where
   // only "gpg" exists. Setting it here ensures configIsValid() sees a valid
   // executable and does not fall back to the blocking config() dialog.
-  QtPassSettings::setGpgExecutable(m_gpgPath);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = m_gpgPath;
+    QtPassSettings::save(s);
+  }
   m_window.reset(new MainWindow);
 }
 
@@ -127,7 +135,11 @@ void tst_mainwindow::cleanupTestCase() {
     s.showProcessOutput = m_savedShowProcessOutput;
     QtPassSettings::save(s);
   }
-  QtPassSettings::setGpgExecutable(m_savedGpgExecutable);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = m_savedGpgExecutable;
+    QtPassSettings::save(s);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -838,15 +838,30 @@ void tst_util::configIsValid() {
   gpgIdFile.write("test@example.com\n");
   gpgIdFile.close();
 
-  SettingGuard<QString, QtPassSettings::setGpgExecutable> gpgGuard{
-      QtPassSettings::load().gpgExecutable, QString()};
+  const QString savedGpgExe = QtPassSettings::load().gpgExecutable;
+  struct RestoreGpg {
+    QString saved;
+    ~RestoreGpg() {
+      AppSettings s = QtPassSettings::load();
+      s.gpgExecutable = saved;
+      QtPassSettings::save(s);
+    }
+  } gpgRestore{savedGpgExe};
 
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = QString();
+    QtPassSettings::save(s);
+  }
   isValid = Util::configIsValid(QtPassSettings::load());
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is missing");
 
-  QtPassSettings::setGpgExecutable(
-      QStringLiteral("definitely_nonexistent_gpg_binary_12345"));
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = QStringLiteral("definitely_nonexistent_gpg_binary_12345");
+    QtPassSettings::save(s);
+  }
   isValid = Util::configIsValid(QtPassSettings::load());
   QVERIFY2(!isValid, "Expected invalid config when .gpg-id exists but gpg "
                      "executable is invalid");


### PR DESCRIPTION
## Summary

Continuation of the #1511 `AppSettings` refactoring series (follows PR #1564).

`initExecutables()` already held an `AppSettings` snapshot and then wrote four fields back via individual setters. This PR rewrites the function to modify the snapshot in-place and call `save()` once, then deletes the four now-dead setter wrappers: `setPassExecutable`, `setGitExecutable`, `setGpgExecutable`, `setPwgenExecutable`.

All test callers are updated to the `load → modify field(s) → save` pattern:
- `tst_mainwindow.cpp`: three `setGpgExecutable` calls (initTestCase, init, cleanup)
- `tst_integration.cpp`: `setGpgExecutable` in initTestCase; `setGitExecutable` folded into the adjacent `useGit` write; three `setPassExecutable`+`setGpgExecutable` pairs collapsed into single two-field saves
- `tst_util.cpp`: `SettingGuard<QString, setGpgExecutable>` + bare `setGpgExecutable` replaced with an inline `RestoreGpg` RAII struct and explicit `load→modify→save` writes

## Test plan

- [x] All test suites pass (`tst_util` 138/138, `tst_mainwindow` 14/14, `tst_settings` 117/117)
- [x] Build clean
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored executable path initialization to automatically discover missing executable paths by searching the system PATH.
  * Updated settings management to use a centralized load/save mechanism instead of individual setter methods.

* **Tests**
  * Updated integration and unit tests to align with new settings management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->