### PR TITLE
fix(#1509): replace broken WSL wslpath shell substitution with real wslpath call

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -65,10 +65,11 @@ auto ImitatePass::pgit(const QString &path) const -> QString {
   if (!m_settings.gitExecutable.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
   QString wslPath;
-  Executor::executeBlocking(QStringLiteral("wsl"),
-                            {QStringLiteral("wslpath"), normalizedPath},
-                            &wslPath);
-  return wslPath.trimmed();
+  const int rc = Executor::executeBlocking(
+      QStringLiteral("wsl"), {QStringLiteral("wslpath"), normalizedPath},
+      &wslPath);
+  const QString translated = wslPath.trimmed();
+  return (rc == 0 && !translated.isEmpty()) ? translated : normalizedPath;
 }
 
 auto ImitatePass::pgpg(const QString &path) const -> QString {
@@ -76,10 +77,11 @@ auto ImitatePass::pgpg(const QString &path) const -> QString {
   if (!m_settings.gpgExecutable.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
   QString wslPath;
-  Executor::executeBlocking(QStringLiteral("wsl"),
-                            {QStringLiteral("wslpath"), normalizedPath},
-                            &wslPath);
-  return wslPath.trimmed();
+  const int rc = Executor::executeBlocking(
+      QStringLiteral("wsl"), {QStringLiteral("wslpath"), normalizedPath},
+      &wslPath);
+  const QString translated = wslPath.trimmed();
+  return (rc == 0 && !translated.isEmpty()) ? translated : normalizedPath;
 }
 
 /**
@@ -1044,10 +1046,12 @@ auto ImitatePass::grepMatchFile(const QProcessEnvironment &env,
                                 const QRegularExpression &rx) -> QStringList {
   QString translatedPath = filePath;
   if (gpgExe.startsWith(QStringLiteral("wsl "))) {
-    Executor::executeBlocking(QStringLiteral("wsl"),
-                              {QStringLiteral("wslpath"), filePath},
-                              &translatedPath);
-    translatedPath = translatedPath.trimmed();
+    QString wslPath;
+    const int wrc = Executor::executeBlocking(
+        QStringLiteral("wsl"), {QStringLiteral("wslpath"), filePath}, &wslPath);
+    const QString translated = wslPath.trimmed();
+    if (wrc == 0 && !translated.isEmpty())
+      translatedPath = translated;
   }
   QString plaintext;
   const int rc =

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -64,18 +64,22 @@ auto ImitatePass::pgit(const QString &path) const -> QString {
   QString normalizedPath = QDir::cleanPath(path);
   if (!m_settings.gitExecutable.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
-  QString res =
-      QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
-  return res.replace('\\', '/');
+  QString wslPath;
+  Executor::executeBlocking(QStringLiteral("wsl"),
+                            {QStringLiteral("wslpath"), normalizedPath},
+                            &wslPath);
+  return wslPath.trimmed();
 }
 
 auto ImitatePass::pgpg(const QString &path) const -> QString {
   QString normalizedPath = QDir::cleanPath(path);
   if (!m_settings.gpgExecutable.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
-  QString res =
-      QStringLiteral("$(wslpath ") + normalizedPath + QLatin1Char(')');
-  return res.replace('\\', '/');
+  QString wslPath;
+  Executor::executeBlocking(QStringLiteral("wsl"),
+                            {QStringLiteral("wslpath"), normalizedPath},
+                            &wslPath);
+  return wslPath.trimmed();
 }
 
 /**
@@ -1040,8 +1044,10 @@ auto ImitatePass::grepMatchFile(const QProcessEnvironment &env,
                                 const QRegularExpression &rx) -> QStringList {
   QString translatedPath = filePath;
   if (gpgExe.startsWith(QStringLiteral("wsl "))) {
-    translatedPath = QStringLiteral("$(wslpath ") + filePath + QLatin1Char(')');
-    translatedPath.replace('\\', '/');
+    Executor::executeBlocking(QStringLiteral("wsl"),
+                              {QStringLiteral("wslpath"), filePath},
+                              &translatedPath);
+    translatedPath = translatedPath.trimmed();
   }
   QString plaintext;
   const int rc =


### PR DESCRIPTION
Fixes #1509.

## Summary

- \`pgit()\`, \`pgpg()\`, and \`grepMatchFile()\` in \`imitatepass.cpp\` constructed \`\$(wslpath /path)\` strings and passed them as QProcess arguments
- \`QProcess::start()\` does not invoke a shell, so the substitution never expanded — WSL-mode git/gpg received the literal 14-char string as an argument and failed silently
- Fix: call \`wsl wslpath <path>\` synchronously via \`Executor::executeBlocking\` and use the captured stdout as the translated path
- Non-WSL paths (the common case) are untouched — early-return before the blocking call

## Test plan

- [x] Build clean
- [x] All existing tests pass (WSL-mode is Windows-only; not exercisable on CI)
- [x] clang-format applied
- Manual testing on Windows + WSL required by a Windows user before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WSL-prefixed command handling by reliably translating Windows paths to WSL format (including whitespace cleanup) for both Git/GPG and grep-related decryption operations. If translation fails or is empty, the original path is used to prevent command breakage.

* **Refactor**
  * Streamlined WSL path translation logic to use direct command execution and consistent result trimming for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->