### PR TITLE
fix: set solid palette on textBrowser context menu

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1488,7 +1488,12 @@ void MainWindow::showContextMenu(const QPoint &pos) {
  */
 void MainWindow::showBrowserContextMenu(const QPoint &pos) {
   QMenu *contextMenu = ui->textBrowser->createStandardContextMenu(pos);
-  contextMenu->setPalette(QApplication::palette());
+  // createStandardContextMenu() parents the menu to textBrowser, which carries
+  // a "background: palette(base)" stylesheet. Qt cascades that stylesheet to
+  // the child QMenu and breaks its opaque native background, leaving the menu
+  // transparent. Reparent to the main window (no stylesheet) so it paints
+  // solid.
+  contextMenu->setParent(this, contextMenu->windowFlags());
   QPoint globalPos = ui->textBrowser->viewport()->mapToGlobal(pos);
 
   contextMenu->exec(globalPos);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1488,6 +1488,7 @@ void MainWindow::showContextMenu(const QPoint &pos) {
  */
 void MainWindow::showBrowserContextMenu(const QPoint &pos) {
   QMenu *contextMenu = ui->textBrowser->createStandardContextMenu(pos);
+  contextMenu->setPalette(QApplication::palette());
   QPoint globalPos = ui->textBrowser->viewport()->mapToGlobal(pos);
 
   contextMenu->exec(globalPos);

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -72,9 +72,12 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
   QString trimmedField = field.trimmed();
   QString trimmedValue = value.trimmed();
 
+  // Scope every rule to the widget type so the transparent background does not
+  // cascade into the field's standard context menu (a child QMenu), which would
+  // otherwise render transparent too.
   const QString buttonStyle =
-      "border-style: none; background: transparent; padding: 0; margin: 0; "
-      "icon-size: 16px; color: inherit;";
+      "QPushButton { border-style: none; background: transparent; padding: 0; "
+      "margin: 0; icon-size: 16px; color: inherit; }";
 
   // Combine the Copy button and the line edit in one widget
   auto *frame = new QFrame();
@@ -128,9 +131,10 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
   // set the echo mode to password, if the field is "password"
   const QString lineStyle =
       s.useMonospace
-          ? "border-style: none; background: transparent; font-family: "
-            "monospace;"
-          : "border-style: none; background: transparent;";
+          ? "QLineEdit, QTextBrowser { border-style: none; background: "
+            "transparent; font-family: monospace; }"
+          : "QLineEdit, QTextBrowser { border-style: none; background: "
+            "transparent; }";
 
   if (s.hidePassword && trimmedField == QObject::tr("Password")) {
     auto *line = new QLineEdit();


### PR DESCRIPTION
## Summary

- Right-clicking in the password display panel showed a transparent context menu, leaking the password text visible behind it
- `QTextBrowser::createStandardContextMenu()` returns a menu with no explicit background — compositing WMs (KDE, GNOME with effects) render it translucent
- Fix: call `setPalette(QApplication::palette())` on the menu before `exec()`, rooting it in the application palette and forcing a solid background
- Same principle as the textBrowser stylesheet fix in #967 (`background: transparent` → `background: palette(base)`)

## Test plan

- Right-click in the password display panel — context menu should have a solid, opaque background
- Verify on a compositor with transparency effects enabled (KWin, Mutter)
- Verify light and dark themes both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the text browser context menu to better match the application’s theme palette and styling.
  * Updated button and input area styling to prevent transparent backgrounds from unintentionally affecting child context-menu appearance.
* **Bug Fixes**
  * Fixed cases where context menus could appear with transparent or inconsistent backgrounds when launched from styled controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->