### PR TITLE
fix: code quality audit for imitatepass.cpp and mainwindow.cpp

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -60,9 +60,10 @@ ImitatePass::~ImitatePass() {
   }
 }
 
-auto ImitatePass::pgit(const QString &path) const -> QString {
+auto ImitatePass::translatePathForWsl(const QString &path,
+                                      const QString &exe) const -> QString {
   QString normalizedPath = QDir::cleanPath(path);
-  if (!m_settings.gitExecutable.startsWith(QStringLiteral("wsl ")))
+  if (!exe.startsWith(QStringLiteral("wsl ")))
     return normalizedPath;
   QString wslPath;
   const int rc = Executor::executeBlocking(
@@ -72,16 +73,12 @@ auto ImitatePass::pgit(const QString &path) const -> QString {
   return (rc == 0 && !translated.isEmpty()) ? translated : normalizedPath;
 }
 
+auto ImitatePass::pgit(const QString &path) const -> QString {
+  return translatePathForWsl(path, m_settings.gitExecutable);
+}
+
 auto ImitatePass::pgpg(const QString &path) const -> QString {
-  QString normalizedPath = QDir::cleanPath(path);
-  if (!m_settings.gpgExecutable.startsWith(QStringLiteral("wsl ")))
-    return normalizedPath;
-  QString wslPath;
-  const int rc = Executor::executeBlocking(
-      QStringLiteral("wsl"), {QStringLiteral("wslpath"), normalizedPath},
-      &wslPath);
-  const QString translated = wslPath.trimmed();
-  return (rc == 0 && !translated.isEmpty()) ? translated : normalizedPath;
+  return translatePathForWsl(path, m_settings.gpgExecutable);
 }
 
 /**
@@ -469,35 +466,6 @@ auto ImitatePass::verifyGpgIdFile(const QString &file) -> bool {
 }
 
 /**
- * @brief ImitatePass::removeDir delete folder recursive.
- * @param dirName which folder.
- * @return was removal successful?
- */
-auto ImitatePass::removeDir(const QString &dirName) -> bool {
-  bool result = true;
-  QDir dir(dirName);
-
-  if (dir.exists(dirName)) {
-    for (const QFileInfo &info :
-         dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden |
-                               QDir::AllDirs | QDir::Files,
-                           QDir::DirsFirst)) {
-      if (info.isDir()) {
-        result = removeDir(info.absoluteFilePath());
-      } else {
-        result = QFile::remove(info.absoluteFilePath());
-      }
-
-      if (!result) {
-        return result;
-      }
-    }
-    result = dir.rmdir(dirName);
-  }
-  return result;
-}
-
-/**
  * @brief ImitatePass::reencryptPath reencrypt all files under the chosen
  * directory
  *
@@ -767,6 +735,7 @@ void ImitatePass::reencryptPath(const QString &dir) {
         emit endReencryptPath();
         return;
       }
+      currentDir = QDir(gpgFiles.fileInfo().path());
     }
     QStringList actualKeys = getKeysFromFile(fileName);
     if (actualKeys != gpgId) {
@@ -1004,9 +973,8 @@ void ImitatePass::finished(int id, int exitCode, const QString &out,
 #ifdef QT_DEBUG
   dbg() << "Imitate Pass";
 #endif
-  static QString transactionOutput;
   PROCESS pid = transactionIsOver(static_cast<PROCESS>(id));
-  transactionOutput.append(out);
+  m_transactionOutput.append(out);
 
   if (exitCode == 0) {
     if (pid == INVALID) {
@@ -1025,8 +993,8 @@ void ImitatePass::finished(int id, int exitCode, const QString &out,
       pid = transactionIsOver(static_cast<PROCESS>(id));
     }
   }
-  Pass::finished(pid, exitCode, transactionOutput, err);
-  transactionOutput.clear();
+  Pass::finished(pid, exitCode, m_transactionOutput, err);
+  m_transactionOutput.clear();
 }
 
 /**

--- a/src/imitatepass.h
+++ b/src/imitatepass.h
@@ -36,12 +36,6 @@ protected:
    */
   auto verifyGpgIdFile(const QString &file) -> bool;
   /**
-   * @brief Remove directory recursively.
-   * @param dirName Directory path.
-   * @return true if removed.
-   */
-  auto removeDir(const QString &dirName) -> bool;
-  /**
    * @brief Check if signing keys are valid.
    * @param signingKeys List of key IDs.
    * @return true if all keys valid.
@@ -297,7 +291,17 @@ public:
 private:
   int m_grepSeq = 0;
   QList<QThread *> m_grepThreads;
+  QString m_transactionOutput;
 
+  /**
+   * @brief Translate @p path for the given @p exe when WSL-routed: wraps in
+   * wslpath substitution, otherwise returns @p path unchanged.
+   * @param path Native filesystem path.
+   * @param exe Executable path (checked for "wsl " prefix).
+   * @return Path suitable for the given executable.
+   */
+  auto translatePathForWsl(const QString &path, const QString &exe) const
+      -> QString;
   /**
    * @brief Translate @p path for git when WSL-routed: wraps in wslpath
    * substitution, otherwise returns @p path unchanged.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -821,6 +821,8 @@ void MainWindow::onTimeoutSearch() {
 
   query.replace(QStringLiteral(" "), ".*");
   QRegularExpression regExp(query, QRegularExpression::CaseInsensitiveOption);
+  if (!regExp.isValid())
+    return;
   proxyModel.setFilterRegularExpression(regExp);
   ui->treeView->setRootIndex(
       proxyModel.rootIndexFor(QtPassSettings::getPassStore()));
@@ -1308,15 +1310,6 @@ void MainWindow::on_profileBox_currentTextChanged(const QString &name) {
  */
 void MainWindow::initTrayIcon() {
   m_tray = new TrayIcon(this);
-  // Setup tray icon
-
-  if (m_tray == nullptr) {
-#ifdef QT_DEBUG
-    dbg() << "Allocating tray icon failed.";
-#endif
-    return;
-  }
-
   if (!m_tray->getIsAllocated()) {
     destroyTrayIcon();
   }
@@ -1633,13 +1626,23 @@ void MainWindow::copyPasswordFromTreeview() {
     // Disconnect any previous connection to avoid accumulation
     disconnect(QtPassSettings::getPass(), &Pass::finishedShow, this,
                &MainWindow::passwordFromFileToClipboard);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    connect(QtPassSettings::getPass(), &Pass::finishedShow, this,
+            &MainWindow::passwordFromFileToClipboard, Qt::SingleShotConnection);
+#else
     connect(QtPassSettings::getPass(), &Pass::finishedShow, this,
             &MainWindow::passwordFromFileToClipboard);
+#endif
     QtPassSettings::getPass()->Show(file);
   }
 }
 
 void MainWindow::passwordFromFileToClipboard(const QString &text) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  // Qt 5: no SingleShotConnection flag — disconnect manually on first fire.
+  disconnect(QtPassSettings::getPass(), &Pass::finishedShow, this,
+             &MainWindow::passwordFromFileToClipboard);
+#endif
   QStringList tokens = text.split('\n');
   m_qtPass->copyTextToClipboard(tokens[0]);
 }

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -1145,7 +1145,6 @@ void tst_util::imitatePassResolveMoveDestinationNonExistent() {
   QVERIFY2(result.isEmpty(), "Should return empty for non-existent source");
 }
 
-
 void tst_util::getRecipientListBasic() {
   QTemporaryDir tempDir;
   QString passStore = tempDir.path();

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -178,7 +178,6 @@ private Q_SLOTS:
   void imitatePassResolveMoveDestinationDestExistsNoForce();
   void imitatePassResolveMoveDestinationDir();
   void imitatePassResolveMoveDestinationNonExistent();
-  void imitatePassRemoveDir();
   void getRecipientListBasic();
   void getRecipientListEmpty();
   void getRecipientListWithComments();
@@ -1146,16 +1145,6 @@ void tst_util::imitatePassResolveMoveDestinationNonExistent() {
   QVERIFY2(result.isEmpty(), "Should return empty for non-existent source");
 }
 
-void tst_util::imitatePassRemoveDir() {
-  ImitatePass pass;
-  QTemporaryDir tmpDir;
-  QString subDir = tmpDir.path() + "/testdir";
-  QVERIFY(QDir().mkpath(subDir));
-  QVERIFY(QDir(subDir).exists());
-  bool result = pass.removeDir(subDir);
-  QVERIFY(result);
-  QVERIFY(!QDir(subDir).exists());
-}
 
 void tst_util::getRecipientListBasic() {
   QTemporaryDir tempDir;


### PR DESCRIPTION
## Summary

Fixes multiple code quality issues identified in an audit of `imitatepass.cpp`, `mainwindow.cpp`, and related files. Closes / references #1508.

- **mainwindow — regex validity guard**: `onTimeoutSearch()` now returns early if the constructed `QRegularExpression` is invalid, preventing `setFilterRegularExpression` from being called with a broken pattern.
- **mainwindow — single-shot clipboard connection**: The `finishedShow → passwordFromFileToClipboard` connection in `copyPasswordFromTreeview` now uses `Qt::SingleShotConnection` on Qt 6 and a manual `disconnect` inside the slot on Qt 5, eliminating accumulated connections across repeated Ctrl+C presses.
- **mainwindow — remove dead null-check**: The `if (m_tray == nullptr)` block after `m_tray = new TrayIcon(this)` is deleted; `operator new` throws `std::bad_alloc` and never returns `nullptr`.
- **imitatepass — fix reencryptPath directory tracking**: `currentDir` is now updated at the end of the per-directory block so the change-detection guard actually fires on directory transitions (previously always compared against an empty `QDir()`).
- **imitatepass — demote static transactionOutput to member**: `static QString transactionOutput` inside `finished()` is promoted to `m_transactionOutput` — a proper instance member — removing shared-static state that could cause cross-instance interference.
- **imitatepass — delete dead removeDir()**: `ImitatePass::removeDir()` was never called from production code (only a test exercised it). The implementation, header declaration, and the unit test `imitatePassRemoveDir` are all removed.
- **imitatepass — deduplicate pgit/pgpg**: A new private helper `translatePathForWsl(path, exe)` encapsulates the shared WSL path-translation body; `pgit` and `pgpg` each delegate to it with the appropriate executable string.

**Fix 8 (lift QMessageBox out of StoreModel) was skipped**: `executeDropAction` returns `bool` synchronously from Qt's `dropMimeData` override. Introducing an async signal/out-parameter confirmation would require a full architectural rework incompatible with Qt's drop protocol; the risk outweighs the benefit.

## Test plan

- [x] `make -j4` — zero build errors
- [x] `QT_QPA_PLATFORM=offscreen ./tests/auto/ui/tst_ui` — 55 passed
- [x] `QT_QPA_PLATFORM=offscreen ./tests/auto/util/tst_util` — 137 passed
- [x] `QT_QPA_PLATFORM=offscreen ./tests/auto/model/tst_model` — 38 passed
- [x] Doxygen — zero code-level warnings
- [ ] Manual smoke-test: search with an invalid regex (e.g. `[`), copy-to-clipboard via Ctrl+C, tray icon init, drag-and-drop, re-encrypt path with nested directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search filtering by validating regex input before applying results.
  * Enhanced WSL path handling to ensure correct filesystem access when using WSL-routed commands.
  * Corrected per-directory verification behavior during re-encryption.
* **Chores**
  * Improved cross-version Qt compatibility for clipboard/finish display handling.
  * Refined transaction output handling and internal cleanup, including removing an obsolete deletion helper and disabling a related test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->