### PR TITLE
fix: report gpg keygen start failures instead of hanging (#1598)

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -82,9 +82,26 @@ void Executor::executeNext() {
 #ifdef QT_DEBUG
           dbg() << "Process failed to start:" << i.id << " " << i.app;
 #endif
+          // Capture before dequeue() invalidates the head reference.
+          const int failedId = i.id;
+          const QString failedApp = i.app;
           m_process.closeWriteChannel();
           running = false;
           m_execQueue.dequeue();
+          // Surface the failure instead of silently dropping the command:
+          // otherwise callers waiting on a finished/error signal (e.g. the GPG
+          // keygen dialog) hang forever with no feedback. Defer the emit via a
+          // queued call so we do not re-enter a caller still on the stack —
+          // KeygenDialog::done() drives key generation synchronously — which
+          // mirrors the normal asynchronous QProcess::finished path. A -1 exit
+          // code routes through Pass::finished's non-zero error gate.
+          QMetaObject::invokeMethod(
+              this,
+              [this, failedId, failedApp]() {
+                emit error(failedId, -1, QString(),
+                           tr("Failed to start %1").arg(failedApp));
+              },
+              Qt::QueuedConnection);
           executeNext();
           return;
         }

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -439,19 +439,31 @@ auto Pass::resolveGpgconfCommand(const QString &gpgPath)
  * @param batch GnuPG style configuration string
  */
 void Pass::GenerateGPGKeys(QString batch) {
-  // Kill any stale GPG agents that might be holding locks on the key database
-  // This helps avoid "database locked" timeouts during key generation
   const QString gpgPath = m_settings.gpgExecutable;
-  if (!gpgPath.isEmpty()) {
-    ResolvedGpgconfCommand resolvedGpgconf = resolveGpgconfCommand(gpgPath);
-    QStringList killArgs = resolvedGpgconf.arguments;
-    killArgs << "--kill";
-    killArgs << "gpg-agent";
-    // Use same environment as key generation to target correct gpg-agent
-    if (Executor::executeBlocking(env, resolvedGpgconf.program, killArgs) !=
-        0) {
-      qWarning() << "Failed to kill gpg-agent";
-    }
+  if (gpgPath.isEmpty()) {
+    // No gpg configured: executeWrapper would hand an empty executable to the
+    // Executor, which silently drops it (see Executor::execute), leaving the
+    // keygen dialog spinning with no feedback. Surface the misconfiguration
+    // instead. Deferred via a queued call so we do not re-enter
+    // KeygenDialog::done(), which drives key generation synchronously.
+    QMetaObject::invokeMethod(
+        this,
+        [this]() {
+          emit processErrorExit(1, tr("No GPG executable configured"));
+        },
+        Qt::QueuedConnection);
+    return;
+  }
+
+  // Kill any stale GPG agents that might be holding locks on the key database.
+  // This helps avoid "database locked" timeouts during key generation.
+  ResolvedGpgconfCommand resolvedGpgconf = resolveGpgconfCommand(gpgPath);
+  QStringList killArgs = resolvedGpgconf.arguments;
+  killArgs << "--kill";
+  killArgs << "gpg-agent";
+  // Use same environment as key generation to target correct gpg-agent
+  if (Executor::executeBlocking(env, resolvedGpgconf.program, killArgs) != 0) {
+    qWarning() << "Failed to kill gpg-agent";
   }
 
   executeWrapper(GPG_GENKEYS, gpgPath, {"--gen-key", "--no-tty", "--batch"},

--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
 // SPDX-License-Identifier: GPL-3.0-or-later
+#include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 #include <QtTest>
 
@@ -463,7 +465,13 @@ void tst_executor::executeAsyncWithWorkDir() {
   exec.execute(5, tmp.path(), sh, {"-c", "pwd"}, true, false);
   QTRY_COMPARE_WITH_TIMEOUT(spy.count(), 1, 5000);
   const QString output = spy.first().at(2).toString().trimmed();
-  QVERIFY2(QDir::cleanPath(output) == QDir::cleanPath(tmp.path()),
+  QVERIFY2(!output.isEmpty(), "pwd must produce output");
+  // Compare canonical paths: on macOS the temp dir lives under /var (a symlink
+  // to /private/var) and the child's pwd reports the resolved physical path, so
+  // a plain string compare fails. canonicalFilePath() resolves symlinks on both
+  // sides so equivalent locations compare equal on every platform.
+  QVERIFY2(QFileInfo(output).canonicalFilePath() ==
+               QFileInfo(tmp.path()).canonicalFilePath(),
            "working directory must match the tmp path");
 }
 

--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -31,6 +31,8 @@ private Q_SLOTS:
   void executeAsyncStartingSignal();
   void executeAsyncMultipleSequential();
   void executeAsyncWithWorkDir();
+  void executeAsyncFailedToStartEmitsError();
+  void executeAsyncCrashExitReportsNonZeroCode();
   void cancelNextWhileRunningReturnsMinusOne();
 #endif
   void executeBlockingNotFound();
@@ -375,6 +377,46 @@ void tst_executor::executeAsyncNonZeroExitCode() {
   QTRY_COMPARE_WITH_TIMEOUT(spy.count(), 1, 5000);
   const int exitCode = spy.first().at(1).toInt();
   QVERIFY2(exitCode != 0, "sh -c 'exit 1' must exit with non-zero code");
+}
+
+void tst_executor::executeAsyncFailedToStartEmitsError() {
+  // Regression test for #1598: a command that carries stdin but fails to start
+  // must surface an error rather than being silently dropped. Previously
+  // executeNext() dequeued it without emitting finished() or error(), leaving
+  // callers (e.g. the GPG keygen dialog) hanging with no feedback.
+  Executor exec;
+  QSignalSpy errorSpy(&exec, &Executor::error);
+  QSignalSpy finishedSpy(&exec,
+                         qOverload<int, int, const QString &, const QString &>(
+                             &Executor::finished));
+  QVERIFY2(errorSpy.isValid(), "spy must connect to Executor::error signal");
+  QVERIFY2(finishedSpy.isValid(),
+           "spy must connect to Executor::finished signal");
+  // Non-empty input forces the waitForStarted() branch in executeNext().
+  exec.execute(1, "/nonexistent/definitely-not-a-real-binary",
+               {"--gen-key", "--no-tty", "--batch"},
+               QStringLiteral("Key-Type: RSA\n%commit\n"), true, true);
+  QTRY_COMPARE_WITH_TIMEOUT(errorSpy.count(), 1, 5000);
+  QCOMPARE(finishedSpy.count(), 0);
+  QCOMPARE(errorSpy.first().at(0).toInt(), 1);
+  QVERIFY2(errorSpy.first().at(1).toInt() != 0,
+           "a failed-to-start process must report a non-zero exit code");
+}
+
+void tst_executor::executeAsyncCrashExitReportsNonZeroCode() {
+  // A signal-killed process is reported by QProcess as CrashExit with an exit
+  // code equal to the signal number (never 0), so it routes through the
+  // non-zero error gate instead of being mistaken for a successful run.
+  const QString sh = QStandardPaths::findExecutable("sh");
+  if (sh.isEmpty())
+    QSKIP("sh not found in PATH");
+  Executor exec;
+  QSignalSpy errorSpy(&exec, &Executor::error);
+  QVERIFY2(errorSpy.isValid(), "spy must connect to Executor::error signal");
+  exec.execute(2, sh, {"-c", "kill -SEGV $$"}, true, true);
+  QTRY_COMPARE_WITH_TIMEOUT(errorSpy.count(), 1, 5000);
+  QVERIFY2(errorSpy.first().at(1).toInt() != 0,
+           "a crashed process must report a non-zero exit code");
 }
 
 void tst_executor::executeAsyncStartingSignal() {

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -216,6 +216,7 @@ private Q_SLOTS:
   void imitatePass_insertMoveAndShow();
   void imitatePass_insertCopyAndShow();
   void imitatePass_insertAndRemove();
+  void imitatePass_generateGpgKeysEmptyExecutable();
   void imitatePass_nestedDirectoryInsertAndShow();
   void imitatePass_editExistingEntry();
   void imitatePass_grepCaseInsensitive();
@@ -341,6 +342,29 @@ void tst_integration::cleanupTestCase() {
 // ---------------------------------------------------------------------------
 // ImitatePass tests
 // ---------------------------------------------------------------------------
+
+void tst_integration::imitatePass_generateGpgKeysEmptyExecutable() {
+  // Regression test for #1598: with no gpg executable configured,
+  // GenerateGPGKeys must surface an error rather than silently dropping the
+  // command (which would leave the keygen dialog spinning forever with no
+  // feedback). No gpg is run.
+  ImitatePass pass;
+  AppSettings s = QtPassSettings::load();
+  s.gpgExecutable = QString(); // unconfigured
+  pass.init(s);
+
+  QSignalSpy errorSpy(&pass, &Pass::processErrorExit);
+  QSignalSpy successSpy(&pass, &Pass::finishedGenerateGPGKeys);
+  QVERIFY(errorSpy.isValid());
+  QVERIFY(successSpy.isValid());
+
+  pass.GenerateGPGKeys(QStringLiteral("Key-Type: RSA\n%commit\n"));
+
+  QTRY_COMPARE_WITH_TIMEOUT(errorSpy.count(), 1, 5000);
+  QCOMPARE(successSpy.count(), 0);
+  QVERIFY2(errorSpy.first().at(0).toInt() != 0,
+           "an unconfigured gpg executable must report a non-zero exit code");
+}
 
 void tst_integration::imitatePass_insertAndShow() {
   QTemporaryDir storeDir;


### PR DESCRIPTION
## Summary

Closes the residual silent-failure path behind #1598 (and the "no output about why" symptom in #637).

The original report — "success shown regardless of exit code" — was already fixed in `8df346373`: `Pass::finished` gates on `if (exitCode != 0) { handleProcessError(...); return; }` before any success signal, so `finishedGenerateGPGKeys` → "generated successfully" is only reachable on exit code 0. A keygen that *runs and returns non-zero* already shows "GPG key pair generation failed".

What was **not** covered: a gpg that **never starts**.

- Keygen sends its batch on stdin, so `Executor::executeNext()` takes the `waitForStarted(-1)` branch. On `FailedToStart` (missing/non-executable binary, or a Flatpak seccomp denial) it dequeued the command **without emitting `finished()` or `error()`** — so `Pass::finished` never ran, `cleanKeygenDialog()` never ran, and the modal keygen dialog spun forever with no feedback.
- An empty configured gpg executable hit the same dead-end via `Executor::execute()`'s intentional empty-app early return.

## Changes

- **`Executor::executeNext()`** — on `FailedToStart`, emit `error(id, -1, …, "Failed to start <app>")` so the failure routes through `Pass::finished`'s existing non-zero exit-code gate to the "generation failed" path. Emitted via a **queued** call so it does not re-enter `KeygenDialog::done()` (which drives key generation synchronously); this makes it behave exactly like the normal async `QProcess::finished` path. Fixes every stdin-carrying command, not just keygen.
- **`Pass::GenerateGPGKeys()`** — when the gpg executable is unconfigured, surface `processErrorExit()` instead of handing an empty command to the `Executor`. The Executor's silent empty-app return is left intact (it is intentional, to avoid spamming bogus failures for unconfigured git).
- **Regression tests** (`tests/auto/executor`):
  - `executeAsyncFailedToStartEmitsError` — a failed-to-start stdin command now emits exactly one `error()` with a non-zero code (previously **zero** signals).
  - `executeAsyncCrashExitReportsNonZeroCode` — locks in that a signal-killed process reports `CrashExit` with a non-zero exit code, so it can never be mistaken for success.

## Notes

- A signal-killed gpg was **verified** to already route correctly: on Unix (Linux verified; forkfd is identical on Qt 5.15) `QProcess` reports `CrashExit` with `exitCode == signal number` (SEGV→11, KILL→9…), never 0 — so it already hits the non-zero gate. No false-success there.
- Signal signatures are unchanged → Qt 5.15 and Qt 6 compatible.
- Deliberately **not** wiring `QProcess::errorOccurred` as the primary fix: for stdin-carrying commands it would double-emit with the `waitForStarted` branch.

## Testing

`make check` — all suites pass (executor: 34 including the 2 new tests; full run 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed-to-start processes now report an error (exit code `-1`) instead of silently stopping, preventing waits from hanging.
  * Key generation now validates GPG executable configuration and cleanly reports “No GPG executable configured” when missing.
  * Crash termination now consistently surfaces as an error with a non-zero exit code.
* **Tests**
  * Added async regression tests for failed start and crash behavior.
  * Added an integration test for key generation error handling with empty GPG executable.
  * Improved working-directory assertion to compare canonical paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->