### PR TITLE
refactor(#1511): fold QtPass::init() fresh-install writes into AppSettings

### DIFF
--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -78,18 +78,19 @@ auto QtPass::init() -> bool {
 #ifdef QT_DEBUG
     dbg() << "assuming fresh install";
 #endif
-    const AppSettings s = QtPassSettings::load();
-    if (s.autoclearSeconds < 5) {
-      QtPassSettings::setAutoclearSeconds(10);
-    }
-    if (s.autoclearPanelSeconds < 5) {
-      QtPassSettings::setAutoclearPanelSeconds(10);
-    }
-    QtPassSettings::setUsePwgen(!s.pwgenExecutable.isEmpty());
-    QtPassSettings::setPassTemplate(QStringLiteral("login\nurl"));
+    AppSettings s = QtPassSettings::load();
+    if (s.autoclearSeconds < 5)
+      s.autoclearSeconds = 10;
+    if (s.autoclearPanelSeconds < 5)
+      s.autoclearPanelSeconds = 10;
+    s.usePwgen = !s.pwgenExecutable.isEmpty();
+    s.passTemplate = QStringLiteral("login\nurl");
+    QtPassSettings::save(s);
   } else {
-    if (QtPassSettings::getPassTemplate().isEmpty()) {
-      QtPassSettings::setPassTemplate(QStringLiteral("login\nurl"));
+    AppSettings s = QtPassSettings::load();
+    if (s.passTemplate.isEmpty()) {
+      s.passTemplate = QStringLiteral("login\nurl");
+      QtPassSettings::save(s);
     }
   }
 

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -299,16 +299,6 @@ auto QtPassSettings::getAutoclearSeconds(const int &defaultValue) -> int {
       ->value(SettingsConstants::autoclearSeconds, defaultValue)
       .toInt();
 }
-void QtPassSettings::setAutoclearSeconds(const int &autoClearSeconds) {
-  getInstance()->setValue(SettingsConstants::autoclearSeconds,
-                          autoClearSeconds);
-}
-void QtPassSettings::setAutoclearPanelSeconds(
-    const int &autoClearPanelSeconds) {
-  getInstance()->setValue(SettingsConstants::autoclearPanelSeconds,
-                          autoClearPanelSeconds);
-}
-
 /**
  * @brief Retrieves the password store path, normalizes it, and ensures the
  * directory exists.
@@ -520,10 +510,6 @@ void QtPassSettings::setQrencodeExecutable(const QString &qrencodeExecutable) {
                           qrencodeExecutable);
 }
 
-void QtPassSettings::setUsePwgen(const bool &usePwgen) {
-  getInstance()->setValue(SettingsConstants::usePwgen, usePwgen);
-}
-
 auto QtPassSettings::isHideOnClose(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::hideOnClose, defaultValue)
@@ -539,14 +525,6 @@ auto QtPassSettings::isAutoPush(const bool &defaultValue) -> bool {
   return getInstance()
       ->value(SettingsConstants::autoPush, defaultValue)
       .toBool();
-}
-auto QtPassSettings::getPassTemplate(const QString &defaultValue) -> QString {
-  return getInstance()
-      ->value(SettingsConstants::passTemplate, defaultValue)
-      .toString();
-}
-void QtPassSettings::setPassTemplate(const QString &passTemplate) {
-  getInstance()->setValue(SettingsConstants::passTemplate, passTemplate);
 }
 
 auto QtPassSettings::isShowProcessOutput(const bool &defaultValue) -> bool {

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -230,18 +230,6 @@ public:
    */
   static auto getAutoclearSeconds(const int &defaultValue = QVariant().toInt())
       -> int;
-  /**
-   * @brief Save autoclear seconds.
-   * @param autoClearSeconds Seconds to wait before clearing.
-   */
-  static void setAutoclearSeconds(const int &autoClearSeconds);
-
-  /**
-   * @brief Save panel autoclear seconds.
-   * @param autoClearPanelSeconds Seconds to wait before clearing panel.
-   */
-  static void setAutoclearPanelSeconds(const int &autoClearPanelSeconds);
-
   // Pass store path
   /**
    * @brief Get password store directory path.
@@ -370,12 +358,6 @@ public:
   static void setQrencodeExecutable(const QString &qrencodeExecutable);
 
   /**
-   * @brief Save pwgen support flag.
-   * @param usePwgen Whether to enable pwgen support.
-   */
-  static void setUsePwgen(const bool &usePwgen);
-
-  /**
    * @brief Get complete password generation configuration.
    * @return Password generation configuration.
    */
@@ -401,20 +383,6 @@ public:
    */
   static auto isAutoPush(const bool &defaultValue = QVariant().toBool())
       -> bool;
-  /**
-   * @brief Get pass entry template.
-   * @param defaultValue String returned if not saved.
-   * @return Pass template.
-   */
-  static auto
-  getPassTemplate(const QString &defaultValue = QVariant().toString())
-      -> QString;
-  /**
-   * @brief Save pass entry template.
-   * @param passTemplate Pass template.
-   */
-  static void setPassTemplate(const QString &passTemplate);
-
   /**
    * @brief Get showProcessOutput setting.
    * @param defaultValue Default value if not set.

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -293,15 +293,12 @@ void tst_settings::setAndGetPasswordLength() {
 namespace {
 struct IntSetting {
   const char *name;
-  void (*setter)(const int &);
   int AppSettings::*field;
 };
 
 const IntSetting intSettings[] = {
-    {"autoclearSeconds", QtPassSettings::setAutoclearSeconds,
-     &AppSettings::autoclearSeconds},
-    {"autoclearPanelSeconds", QtPassSettings::setAutoclearPanelSeconds,
-     &AppSettings::autoclearPanelSeconds},
+    {"autoclearSeconds", &AppSettings::autoclearSeconds},
+    {"autoclearPanelSeconds", &AppSettings::autoclearPanelSeconds},
 };
 
 struct StringSetting {
@@ -342,7 +339,9 @@ void tst_settings::intRoundTrip() {
 
   for (const auto &s : intSettings) {
     if (setting == s.name) {
-      s.setter(testValue);
+      AppSettings toSave = QtPassSettings::load();
+      toSave.*s.field = testValue;
+      QtPassSettings::save(toSave);
       QCOMPARE(QtPassSettings::load().*s.field, testValue);
       return;
     }

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -107,6 +107,23 @@ private:
     SettingGuard &operator=(const SettingGuard &) = delete;
   };
 
+  template <typename T, T AppSettings::*Field> struct AppSettingsGuard {
+    T original;
+    explicit AppSettingsGuard(const T &newVal)
+        : original(QtPassSettings::load().*Field) {
+      AppSettings s = QtPassSettings::load();
+      s.*Field = newVal;
+      QtPassSettings::save(s);
+    }
+    ~AppSettingsGuard() {
+      AppSettings s = QtPassSettings::load();
+      s.*Field = original;
+      QtPassSettings::save(s);
+    }
+    AppSettingsGuard(const AppSettingsGuard &) = delete;
+    AppSettingsGuard &operator=(const AppSettingsGuard &) = delete;
+  };
+
 private Q_SLOTS:
   void cleanupTestCase();
   void normalizeFolderPath();
@@ -671,20 +688,7 @@ void tst_util::createGpgIdFileEmptyKeys() {
 }
 
 void tst_util::generateRandomPassword() {
-  const bool savedUsePwgen = QtPassSettings::load().usePwgen;
-  struct RestoreUsePwgen {
-    bool saved;
-    ~RestoreUsePwgen() {
-      AppSettings s = QtPassSettings::load();
-      s.usePwgen = saved;
-      QtPassSettings::save(s);
-    }
-  } pwgenRestore{savedUsePwgen};
-  {
-    AppSettings s = QtPassSettings::load();
-    s.usePwgen = false;
-    QtPassSettings::save(s);
-  }
+  AppSettingsGuard<bool, &AppSettings::usePwgen> disablePwgenGuard{false};
 
   ImitatePass pass;
   QString charset = "abcdefghijklmnopqrstuvwxyz";
@@ -772,20 +776,7 @@ void tst_util::generateRandomPassword() {
 }
 
 void tst_util::boundedRandom() {
-  const bool savedUsePwgen = QtPassSettings::load().usePwgen;
-  struct RestoreUsePwgen {
-    bool saved;
-    ~RestoreUsePwgen() {
-      AppSettings s = QtPassSettings::load();
-      s.usePwgen = saved;
-      QtPassSettings::save(s);
-    }
-  } pwgenRestore{savedUsePwgen};
-  {
-    AppSettings s = QtPassSettings::load();
-    s.usePwgen = false;
-    QtPassSettings::save(s);
-  }
+  AppSettingsGuard<bool, &AppSettings::usePwgen> disablePwgenGuard{false};
 
   ImitatePass pass;
 

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -671,8 +671,20 @@ void tst_util::createGpgIdFileEmptyKeys() {
 }
 
 void tst_util::generateRandomPassword() {
-  SettingGuard<bool, QtPassSettings::setUsePwgen> disablePwgenGuard{
-      QtPassSettings::load().usePwgen, false};
+  const bool savedUsePwgen = QtPassSettings::load().usePwgen;
+  struct RestoreUsePwgen {
+    bool saved;
+    ~RestoreUsePwgen() {
+      AppSettings s = QtPassSettings::load();
+      s.usePwgen = saved;
+      QtPassSettings::save(s);
+    }
+  } pwgenRestore{savedUsePwgen};
+  {
+    AppSettings s = QtPassSettings::load();
+    s.usePwgen = false;
+    QtPassSettings::save(s);
+  }
 
   ImitatePass pass;
   QString charset = "abcdefghijklmnopqrstuvwxyz";
@@ -760,8 +772,20 @@ void tst_util::generateRandomPassword() {
 }
 
 void tst_util::boundedRandom() {
-  SettingGuard<bool, QtPassSettings::setUsePwgen> disablePwgenGuard{
-      QtPassSettings::load().usePwgen, false};
+  const bool savedUsePwgen = QtPassSettings::load().usePwgen;
+  struct RestoreUsePwgen {
+    bool saved;
+    ~RestoreUsePwgen() {
+      AppSettings s = QtPassSettings::load();
+      s.usePwgen = saved;
+      QtPassSettings::save(s);
+    }
+  } pwgenRestore{savedUsePwgen};
+  {
+    AppSettings s = QtPassSettings::load();
+    s.usePwgen = false;
+    QtPassSettings::save(s);
+  }
 
   ImitatePass pass;
 


### PR DESCRIPTION
## Summary

Continuation of the #1511 `AppSettings` refactoring series (follows PR #1565).

`QtPass::init()` held a snapshot (`const AppSettings s`) in the fresh-install branch but then wrote four fields back via individual setters. This PR:

- Makes `s` mutable, replaces the four setter calls with direct field assignments, and calls `save(s)` once
- Converts the `else` branch to read `s.passTemplate` from a fresh snapshot instead of calling `getPassTemplate()`
- Deletes the five now-dead wrappers: `setAutoclearSeconds`, `setAutoclearPanelSeconds`, `setUsePwgen`, `getPassTemplate`, `setPassTemplate`

Test callers updated:
- `tst_settings.cpp`: `IntSetting` struct loses the `void (*setter)(const int &)` pointer; `intRoundTrip()` uses `load → modify → save` (matching the bool/string round-trip pattern from PR #1563)
- `tst_util.cpp`: two `SettingGuard<bool, setUsePwgen>` usages replaced with inline `RestoreUsePwgen` RAII structs

## Test plan

- [x] All test suites pass (`tst_settings` 117/117, `tst_util` 138/138, `tst_mainwindow` 14/14)
- [x] Build clean
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved configuration handling by switching to a single load/modify/save workflow for persisted settings.
  * Updated settings round-trip tests to verify values through save/reload behavior.

* **New Features**
  * Added support for explicitly configuring the QR encoding executable path.

* **Bug Fixes**
  * Enforced more consistent default behavior for auto-clear timing and the default password template on new installations.

* **Tests**
  * Refined test utilities to use automatic restore of settings during randomized password tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->