### PR TITLE
ci: build macOS on Qt 6.11; keep 6.8 LTS on Linux/Windows

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -56,11 +56,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Qt 6.8 (LTS) is verified on Linux and Windows. macOS is not tested on
+        # 6.8: the macos-latest runner's Xcode 26.x cannot compile Qt 6.8.x
+        # (qyieldcpu.h uses the ARM __yield intrinsic, unfixed until 6.11.1).
+        # macOS is covered by the 6.11 entry below, matching what the dmg ships.
+        os: [ubuntu-latest, windows-latest]
         qt: ["6.8"]
         include:
           - os: ubuntu-latest
             qt: "5.15"
+          - os: ubuntu-latest
+            qt: "6.11"
+          - os: macos-latest
+            qt: "6.11"
 
     steps:
       - name: Check if build needed

--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -78,6 +78,9 @@ jobs:
 
       - uses: jurplel/install-qt-action@v4.3.1
         if: steps.need_build.outputs.run_build == 'true'
+        with:
+          # The Windows installer ships on Qt 6.8 (LTS).
+          version: "6.8"
 
       - name: Install Inno Setup
         if: steps.need_build.outputs.run_build == 'true'
@@ -170,6 +173,12 @@ jobs:
 
       - uses: jurplel/install-qt-action@v4.3.1
         if: steps.need_build.outputs.run_build == 'true'
+        with:
+          # Qt 6.11 (6.11.1+) is required to build on the macos-latest runner:
+          # its Xcode 26.x clang rejects the ARM __yield intrinsic used by
+          # Qt 6.8.x's qyieldcpu.h. 6.11 reordered that header to prefer
+          # __builtin_arm_yield, so it compiles cleanly.
+          version: "6.11"
 
       - name: Install dmg helper
         if: steps.need_build.outputs.run_build == 'true'


### PR DESCRIPTION
## Summary

Fixes the macOS **Release Build** (`build-macos` / dmg) failure and adds Qt 6.11 CI coverage.

> Supersedes this PR's original approach. The first attempt pinned `version: "6.8"`, which was a **no-op** — it resolves to the same `6.8.3` default that was already failing. Corrected below.

## Root cause

The macOS dmg job and `ccpp.yml`'s macOS job both used **Qt 6.8.3**. The difference was the runner: `macos-latest` is mid-migration and hands out **macOS 26 / Xcode 26.5** to some jobs and **macOS 15 / Xcode 16.4** to others. Under Xcode 26.5, clang reports `__has_builtin(__yield)` true and then errors on Qt 6.8.x's `qyieldcpu.h`, which calls the ARM `__yield()` intrinsic without `#include <arm_acle.h>`:

```
QtCore.framework/Headers/qyieldcpu.h:35:5: error:
  implicitly declaring library function '__yield' [-Werror,-Wimplicit-function-declaration]
```

I checked the Qt sources directly: the header is broken in **6.8.3, 6.9.2, and 6.9.3**; the reorder that prefers `__builtin_arm_yield` first landed only in **Qt 6.11.1**. So Qt 6.8/6.9 simply cannot build on the current macOS runner.

## Approach

Move macOS forward to Qt 6.11 (works on Xcode 26.x) rather than pinning an ancient runner:

- **`release-installers.yml`**: build the macOS dmg with `version: "6.11"`; pin the Windows installer explicitly to `version: "6.8"` (LTS).
- **`ccpp.yml`**: add Qt **6.11** jobs on `macos-latest` and `ubuntu-latest`; keep the Qt **6.8** LTS matrix on Linux + Windows (macOS can no longer build 6.8 on this runner) and the existing Qt **5.15** Linux job.

## Verification note

This PR only touches workflow files, so the `changes`/`need_build` gate **skips the compile** on this PR's own runs — the new Qt 6.11 job can't self-demonstrate here. It gets exercised the first time a source PR runs the matrix (e.g. #1599 rebased onto main once this merges). If QtPass turns out to need adjustments for Qt 6.11, that surfaces there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
