### PR TITLE
fix: escape URLs in password display to prevent XSS

### DIFF
--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -115,7 +115,8 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
     urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
                                         QIcon(":/icons/open-url.svg")));
     // Escape only for tooltip rendering (rich-text safe display). The launched
-    // URL must remain the original validated value; HTML escaping would change it.
+    // URL must remain the original validated value; HTML escaping would change
+    // it.
     urlButton->setToolTip(
         QObject::tr("Open %1 in browser").arg(trimmedValue.toHtmlEscaped()));
     urlButton->setStyleSheet(buttonStyle);

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -25,6 +25,7 @@
 #include <QLineEdit>
 #include <QPalette>
 #include <QPushButton>
+#include <QRegularExpressionMatchIterator>
 #include <QTextBrowser>
 #include <QUrl>
 
@@ -164,8 +165,24 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
     contentTextBrowser->setSizePolicy(
         QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum));
     contentTextBrowser->setObjectName(trimmedField);
-    contentTextBrowser->setText(
-        trimmedValue.replace(Util::protocolRegex(), R"(<a href="\1">\1</a>)"));
+    {
+      QString linkedText;
+      int lastIndex = 0;
+      const QRegularExpression re = Util::protocolRegex();
+      QRegularExpressionMatchIterator it = re.globalMatch(trimmedValue);
+      while (it.hasNext()) {
+        const QRegularExpressionMatch match = it.next();
+        const int start = match.capturedStart(0);
+        const int end = match.capturedEnd(0);
+        linkedText +=
+            trimmedValue.mid(lastIndex, start - lastIndex).toHtmlEscaped();
+        const QString escapedUrl = match.captured(0).toHtmlEscaped();
+        linkedText += QStringLiteral("<a href=\"%1\">%1</a>").arg(escapedUrl);
+        lastIndex = end;
+      }
+      linkedText += trimmedValue.mid(lastIndex).toHtmlEscaped();
+      contentTextBrowser->setText(linkedText);
+    }
     contentTextBrowser->setReadOnly(true);
     contentTextBrowser->setStyleSheet(lineStyle);
     contentTextBrowser->setContentsMargins(0, 0, 0, 0);

--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -114,6 +114,8 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
     auto *urlButton = new QPushButton(m_widgetParent);
     urlButton->setIcon(QIcon::fromTheme(QStringLiteral("applications-internet"),
                                         QIcon(":/icons/open-url.svg")));
+    // Escape only for tooltip rendering (rich-text safe display). The launched
+    // URL must remain the original validated value; HTML escaping would change it.
     urlButton->setToolTip(
         QObject::tr("Open %1 in browser").arg(trimmedValue.toHtmlEscaped()));
     urlButton->setStyleSheet(buttonStyle);


### PR DESCRIPTION
_This PR applies 1/2 suggestions from code quality [AI findings](https://github.com/IJHack/QtPass/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL rendering safety by properly escaping HTML characters in displayed links.
  * Enhanced tooltip text rendering to ensure safe display of URL information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->