### PR TITLE
docs: explain why fieldHeight is 26px

### DIFF
--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -144,7 +144,7 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
           : "QLineEdit, QTextBrowser { border-style: none; background: "
             "transparent; }";
 
-  // Fixed control height keeps line edits and action buttons aligned.
+  // 26px matches the action-button visual height for consistent alignment.
   constexpr int fieldHeight = 26;
   if (s.hidePassword && trimmedField == QObject::tr("Password")) {
     auto *passwordLineEdit = new QLineEdit();


### PR DESCRIPTION
## Summary

- Clarify that 26px matches the action-button visual height for consistent vertical alignment in the credentials panel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal documentation clarification in code comments with no functional impact on user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->