### PR TITLE
chore: ignore .tmp/ build artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ qtpass.xcodeproj/xcuserdata/*
 qtpass.xcworkspace/xcuserdata/*
 .DS_Store
 .qmake.stash
+.tmp/
 *.o
 moc_*.cpp
 qrc_*.cpp


### PR DESCRIPTION
## Summary
- Add `.tmp/` to `.gitignore`

The `.tmp/` directory holds checkinstall/build staging output (root-owned `usr/lib64/qt6` subdirs from packaging runs). It was showing up as untracked in `git status` and breaking `git stash -u` with `failed to remove ... Permission denied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to ignore temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->