### PR TITLE
refactor(#1511): capture load() snapshot in ConfigDialog profile-init loop

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -785,15 +785,15 @@ void ConfigDialog::initializeNewProfiles(
 
     // Show user selection dialog for GPG recipients
     // UsersDialog will run pass init when accepted
-    UsersDialog usersDialog(QtPassSettings::getPass(), QtPassSettings::load(),
-                            cleanPath, this);
+    const AppSettings settings = QtPassSettings::load();
+    UsersDialog usersDialog(QtPassSettings::getPass(), settings, cleanPath,
+                            this);
     usersDialog.setWindowTitle(tr("Select recipients for %1").arg(name));
     const int result = usersDialog.exec();
 
     // Use per-profile useGit setting, falling back to global if not set
     QString useGitStr = newProfiles.value(name).value("useGit");
-    bool useGit =
-        useGitStr.isEmpty() ? QtPassSettings::isUseGit() : useGitStr == "true";
+    bool useGit = useGitStr.isEmpty() ? settings.useGit : useGitStr == "true";
 
     if (result == QDialog::Accepted && useGit) {
       QtPassSettings::getPass()->GitInit();


### PR DESCRIPTION
## Summary

Final cleanup in the #1511 `AppSettings` refactoring series.

In the profile-init loop in `ConfigDialog`, `QtPassSettings::load()` was called inline as an argument to `UsersDialog` without being captured — so a subsequent `isUseGit()` call in the same block still hit the singleton separately. Capture the result into a local `AppSettings`, pass the variable to `UsersDialog`, and read `settings.useGit` from it directly. One fewer singleton call; the snapshot is now the single source of truth for both reads in the block.

No other multi-field read sites remain unconverted in production code.

## Test plan

- [x] Build clean
- [x] `tst_settings` 117/117, `tst_ui` 55/55
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized settings initialization logic in profile configuration to improve consistency and reduce redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->