### PR TITLE
i18n: fix CodeRabbit-flagged translation bugs from #1576

### DIFF
--- a/localization/localization_af.ts
+++ b/localization/localization_af.ts
@@ -567,12 +567,12 @@ Die waarde sal steeds gestoor word soos ingevoer.</translation>
     <message>
         <location filename="../src/configdialog.cpp" line="963"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store to get it.&lt;br&gt;If you already did so, make sure you started it once and&lt;br&gt;click &quot;Autodetect&quot; in the next dialog.</source>
-        <translation>Installeer asseblief GnuPG op jou stelsel. &lt;br&gt; installeer &lt;strong&gt; Ubuntu &lt;/strong&gt; van die Microsoft-Winkel om dit te kry. &lt;br&gt; as jy dit reeds gedoen het, maak seker dat jy dit eers begin en &lt;br&gt; Klik &quot;Outobespeur&quot; in die volgende dialoog.</translation>
+        <translation>Installeer asseblief GnuPG op jou stelsel.&lt;br&gt;Installeer &lt;strong&gt;Ubuntu&lt;/strong&gt; van die Microsoft Store om dit te kry.&lt;br&gt;As jy dit reeds gedoen het, maak seker dat jy dit een keer begin het en&lt;br&gt;klik &quot;Outospeur&quot; in die volgende dialoog.</translation>
     </message>
     <message>
         <location filename="../src/configdialog.cpp" line="968"/>
         <source>Please install GnuPG on your system.&lt;br&gt;Install &lt;strong&gt;Ubuntu&lt;/strong&gt; from the Microsoft Store&lt;br&gt;or &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;download&lt;/a&gt; it from GnuPG.org</source>
-        <translation>Installeer GnuPG op u stelsel. &lt;br&gt; Installeer &lt;strong&gt; Ubuntu &lt;/strong&gt; van die Microsoft Store &lt;br&gt; of &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt; laai dit af &lt;/a&gt; van GnuPG.org</translation>
+        <translation>Installeer asseblief GnuPG op jou stelsel.&lt;br&gt;Installeer &lt;strong&gt;Ubuntu&lt;/strong&gt; van die Microsoft Store&lt;br&gt;of &lt;a href=&quot;https://www.gnupg.org/download/#sec-1-2&quot;&gt;laai dit af&lt;/a&gt; van GnuPG.org</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="443"/>
@@ -751,12 +751,12 @@ Jy sal nie die gebruikerslys kan verander nie!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="264"/>
         <source>Failed to open .gpg-id for writing.</source>
-        <translation>Kon nie oopmaak nie. gpg-id vir skryf.</translation>
+        <translation>Kon nie .gpg-id vir skryf oopmaak nie.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="283"/>
         <source>Check selected users!</source>
-        <translation>Kies geselekteerde gebruikers!</translation>
+        <translation>Kontroleer geselekteerde gebruikers!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="284"/>

--- a/localization/localization_cs.ts
+++ b/localization/localization_cs.ts
@@ -1469,7 +1469,7 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="153"/>
         <source>Operation timed out; re-enabling interface.</source>
-        <translation type="unfinished">Operace vypršela; rozhraní se znovu aktivuje.</translation>
+        <translation>Operace vypršela; rozhraní se znovu aktivuje.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="359"/>
@@ -1479,22 +1479,22 @@ Expire-Date: 0
     <message>
         <location filename="../src/mainwindow.cpp" line="886"/>
         <source>Content search uses POSIX basic regular expressions (pass grep).</source>
-        <translation type="unfinished">Hledání v obsahu používá základní regulární výrazy POSIX (pass grep).</translation>
+        <translation>Hledání v obsahu používá základní regulární výrazy POSIX (pass grep).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="888"/>
         <source>Content search uses Perl-compatible regular expressions (PCRE).</source>
-        <translation type="unfinished">Hledání v obsahu používá regulární výrazy kompatibilní s Perlem (PCRE).</translation>
+        <translation>Hledání v obsahu používá regulární výrazy kompatibilní s Perlem (PCRE).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
         <source>Invalid name</source>
-        <translation type="unfinished">Neplatné jméno</translation>
+        <translation>Neplatné jméno</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1038"/>
         <source>That name would resolve outside the password store. Please choose a different name.</source>
-        <translation type="unfinished">Tento název by odkazoval mimo úložiště hesel. Zvolte prosím jiný název.</translation>
+        <translation>Tento název by odkazoval mimo úložiště hesel. Zvolte prosím jiný název.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1444"/>
@@ -1741,12 +1741,12 @@ Pokračovat?</translation>
         <location filename="../src/passworddisplaypanel.cpp" line="111"/>
         <location filename="../src/passworddisplaypanel.cpp" line="139"/>
         <source>Password</source>
-        <translation type="unfinished">Heslo</translation>
+        <translation>Heslo</translation>
     </message>
     <message>
         <location filename="../src/passworddisplaypanel.cpp" line="117"/>
         <source>Open %1 in browser</source>
-        <translation type="unfinished">Otevřít %1 v prohlížeči</translation>
+        <translation>Otevřít %1 v prohlížeči</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_cy.ts
+++ b/localization/localization_cy.ts
@@ -652,7 +652,7 @@ Bydd y gwerth yn dal i gael ei gadw fel y&apos;i nodwyd.</translation>
         <location filename="../src/imitatepass.cpp" line="154"/>
         <location filename="../src/imitatepass.cpp" line="577"/>
         <source>Could not read encryption key to use, .gpg-id file missing or invalid.</source>
-        <translation>Methwyd darllen allwedd amgryptio i&apos;w ddefnyddio, .gpg-id File ar goll neu annilys.</translation>
+        <translation>Methwyd darllen allwedd amgryptio i&apos;w defnyddio, ffeil .gpg-id ar goll neu annilys.</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="322"/>
@@ -1806,7 +1806,7 @@ Nid yw cofnodion coch yn ddilys, ni fyddwch yn gallu amgryptio i&apos;r rhain.</
     <message>
         <location filename="../src/usersdialog.cpp" line="83"/>
         <source>Keylist missing</source>
-        <translation>Keylist ar goll</translation>
+        <translation>Rhestr allweddi ar goll</translation>
     </message>
     <message>
         <location filename="../src/usersdialog.cpp" line="84"/>

--- a/localization/localization_da.ts
+++ b/localization/localization_da.ts
@@ -1425,7 +1425,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1415"/>
         <source>Open folder with file manager</source>
-        <translation>Åben mappen med filhåndteringen</translation>
+        <translation>Åbn mappen med filhåndteringen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="390"/>
@@ -1534,12 +1534,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
         <source>Invalid name</source>
-        <translation type="unfinished">Ugyldigt navn</translation>
+        <translation>Ugyldigt navn</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1038"/>
         <source>That name would resolve outside the password store. Please choose a different name.</source>
-        <translation type="unfinished">Det navn peger uden for adgangskodelageret. Vælg venligst et andet navn.</translation>
+        <translation>Det navn peger uden for adgangskodelageret. Vælg venligst et andet navn.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1444"/>

--- a/localization/localization_de_DE.ts
+++ b/localization/localization_de_DE.ts
@@ -764,7 +764,7 @@ Sie können die Benutzerliste nicht ändern!</translation>
         <source>None of the selected keys have a secret key available.
 You will not be able to decrypt any newly added passwords!</source>
         <translation>Der Partnerschlüssel der selektierten Schlüssel fehlt.
-Hiermit können keine neu hinzugefügefügten Kennwörter entschlüsselt werden!</translation>
+Hiermit können keine neu hinzugefügten Kennwörter entschlüsselt werden!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="640"/>
@@ -1528,7 +1528,7 @@ Expire-Date: 0
         <location filename="../src/mainwindow.cpp" line="957"/>
         <source>Found %n match(es)</source>
         <translation>
-            <numerusform>Ein Treffer gefunden</numerusform>
+            <numerusform>%n Treffer gefunden</numerusform>
             <numerusform>%n Treffer gefunden</numerusform>
         </translation>
     </message>

--- a/localization/localization_en_GB.ts
+++ b/localization/localization_en_GB.ts
@@ -706,7 +706,7 @@ e-mail</translation>
         <location filename="../src/imitatepass.cpp" line="153"/>
         <location filename="../src/imitatepass.cpp" line="576"/>
         <source>Can not edit</source>
-        <translation>Can not edit</translation>
+        <translation>Cannot edit</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="154"/>
@@ -1546,7 +1546,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="153"/>
         <source>Operation timed out; re-enabling interface.</source>
-        <translation type="unfinished">Operation timed out; re-enabling interface.</translation>
+        <translation>Operation timed out; re-enabling interface.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="359"/>
@@ -1556,12 +1556,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="886"/>
         <source>Content search uses POSIX basic regular expressions (pass grep).</source>
-        <translation type="unfinished">Content search uses POSIX basic regular expressions (pass grep).</translation>
+        <translation>Content search uses POSIX basic regular expressions (pass grep).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="888"/>
         <source>Content search uses Perl-compatible regular expressions (PCRE).</source>
-        <translation type="unfinished">Content search uses Perl-compatible regular expressions (PCRE).</translation>
+        <translation>Content search uses Perl-compatible regular expressions (PCRE).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1037"/>
@@ -1818,12 +1818,12 @@ Continue?</translation>
         <location filename="../src/passworddisplaypanel.cpp" line="111"/>
         <location filename="../src/passworddisplaypanel.cpp" line="139"/>
         <source>Password</source>
-        <translation type="unfinished">Password</translation>
+        <translation>Password</translation>
     </message>
     <message>
         <location filename="../src/passworddisplaypanel.cpp" line="117"/>
         <source>Open %1 in browser</source>
-        <translation type="unfinished">Open %1 in browser</translation>
+        <translation>Open %1 in browser</translation>
     </message>
 </context>
 <context>

--- a/localization/localization_en_US.ts
+++ b/localization/localization_en_US.ts
@@ -1512,12 +1512,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/mainwindow.cpp" line="886"/>
         <source>Content search uses POSIX basic regular expressions (pass grep).</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Content search uses POSIX basic regular expressions (pass grep).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="888"/>
         <source>Content search uses Perl-compatible regular expressions (PCRE).</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Content search uses Perl-compatible regular expressions (PCRE).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="933"/>

--- a/localization/localization_es_AR.ts
+++ b/localization/localization_es_AR.ts
@@ -705,7 +705,7 @@ dirección de correo</translation>
         <location filename="../src/imitatepass.cpp" line="391"/>
         <source>None of the secret signing keys is available.
 You will not be able to change the user list!</source>
-        <translation>Ninguna de las claves secretas de la firma están disponible.
+        <translation>Ninguna de las claves secretas de firma está disponible.
 ¡No vas a poder modificar la lista de usuarios!</translation>
     </message>
     <message>
@@ -1441,7 +1441,8 @@ Expire-Date: 0
         <location filename="../src/mainwindow.cpp" line="1086"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nuevo archivo de contraseña:
+(Se ubicará en %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1444"/>

--- a/localization/localization_es_EC.ts
+++ b/localization/localization_es_EC.ts
@@ -699,7 +699,7 @@ dirección de correo</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="390"/>
         <source>No signing key!</source>
-        <translation>¡Sin firma!</translation>
+        <translation>¡No hay clave de firma!</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="391"/>
@@ -1441,7 +1441,8 @@ Expire-Date: 0
         <location filename="../src/mainwindow.cpp" line="1086"/>
         <source>New password file: 
 (Will be placed in %1 )</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nuevo archivo de contraseñas:
+(Se colocará en %1 )</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1444"/>


### PR DESCRIPTION
## Summary

Addresses the 17 translation-content issues CodeRabbit flagged on #1576 (which were resolved out-of-scope there to keep that mechanical location-ref refresh clean). **Translation text only — no `<source>` strings changed.**

| File | Fix |
|------|-----|
| af | Clean MT artifacts in Windows GnuPG strings, fix garbled `.gpg-id` string, `Kies`→`Kontroleer` |
| cs | Drop `type="unfinished"` on 7 already-complete entries |
| cy | `File`→`ffeil` mixed-language token, translate `Keylist`→`Rhestr allweddi` |
| da | Imperative `Åben`→`Åbn`, unmark 2 complete entries |
| de_DE | `hinzugefügefügten`→`hinzugefügten`, restore `%n` in singular numerus |
| en_GB | `Can not edit`→`Cannot edit`, unmark 5 complete entries |
| en_US | Fill 2 empty unfinished entries with source baseline |
| es_AR | Grammar `están disponible`→`está disponible`, fill empty entry |
| es_EC | Signing-key wording, fill empty entry |

## Validation
- Structural audit: **0 placeholder / 0 HTML** issues across all 9 files
- `lrelease6` validates all 9 files; `cs` and `en_GB` now fully finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)