### PR TITLE
fix(#1508): audit quality sweep — path sep, null-check, timeout, docs, tests

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -899,7 +899,11 @@ auto ConfigDialog::isQrencodeAvailable() -> bool {
 #else
   QProcess which;
   which.start("which", QStringList() << "qrencode");
-  which.waitForFinished(2000);
+  if (!which.waitForFinished(2000)) {
+    which.kill();
+    which.waitForFinished(500);
+    return false;
+  }
   QtPassSettings::setQrencodeExecutable(
       which.readAllStandardOutput().trimmed());
   return which.exitCode() == 0;

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -261,6 +261,8 @@ void ConfigDialog::validate(QTableWidgetItem *item) {
       for (int j = 0; j < ui->profileTable->columnCount(); j++) {
         QTableWidgetItem *_item = ui->profileTable->item(i, j);
 
+        if (!_item)
+          continue;
         if (_item->text().isEmpty() && j != 2) {
           _item->setBackground(Qt::red);
           _item->setToolTip(tr("This field is required"));
@@ -897,7 +899,7 @@ auto ConfigDialog::isQrencodeAvailable() -> bool {
 #else
   QProcess which;
   which.start("which", QStringList() << "qrencode");
-  which.waitForFinished();
+  which.waitForFinished(2000);
   QtPassSettings::setQrencodeExecutable(
       which.readAllStandardOutput().trimmed());
   return which.exitCode() == 0;

--- a/src/pass.h
+++ b/src/pass.h
@@ -281,8 +281,14 @@ protected:
   auto boundedRandom(quint32 bound) -> quint32;
   /**
    * @brief Set or remove an environment variable.
-   * @param key Variable name including trailing '='.
-   * @param value New value; empty string removes the variable.
+   *
+   * The @p key must include a trailing '=' character (e.g. "FOO="). This
+   * convention anchors the lookup so that "FOO=" never accidentally matches
+   * "FOOBAR=". Callers are responsible for appending the '='; the function
+   * asserts and warns (but does not modify env) if the '=' is missing.
+   *
+   * @param key Variable name with trailing '=' (e.g. "PASSWORD_STORE_DIR=").
+   * @param value New value; an empty string removes the variable entirely.
    */
   void setEnvVar(const QString &key, const QString &value);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -105,11 +105,10 @@ auto Util::findPasswordStore() -> QString {
 
 auto Util::normalizeFolderPath(const QString &path) -> QString {
   QString normalizedPath = path;
-  if (!normalizedPath.endsWith("/") &&
-      !normalizedPath.endsWith(QDir::separator())) {
-    normalizedPath += QDir::separator();
+  if (!normalizedPath.endsWith('/')) {
+    normalizedPath += '/';
   }
-  return QDir::toNativeSeparators(normalizedPath);
+  return normalizedPath;
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -31,15 +31,19 @@ public:
   static auto findBinaryInPath(const QString &binary) -> QString;
   /**
    * @brief Locate the password store directory.
-   * @return QString Path to the password store, always ends with native
-   * directory separator.
+   * @return QString Path to the password store, always ends with '/'.
    */
   static auto findPasswordStore() -> QString;
   /**
-   * @brief Ensure a folder path always ends with the native directory
-   * separator.
+   * @brief Ensure a folder path always ends with '/'.
+   *
+   * Qt normalises paths to forward slashes internally, so this function
+   * appends '/' unconditionally rather than the platform-native separator.
+   * Callers that need native separators can call QDir::toNativeSeparators()
+   * themselves.
+   *
    * @param path The folder path to normalize.
-   * @return QString Path with trailing separator added if missing.
+   * @return QString Path with a trailing '/' added if it was missing.
    */
   static auto normalizeFolderPath(const QString &path) -> QString;
   /**

--- a/tests/auto/util/tst_util.cpp
+++ b/tests/auto/util/tst_util.cpp
@@ -272,6 +272,8 @@ private Q_SLOTS:
   void getFolderTemplateInParent();
   void getFolderTemplateNoneFound();
   void getFolderTemplateCommentIgnored();
+  // normalizeFolderPath — new contract (always forward slash)
+  void normalizeFolder();
 };
 
 /**
@@ -309,41 +311,30 @@ void tst_util::cleanupTestCase() {
 
 /**
  * @brief tst_util::normalizeFolderPath test to check correct working
- * of Util::normalizeFolderPath the paths should always end with a slash
+ * of Util::normalizeFolderPath the paths should always end with '/'
  */
 void tst_util::normalizeFolderPath() {
   QString result;
-  QString sep = QDir::separator();
 
-  // Forward slash path
+  // Path without trailing slash — slash must be appended.
   result = Util::normalizeFolderPath("test");
-  QVERIFY(result.endsWith(sep));
-  result = Util::normalizeFolderPath("test/");
-  QVERIFY(result.endsWith(sep));
-  // Verify exact normalized path content
-  result = Util::normalizeFolderPath("test");
-  QVERIFY2(result == "test" + sep,
-           qPrintable(QString("Expected 'test%1', got '%2'").arg(sep, result)));
-  result = Util::normalizeFolderPath("test/");
-  QVERIFY2(result == "test" + sep,
-           qPrintable(QString("Expected 'test%1', got '%2'").arg(sep, result)));
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("test/"));
 
-  // Windows-style backslash path (only on Windows)
-  if (QDir::separator() == '\\') {
-    result = Util::normalizeFolderPath("test\\subdir");
-    QVERIFY(result.endsWith("\\"));
-    QVERIFY(result.contains("test"));
-    QVERIFY(result.contains("subdir"));
-    // Verify exact normalized path content
-    QVERIFY2(
-        result == "test\\subdir\\",
-        qPrintable(
-            QString("Expected 'test\\\\subdir\\\\', got '%1'").arg(result)));
-  }
+  // Path already ending with '/' — must be idempotent (no double slash).
+  result = Util::normalizeFolderPath("test/");
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("test/"));
 
-  // Mixed separators test
+  // Nested path without trailing slash.
+  result = Util::normalizeFolderPath("test/subdir");
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("test/subdir/"));
+
+  // Mixed separators: the function does NOT normalize backslashes; callers
+  // should run QDir::cleanPath() first if needed.
   result = Util::normalizeFolderPath("test/subdir\\folder");
-  QVERIFY(result.endsWith(sep));
+  QVERIFY(result.endsWith('/'));
   QVERIFY(result.contains("test"));
   QVERIFY(result.contains("subdir"));
   QVERIFY(result.contains("folder"));
@@ -468,19 +459,31 @@ void tst_util::regexPatterns() {
 }
 
 void tst_util::normalizeFolderPathEdgeCases() {
+  // Empty string -> "/" (a single forward slash is appended).
   QString result = Util::normalizeFolderPath("");
-  QVERIFY(result.endsWith(QDir::separator()));
-  QVERIFY2(result == QDir::separator() || result.endsWith(QDir::separator()),
-           "Empty path should become separator");
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("/"));
 
-  result = Util::normalizeFolderPath(QDir::separator());
-  QVERIFY(result.endsWith(QDir::separator()));
+  // Already a single '/' -> idempotent.
+  result = Util::normalizeFolderPath("/");
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("/"));
 
+  // Already-normalized deep path -> idempotent.
   result = Util::normalizeFolderPath("path/to/dir/");
-  QVERIFY(result.endsWith(QDir::separator()));
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("path/to/dir/"));
 
-  QString nativeResult = Util::normalizeFolderPath("path/to/dir");
-  QVERIFY(nativeResult.endsWith(QDir::separator()));
+  // Path without trailing slash -> slash added.
+  result = Util::normalizeFolderPath("path/to/dir");
+  QVERIFY(result.endsWith('/'));
+  QCOMPARE(result, QStringLiteral("path/to/dir/"));
+
+  // Path ending with a Windows backslash: the function appends '/' after the
+  // backslash because it only checks for '/'.  Callers that need normalized
+  // separators should run QDir::cleanPath() before calling this function.
+  result = Util::normalizeFolderPath("C:\\Users\\test");
+  QVERIFY(result.endsWith('/'));
 }
 
 void tst_util::fileContentEdgeCases() {
@@ -827,7 +830,7 @@ void tst_util::findBinaryInPath() {
 void tst_util::findPasswordStore() {
   QString result = Util::findPasswordStore();
   QVERIFY(!result.isEmpty());
-  QVERIFY(result.endsWith(QDir::separator()));
+  QVERIFY(result.endsWith('/'));
 }
 
 void tst_util::configIsValid() {
@@ -981,8 +984,10 @@ void tst_util::findPasswordStoreEnvVar() {
 void tst_util::normalizeFolderPathMultipleCalls() {
   QString result1 = Util::normalizeFolderPath("test1");
   QString result2 = Util::normalizeFolderPath("test2");
-  QVERIFY(result1.endsWith(QDir::separator()));
-  QVERIFY(result2.endsWith(QDir::separator()));
+  QVERIFY(result1.endsWith('/'));
+  QVERIFY(result2.endsWith('/'));
+  QCOMPARE(result1, QStringLiteral("test1/"));
+  QCOMPARE(result2, QStringLiteral("test2/"));
 }
 
 void tst_util::userInfoFullyValid() {
@@ -2676,6 +2681,34 @@ void tst_util::getFolderTemplateCommentIgnored() {
   QString result = TemplateIO::getFolderTemplate(subPath, store.path());
   QVERIFY2(result.isEmpty(),
            ".default_template with only a comment must return empty string");
+}
+
+/**
+ * @brief normalizeFolder — explicit contract tests for normalizeFolderPath.
+ *
+ * normalizeFolderPath always appends '/' when the path does not already end
+ * with one. It never calls QDir::toNativeSeparators(), so the result always
+ * uses forward slashes regardless of the host platform.
+ */
+void tst_util::normalizeFolder() {
+  // Already-normalized path ending in '/' -> idempotent (no double slash).
+  QCOMPARE(Util::normalizeFolderPath(QStringLiteral("/home/user/store/")),
+           QStringLiteral("/home/user/store/"));
+
+  // Path NOT ending in '/' -> slash appended.
+  QCOMPARE(Util::normalizeFolderPath(QStringLiteral("/home/user/store")),
+           QStringLiteral("/home/user/store/"));
+
+  // Empty string -> "/" (single forward slash).
+  QCOMPARE(Util::normalizeFolderPath(QString()), QStringLiteral("/"));
+
+  // Path ending in backslash: '\\' is NOT '/', so '/' is appended after it.
+  // Callers needing clean separators should run QDir::cleanPath() first.
+  QString backslashPath = QStringLiteral("C:\\Users\\test");
+  QString result = Util::normalizeFolderPath(backslashPath);
+  QVERIFY2(result.endsWith('/'),
+           "normalizeFolderPath must append '/' even after a backslash");
+  QCOMPARE(result, QStringLiteral("C:\\Users\\test/"));
 }
 
 QTEST_MAIN(tst_util)


### PR DESCRIPTION
## Summary

Fixes five code-quality issues identified in #1508:

- **`src/util.cpp` — `normalizeFolderPath`**: Remove forbidden `QDir::separator()` and `QDir::toNativeSeparators()` calls (CLAUDE.md prohibits `QDir::separator()` in path checks). The function now always appends `'/'`, matching Qt's internal path convention. Callers needing native separators can convert themselves.

- **`src/configdialog.cpp` — `validate()`**: Add null-check before dereferencing `QTableWidgetItem*` returned by `QTableWidget::item()`. The Qt docs state `item()` returns `nullptr` for cells never explicitly set; the previous code would crash unconditionally on such cells.

- **`src/configdialog.cpp` — `isQrencodeAvailable()`**: Pass `2000` ms to `waitForFinished()` instead of the infinite-timeout default, preventing the UI from hanging indefinitely on stalled network filesystems.

- **`src/pass.h` — `setEnvVar()` doc**: Expand the doc-block to make the trailing-`=` contract unambiguous. The existing implementation asserts and warns if `'='` is missing; the prior one-liner `@param` description was easy to miss.

- **`tests/auto/util/tst_util.cpp`**: Update existing `normalizeFolderPath` tests to match the new forward-slash contract; add `normalizeFolder()` covering idempotency, append-on-missing-slash, empty-string → `"/"`, and backslash-terminated input.

## Test plan

- [x] `make -j4` — zero errors
- [x] `QT_QPA_PLATFORM=offscreen ./tests/auto/util/tst_util` — 139 passed, 0 failed
- [x] `QT_QPA_PLATFORM=offscreen ./tests/auto/settings/tst_settings` — 117 passed, 0 failed
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented crashes during configuration validation when some profile rows are partially populated.
  * Fixed potential indefinite waiting when checking qrencode availability by adding a bounded timeout.

* **Documentation**
  * Clarified environment variable key requirements for setting/removing variables.
  * Updated folder-path documentation to guarantee forward slashes and a trailing `/`.

* **Tests**
  * Strengthened unit tests to enforce the updated `normalizeFolderPath()` contract, including edge cases and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->