### PR TITLE
fix: P1 audit findings — executor crash, storemodel guard, getKeysFromFile, sort order, reencryptPath init

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -859,7 +859,7 @@ void ConfigDialog::on_deleteButton_clicked() {
     selectedRows.insert(item->row());
   // get a list, and sort it big to small
   QList<int> rows = selectedRows.values();
-  std::sort(rows.begin(), rows.end(), std::greater<int>());
+  std::sort(rows.begin(), rows.end(), std::greater<>());
   // now actually do the removing:
   foreach (int row, rows)
     ui->profileTable->removeRow(row);

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -859,7 +859,7 @@ void ConfigDialog::on_deleteButton_clicked() {
     selectedRows.insert(item->row());
   // get a list, and sort it big to small
   QList<int> rows = selectedRows.values();
-  std::sort(rows.begin(), rows.end());
+  std::sort(rows.begin(), rows.end(), std::greater<int>());
   // now actually do the removing:
   foreach (int row, rows)
     ui->profileTable->removeRow(row);

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -345,7 +345,16 @@ void Executor::finished(int exitCode, QProcess::ExitStatus exitStatus) {
       }
     }
     emit finished(i.id, exitCode, output, err);
+  } else {
+    QString output;
+    QString err;
+    if (i.readStdout) {
+      output = decodeAssumingUtf8(m_process.readAllStandardOutput());
+    }
+    if (i.readStderr) {
+      err = decodeAssumingUtf8(m_process.readAllStandardError());
+    }
+    emit error(i.id, exitCode, output, err);
   }
-  //  else: emit crashed with ID, which may give a chance to recover ?
   executeNext();
 }

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -351,7 +351,7 @@ void Executor::finished(int exitCode, QProcess::ExitStatus exitStatus) {
     if (i.readStdout) {
       output = decodeAssumingUtf8(m_process.readAllStandardOutput());
     }
-    if (i.readStderr) {
+    if (i.readStderr || exitCode != 0) {
       err = decodeAssumingUtf8(m_process.readAllStandardError());
     }
     emit error(i.id, exitCode, output, err);

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -542,7 +542,7 @@ auto ImitatePass::getKeysFromFile(const QString &fileName) -> QStringList {
   QString err;
   const int result =
       Executor::executeBlocking(m_settings.gpgExecutable, args, &keys, &err);
-  if (result != 0 && keys.isEmpty() && err.isEmpty()) {
+  if (result != 0) {
     return {};
   }
   QStringList actualKeys;

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -68,11 +68,7 @@ Pass::Pass() : env(QProcessEnvironment::systemEnvironment()) {
           static_cast<void (Executor::*)(int, int, const QString &,
                                          const QString &)>(&Executor::finished),
           this, &Pass::finished);
-
-  // This was previously using direct QProcess signals.
-  // The code now uses Executor instead of raw QProcess for better control.
-  // connect(&process, SIGNAL(error(QProcess::ProcessError)), this,
-  //        SIGNAL(error(QProcess::ProcessError)));
+  connect(&exec, &Executor::error, this, &Pass::finished);
 
   connect(&exec, &Executor::starting, this, &Pass::startingExecuteWrapper);
   // Merge our vars into WSLENV rather than blindly appending a duplicate entry

--- a/src/passbackendfactory.cpp
+++ b/src/passbackendfactory.cpp
@@ -48,6 +48,8 @@ auto PassBackendFactory::getRealPass() -> RealPass * {
 auto PassBackendFactory::getImitatePass() -> ImitatePass * {
   if (imitatePass.isNull()) {
     imitatePass.reset(new ImitatePass());
+    AppSettings s = QtPassSettings::load();
+    imitatePass->init(s);
   }
   return imitatePass.data();
 }

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -215,7 +215,7 @@ auto StoreModel::mimeData(const QModelIndexList &indexes) const -> QMimeData * {
   dragAndDropInfoPasswordStore info;
 
   if (indexes.isEmpty())
-    return new QMimeData();
+    return nullptr;
   QByteArray encodedData;
   // only use the first, otherwise we should enable multiselection
   QModelIndex index = indexes.at(0);

--- a/src/storemodel.cpp
+++ b/src/storemodel.cpp
@@ -214,6 +214,8 @@ auto StoreModel::mimeTypes() const -> QStringList {
 auto StoreModel::mimeData(const QModelIndexList &indexes) const -> QMimeData * {
   dragAndDropInfoPasswordStore info;
 
+  if (indexes.isEmpty())
+    return new QMimeData();
   QByteArray encodedData;
   // only use the first, otherwise we should enable multiselection
   QModelIndex index = indexes.at(0);


### PR DESCRIPTION
## Summary

- **executor**: emit `error()` signal on `CrashExit` instead of silently swallowing it — callers are now notified when a process crashes instead of hanging forever
- **storemodel**: guard `indexes.at(0)` against empty list in `mimeData()` — prevents an assertion/crash when Qt calls `mimeData()` with an empty selection
- **imitatepass**: bail `getKeysFromFile()` on _any_ non-zero GPG exit code (was only bailing when both stdout and stderr were empty) — prevents GPG error messages from being parsed as key material
- **configdialog**: sort profile deletion rows descending before deleting (comment said "big to small", code sorted ascending) — removes rows from the bottom up so earlier row indices remain valid
- **passbackendfactory**: call `init()` in `getImitatePass()` so `ImitatePass` has valid settings when accessed directly in RealPass mode for `reencryptPath`

Closes #1508

## Test plan

- [x] Build passes with no errors
- [x] `tst_settings` — all 117 tests pass
- [x] `tst_util` — all 138 tests pass (4 platform skips expected)
- [ ] Manual: trigger a process crash and verify `error()` signal is emitted
- [ ] Manual: drag-and-drop with empty selection does not crash
- [ ] Manual: delete multiple profiles in config dialog removes correct rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed deleting multiple profiles by removing selected rows without index shifting.
  * Improved handling of non-standard process exits, including conditional stdout/stderr capture and clearer error signaling.
  * Corrected GPG key lookup to return no keys whenever the key listing command exits non-zero.
  * Prevented drag-and-drop payload creation when no items are selected.
  * Improved password backend setup by loading settings and initializing the imitate pass after creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->