### PR TITLE
fix: firstFile invalid return, rename line vars, extract fieldHeight

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1004,18 +1004,19 @@ void MainWindow::selectFirstFile() {
  * @return QModelIndex
  */
 auto MainWindow::firstFile(QModelIndex parentIndex) -> QModelIndex {
-  QModelIndex index = parentIndex;
   int numRows = proxyModel.rowCount(parentIndex);
   for (int row = 0; row < numRows; ++row) {
-    index = proxyModel.index(row, 0, parentIndex);
+    QModelIndex index = proxyModel.index(row, 0, parentIndex);
     if (model.fileInfo(proxyModel.mapToSource(index)).isFile()) {
       return index;
     }
     if (proxyModel.hasChildren(index)) {
-      return firstFile(index);
+      QModelIndex childFile = firstFile(index);
+      if (childFile.isValid())
+        return childFile;
     }
   }
-  return index;
+  return QModelIndex();
 }
 
 /**

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -136,34 +136,36 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
           : "QLineEdit, QTextBrowser { border-style: none; background: "
             "transparent; }";
 
+  constexpr int fieldHeight = 26;
   if (s.hidePassword && trimmedField == QObject::tr("Password")) {
-    auto *line = new QLineEdit();
-    line->setObjectName(trimmedField);
-    line->setText(trimmedValue);
-    line->setReadOnly(true);
-    line->setStyleSheet(lineStyle);
-    line->setContentsMargins(0, 0, 0, 0);
-    line->setEchoMode(QLineEdit::Password);
-    auto *showButton = new QPushButtonShowPassword(line, m_widgetParent);
+    auto *passwordLineEdit = new QLineEdit();
+    passwordLineEdit->setObjectName(trimmedField);
+    passwordLineEdit->setText(trimmedValue);
+    passwordLineEdit->setReadOnly(true);
+    passwordLineEdit->setStyleSheet(lineStyle);
+    passwordLineEdit->setContentsMargins(0, 0, 0, 0);
+    passwordLineEdit->setEchoMode(QLineEdit::Password);
+    auto *showButton =
+        new QPushButtonShowPassword(passwordLineEdit, m_widgetParent);
     showButton->setStyleSheet(buttonStyle);
     showButton->setContentsMargins(0, 0, 0, 0);
     frame->layout()->addWidget(showButton);
-    frame->layout()->addWidget(line);
+    frame->layout()->addWidget(passwordLineEdit);
   } else {
-    auto *line = new QTextBrowser();
-    line->setOpenExternalLinks(true);
-    line->setOpenLinks(true);
-    line->setMaximumHeight(26);
-    line->setMinimumHeight(26);
-    line->setSizePolicy(
+    auto *contentTextBrowser = new QTextBrowser();
+    contentTextBrowser->setOpenExternalLinks(true);
+    contentTextBrowser->setOpenLinks(true);
+    contentTextBrowser->setMaximumHeight(fieldHeight);
+    contentTextBrowser->setMinimumHeight(fieldHeight);
+    contentTextBrowser->setSizePolicy(
         QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum));
-    line->setObjectName(trimmedField);
+    contentTextBrowser->setObjectName(trimmedField);
     trimmedValue.replace(Util::protocolRegex(), R"(<a href="\1">\1</a>)");
-    line->setText(trimmedValue);
-    line->setReadOnly(true);
-    line->setStyleSheet(lineStyle);
-    line->setContentsMargins(0, 0, 0, 0);
-    frame->layout()->addWidget(line);
+    contentTextBrowser->setText(trimmedValue);
+    contentTextBrowser->setReadOnly(true);
+    contentTextBrowser->setStyleSheet(lineStyle);
+    contentTextBrowser->setContentsMargins(0, 0, 0, 0);
+    frame->layout()->addWidget(contentTextBrowser);
   }
 
   // Derive the border colour from the palette so it adapts to light/dark


### PR DESCRIPTION
## Summary

Three real findings from the Greptile scan, two false positives explained.

**Fixed:**
- `firstFile()`: returned the last-evaluated directory index when no file was found; now returns `QModelIndex()`. Also fixed the recursive call — previously bailed out of sibling directories after entering the first subtree even if it contained no files
- `passworddisplaypanel`: renamed ambiguous `line` variable (reused across `if`/`else` with different types) to `passwordLineEdit` / `contentTextBrowser`
- `passworddisplaypanel`: extracted magic `26` → `constexpr int fieldHeight`

**False positives (not changed):**
- `MS_PER_SECOND` — defined in `src/util.h`
- `UiWatchdogMs` / `MaxOutputLines` — defined as `static constexpr` members in `src/mainwindow.h`
- `m_qtPass` raw pointer — Qt parent-child ownership handles deletion; `unique_ptr` + Qt parent risks double-delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a directory traversal issue that could return an invalid selection when searching for the first available file; it now only returns a valid file result when one exists.

* **Refactor**
  * Improved the “Password” and other field UI construction for consistency and readability, including using shared sizing for the non-password display and clearer internal widget naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->