### PR TITLE
fix: store regex matches; rename vars; local widget in clear()

### DIFF
--- a/src/passworddisplaypanel.cpp
+++ b/src/passworddisplaypanel.cpp
@@ -41,10 +41,9 @@ PasswordDisplayPanel::PasswordDisplayPanel(QGridLayout *grid,
 void PasswordDisplayPanel::clear() {
   while (m_grid->count() > 0) {
     QLayoutItem *item = m_grid->takeAt(0);
-    if (item->widget()) {
-      delete item->widget();
+    if (QWidget *widget = item->widget()) {
+      delete widget;
     }
-    // Layouts and spacers: QLayoutItem destructor handles cleanup.
     delete item;
   }
   m_container->setSpacing(0);
@@ -173,26 +172,22 @@ void PasswordDisplayPanel::addField(int position, const QString &field,
     contentTextBrowser->setObjectName(trimmedField);
     {
       QString linkedText;
-      qsizetype matchedUrlLength = 0;
-      qsizetype matchCount = 0;
+      QList<QRegularExpressionMatch> urlMatches;
+      qsizetype totalUrlLength = 0;
       {
-        QRegularExpressionMatchIterator sizeIt =
+        QRegularExpressionMatchIterator it =
             kProtocolRegex.globalMatch(trimmedValue);
-        while (sizeIt.hasNext()) {
-          const QRegularExpressionMatch match = sizeIt.next();
-          matchedUrlLength += match.capturedLength(0);
-          ++matchCount;
+        while (it.hasNext()) {
+          QRegularExpressionMatch match = it.next();
+          totalUrlLength += match.capturedLength(0);
+          urlMatches.append(match);
         }
       }
-      // Base text + duplicated URL text in href/content + fixed tag overhead.
       constexpr qsizetype anchorTagOverhead = sizeof("<a href=\"\"></a>") - 1;
-      linkedText.reserve(trimmedValue.size() + matchedUrlLength +
-                         matchCount * anchorTagOverhead);
+      linkedText.reserve(trimmedValue.size() + totalUrlLength +
+                         urlMatches.size() * anchorTagOverhead);
       int lastIndex = 0;
-      QRegularExpressionMatchIterator it =
-          kProtocolRegex.globalMatch(trimmedValue);
-      while (it.hasNext()) {
-        const QRegularExpressionMatch match = it.next();
+      for (const QRegularExpressionMatch &match : std::as_const(urlMatches)) {
         const int start = match.capturedStart(0);
         const int end = match.capturedEnd(0);
         linkedText +=


### PR DESCRIPTION
## Summary
- **clear()**: use local `widget` pointer; remove misleading comment (QLayoutItem dtor does NOT clean child layouts)
- **Variable renaming**: `matchedUrlLength` → `totalUrlLength`, `matchCount` → `urlMatchCount`
- **Single regex pass**: store `QRegularExpressionMatch` in `QList` during size pass, reuse for link building — avoids second `globalMatch` call on same input

### Findings addressed
| Finding | Status |
|---------|--------|
| 1. clear() widget reuse + misleading comment | ✅ Partial (skipped dead layout branch — grid only ever gets widgets) |
| 2. Ambiguous variable names | ✅ Renamed |
| 3. Double regex pass | ✅ Single pass with stored matches |
| 4. sizeof → 13 | ❌ Rejected — math is wrong (9+2+4=15, not 13); sizeof is self-documenting |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved stability of password panel cleanup by refining how dynamically created widgets are removed and deleted.
  * Improved link rendering in password fields by optimizing URL match processing for faster, more efficient text generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->