### PR TITLE
fix(gl): correct Galician 'Tódolos' to 'Todos os'

### DIFF
--- a/localization/localization_gl.ts
+++ b/localization/localization_gl.ts
@@ -96,7 +96,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="373"/>
         <source>All Characters</source>
-        <translation>Tódolos caracteres</translation>
+        <translation>Todos os caracteres</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="378"/>
@@ -341,7 +341,7 @@
     <message>
         <location filename="../src/configdialog.ui" line="1089"/>
         <source>Show all fields templated</source>
-        <translation>Mostra tódolos campos dos modelos</translation>
+        <translation>Mostra todos os campos dos modelos</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1116"/>
@@ -1696,7 +1696,7 @@ Continuar?</translation>
     <message>
         <location filename="../src/passworddialog.ui" line="114"/>
         <source>All Characters</source>
-        <translation>Tódolos caracteres</translation>
+        <translation>Todos os caracteres</translation>
     </message>
     <message>
         <location filename="../src/passworddialog.ui" line="119"/>


### PR DESCRIPTION
## Summary\n- Correct contracted 'Tódolos' to separated 'Todos os' in Galician translations (3 occurrences)\n- AI code quality finding fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Galician language translations for improved consistency and standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->