### PR TITLE
refactor(#1511): collapse selectProfile() three-setter block into AppSettings

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1283,12 +1283,13 @@ void MainWindow::on_profileBox_currentTextChanged(const QString &name) {
 
   ui->lineEdit->clear();
 
-  QtPassSettings::setProfile(name);
-
-  QtPassSettings::setPassStore(
-      QtPassSettings::getProfiles().value(name).value("path"));
-  QtPassSettings::setPassSigningKey(
-      QtPassSettings::getProfiles().value(name).value("signingKey"));
+  const QHash<QString, QString> prof =
+      QtPassSettings::getProfiles().value(name);
+  AppSettings s = QtPassSettings::load();
+  s.activeProfile = name;
+  s.passStore = prof.value("path");
+  s.passSigningKey = prof.value("signingKey");
+  QtPassSettings::save(s);
   ui->statusBar->showMessage(tr("Profile changed to %1").arg(name), 2000);
 
   QtPassSettings::getPass()->updateEnv();

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -338,10 +338,6 @@ auto QtPassSettings::getPassStore(const QString &defaultValue) -> QString {
 void QtPassSettings::setPassStore(const QString &passStore) {
   getInstance()->setValue(SettingsConstants::passStore, passStore);
 }
-void QtPassSettings::setPassSigningKey(const QString &passSigningKey) {
-  getInstance()->setValue(SettingsConstants::passSigningKey, passSigningKey);
-}
-
 /**
  * @brief Initializes executable paths for Pass, Git, GPG, and Pwgen by locating
  * them in the system PATH.
@@ -378,10 +374,6 @@ auto QtPassSettings::getProfile(const QString &defaultValue) -> QString {
       ->value(SettingsConstants::profile, defaultValue)
       .toString();
 }
-void QtPassSettings::setProfile(const QString &profile) {
-  getInstance()->setValue(SettingsConstants::profile, profile);
-}
-
 /**
  * @brief Gets the useGit setting for a specific profile.
  * @param profileName The profile name.

--- a/src/qtpasssettings.h
+++ b/src/qtpasssettings.h
@@ -244,12 +244,6 @@ public:
    */
   static void setPassStore(const QString &passStore);
 
-  /**
-   * @brief Save GPG signing key.
-   * @param passSigningKey Key ID to use for signing.
-   */
-  static void setPassSigningKey(const QString &passSigningKey);
-
   // Executable paths
   /**
    * @brief Initialize executable paths by auto-detecting them.
@@ -277,12 +271,6 @@ public:
    */
   static auto getProfile(const QString &defaultValue = QVariant().toString())
       -> QString;
-  /**
-   * @brief Save active profile name.
-   * @param profile Profile name.
-   */
-  static void setProfile(const QString &profile);
-
   /**
    * @brief Get Git setting for a specific profile.
    * @param profileName Name of the profile.

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -311,7 +311,11 @@ void tst_integration::initTestCase() {
     QtPassSettings::save(s);
   }
   m_originalPassSigningKey = QtPassSettings::load().passSigningKey;
-  QtPassSettings::setPassSigningKey(QString());
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passSigningKey = QString();
+    QtPassSettings::save(s);
+  }
   qRegisterMetaType<GrepResults>("GrepResults");
   qRegisterMetaType<GrepResults>(
       "QList<QPair<QString,QStringList>>"); // Qt5 fallback
@@ -319,7 +323,11 @@ void tst_integration::initTestCase() {
 
 void tst_integration::cleanupTestCase() {
   // Restore original pass signing key
-  QtPassSettings::setPassSigningKey(m_originalPassSigningKey);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.passSigningKey = m_originalPassSigningKey;
+    QtPassSettings::save(s);
+  }
 
   // Kill any gpg-agent started in our temporary homedir so it doesn't linger.
   QProcess killer;

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -584,8 +584,12 @@ void tst_settings::profileGitOptions() {
 
 void tst_settings::setAndGetProfileDefault() {
   const QString expectedProfile = QStringLiteral("defaultProfile");
-  QtPassSettings::setProfile(expectedProfile);
-  QCOMPARE(QtPassSettings::getProfile(), expectedProfile);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.activeProfile = expectedProfile;
+    QtPassSettings::save(s);
+  }
+  QCOMPARE(QtPassSettings::load().activeProfile, expectedProfile);
 }
 
 void tst_settings::serializerLoadDefaults() {


### PR DESCRIPTION
## Summary

Continuation of the #1511 `AppSettings` refactoring series (follows PR #1566).

`MainWindow::selectProfile()` wrote three fields (`activeProfile`, `passStore`, `passSigningKey`) via individual setters, looking up the profile map twice. Replace with a single `load → modify → save`, looking up the map once.

Delete the two now-dead wrappers `setProfile` and `setPassSigningKey`; `setPassStore` has other callers and is kept.

Test callers updated:
- `tst_integration.cpp`: replace `setPassSigningKey` in initTestCase/cleanupTestCase with `load → modify → save` blocks
- `tst_settings.cpp`: replace `setProfile` + `getProfile` in `setAndGetProfileDefault` with AppSettings write/read

## Test plan

- [x] All test suites pass (`tst_settings` 117/117, `tst_mainwindow` 14/14)
- [x] Build clean
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal settings management by consolidating how the application saves and loads configuration, reducing redundant setting accessors and improving consistency in profile and credential handling.

* **Tests**
  * Updated test suite to validate the refactored settings management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->