### PR TITLE
fix: stop ConfigDialog from silently corrupting saved settings

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -1269,6 +1269,9 @@ void ConfigDialog::usePwgen(bool usePwgen) {
 
 void ConfigDialog::setPasswordConfiguration(
     const PasswordConfiguration &config) {
+  // Retain the custom charset so it survives even when a builtin set is the
+  // active selection (the line edit then shows the builtin's characters).
+  m_customPasswordChars = config.Characters[PasswordConfiguration::CUSTOM];
   ui->spinBoxPasswordLength->setValue(config.length);
   ui->passwordCharTemplateSelector->setCurrentIndex(config.selected);
   if (config.selected != PasswordConfiguration::CUSTOM) {
@@ -1285,14 +1288,12 @@ auto ConfigDialog::getPasswordConfiguration() -> PasswordConfiguration {
   // The line edit only holds the user's custom charset while CUSTOM is
   // selected; for a builtin selection it shows that builtin's characters.
   // Reading it unconditionally would overwrite the saved custom charset with a
-  // builtin string, so preserve the persisted custom value in that case.
+  // builtin string, so fall back to the retained custom value in that case.
   if (config.selected == PasswordConfiguration::CUSTOM) {
     config.Characters[PasswordConfiguration::CUSTOM] =
         ui->lineEditPasswordChars->text();
   } else {
-    config.Characters[PasswordConfiguration::CUSTOM] =
-        QtPassSettings::getPasswordConfiguration()
-            .Characters[PasswordConfiguration::CUSTOM];
+    config.Characters[PasswordConfiguration::CUSTOM] = m_customPasswordChars;
   }
   return config;
 }

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -150,6 +150,12 @@ void ConfigDialog::applySettings(const AppSettings &settings) {
   useOtp(settings.useOtp);
   useGrepSearch(settings.useGrepSearch);
   useQrencode(settings.useQrencode);
+  // Restore the persisted pwgen path and password-generation settings before
+  // toggling usePwgen (which is gated on a non-empty pwgen path). Without this
+  // the Password-tab widgets keep their .ui defaults and readSettings() writes
+  // those defaults back over the user's saved configuration on every OK.
+  setPwgenPath(settings.pwgenExecutable);
+  setPasswordConfiguration(settings.passwordConfiguration);
   usePwgen(settings.usePwgen);
   useTemplate(settings.useTemplate);
 }
@@ -254,8 +260,8 @@ void ConfigDialog::usePass(bool usePass) {
  * @return void - This function does not return a value.
  */
 void ConfigDialog::validate(QTableWidgetItem *item) {
-  bool status = true;
-
+  // Update the required-field marker(s): all cells when no specific item is
+  // given, otherwise just the one that changed.
   if (item == nullptr) {
     for (int i = 0; i < ui->profileTable->rowCount(); i++) {
       for (int j = 0; j < ui->profileTable->columnCount(); j++) {
@@ -266,26 +272,34 @@ void ConfigDialog::validate(QTableWidgetItem *item) {
         if (_item->text().isEmpty() && j != 2) {
           _item->setBackground(Qt::red);
           _item->setToolTip(tr("This field is required"));
-          status = false;
-          break;
         } else {
           _item->setBackground(QBrush());
           _item->setToolTip(QString());
         }
-      }
-
-      if (!status) {
-        break;
       }
     }
   } else {
     if (item->text().isEmpty() && item->column() != 2) {
       item->setBackground(Qt::red);
       item->setToolTip(tr("This field is required"));
-      status = false;
     } else {
       item->setBackground(QBrush());
       item->setToolTip(QString());
+    }
+  }
+
+  // Enable OK only when every required cell across all rows is filled. Deriving
+  // this from a single changed item would re-enable OK while another row still
+  // has an empty required field, letting an empty-named profile be saved (and
+  // then silently dropped, losing that profile's path and signing key).
+  bool status = true;
+  for (int i = 0; i < ui->profileTable->rowCount() && status; i++) {
+    for (int j = 0; j < ui->profileTable->columnCount(); j++) {
+      QTableWidgetItem *_item = ui->profileTable->item(i, j);
+      if (_item && _item->text().isEmpty() && j != 2) {
+        status = false;
+        break;
+      }
     }
   }
 
@@ -619,24 +633,40 @@ void ConfigDialog::setProfiles(QHash<QString, QHash<QString, QString>> profiles,
   // Cache profiles for use in onProfileTableSelectionChanged
   m_profiles = profiles;
 
+  // Populate with sorting disabled: writing into the sort column re-sorts the
+  // table between setItem calls, so the path/signingKey cells would land in a
+  // different profile's row — corrupting the display and destroying data on
+  // save. Restore the previous sort state and locate the current row by item
+  // pointer afterwards.
+  bool sortingEnabled = ui->profileTable->isSortingEnabled();
+  ui->profileTable->setSortingEnabled(false);
+
   ui->profileTable->setRowCount(static_cast<int>(profiles.count()));
   QHashIterator<QString, QHash<QString, QString>> i(profiles);
   int n = 0;
+  QTableWidgetItem *currentItem = nullptr;
   while (i.hasNext()) {
     i.next();
     if (!i.value().isEmpty() && !i.key().isEmpty()) {
-      ui->profileTable->setItem(n, 0, new QTableWidgetItem(i.key()));
+      auto *nameItem = new QTableWidgetItem(i.key());
+      ui->profileTable->setItem(n, 0, nameItem);
       ui->profileTable->setItem(n, 1,
                                 new QTableWidgetItem(i.value().value("path")));
       ui->profileTable->setItem(
           n, 2, new QTableWidgetItem(i.value().value("signingKey")));
       if (i.key() == currentProfile) {
-        ui->profileTable->selectRow(n);
-        // Load git settings for current profile
-        loadGitSettingsForProfile(currentProfile, m_profiles);
+        currentItem = nameItem;
       }
     }
     ++n;
+  }
+
+  ui->profileTable->setSortingEnabled(sortingEnabled);
+
+  if (currentItem != nullptr) {
+    ui->profileTable->selectRow(ui->profileTable->row(currentItem));
+    // Load git settings for current profile
+    loadGitSettingsForProfile(currentProfile, m_profiles);
   }
 }
 
@@ -815,18 +845,22 @@ void ConfigDialog::on_addButton_clicked() {
 
   int n = ui->profileTable->rowCount();
   ui->profileTable->insertRow(n);
-  ui->profileTable->setItem(n, 0, new QTableWidgetItem(tr("New Profile")));
+  auto *nameItem = new QTableWidgetItem(tr("New Profile"));
+  ui->profileTable->setItem(n, 0, nameItem);
   ui->profileTable->setItem(n, 1, new QTableWidgetItem(ui->storePath->text()));
   ui->profileTable->setItem(n, 2, new QTableWidgetItem());
 
   ui->profileTable->setSortingEnabled(sortingEnabled);
 
-  int currentRow = ui->profileTable->row(ui->profileTable->item(n, 0));
+  // Re-enabling sorting may move the new row, so locate it by item pointer
+  // rather than the stale insertion index — item(n, 0) could now be a
+  // different, existing profile, which we would then wrongly rename/select.
+  int currentRow = ui->profileTable->row(nameItem);
   ui->profileTable->selectRow(currentRow);
   ui->deleteButton->setEnabled(true);
 
-  ui->profileTable->editItem(ui->profileTable->item(currentRow, 0));
-  ui->profileTable->item(currentRow, 0)->setSelected(true);
+  ui->profileTable->editItem(nameItem);
+  nameItem->setSelected(true);
 
   validate();
   updateProfileStatus(currentRow);
@@ -840,7 +874,14 @@ void ConfigDialog::on_profileTable_cellDoubleClicked(int row, int column) {
   if (column == 1) {
     QString dir = selectFolder();
     if (!dir.isEmpty()) {
-      ui->profileTable->item(row, 1)->setText(dir);
+      // QTableWidget emits cellDoubleClicked even for cells with no item, so
+      // guard against a null path cell rather than dereferencing it.
+      QTableWidgetItem *pathItem = ui->profileTable->item(row, 1);
+      if (pathItem != nullptr) {
+        pathItem->setText(dir);
+      } else {
+        ui->profileTable->setItem(row, 1, new QTableWidgetItem(dir));
+      }
     }
   }
 }
@@ -1241,8 +1282,18 @@ auto ConfigDialog::getPasswordConfiguration() -> PasswordConfiguration {
   config.length = ui->spinBoxPasswordLength->value();
   config.selected = static_cast<PasswordConfiguration::characterSet>(
       ui->passwordCharTemplateSelector->currentIndex());
-  config.Characters[PasswordConfiguration::CUSTOM] =
-      ui->lineEditPasswordChars->text();
+  // The line edit only holds the user's custom charset while CUSTOM is
+  // selected; for a builtin selection it shows that builtin's characters.
+  // Reading it unconditionally would overwrite the saved custom charset with a
+  // builtin string, so preserve the persisted custom value in that case.
+  if (config.selected == PasswordConfiguration::CUSTOM) {
+    config.Characters[PasswordConfiguration::CUSTOM] =
+        ui->lineEditPasswordChars->text();
+  } else {
+    config.Characters[PasswordConfiguration::CUSTOM] =
+        QtPassSettings::getPasswordConfiguration()
+            .Characters[PasswordConfiguration::CUSTOM];
+  }
   return config;
 }
 

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -221,6 +221,9 @@ private:
 
   MainWindow *mainWindow;
   QHash<QString, QHash<QString, QString>> m_profiles;
+  /// User-defined custom charset, retained while a builtin set is selected so
+  /// it is not lost when the line edit shows the builtin's characters instead.
+  QString m_customPasswordChars;
 };
 
 #endif // SRC_CONFIGDIALOG_H_

--- a/src/qtpasssettings.cpp
+++ b/src/qtpasssettings.cpp
@@ -166,7 +166,17 @@ auto QtPassSettings::getProfiles() -> QHash<QString, QHash<QString, QString>> {
  */
 void QtPassSettings::setProfiles(
     const QHash<QString, QHash<QString, QString>> &profiles) {
+  // The "profile" key is overloaded: it stores both the active-profile name
+  // (a scalar, read by getProfile()) and the per-profile group
+  // (profile/<name>/...). remove() clears the whole subtree including the
+  // scalar, which would silently switch the active password store on every
+  // save, so preserve and restore the active-profile name around the rewrite.
+  const QString activeProfile =
+      getInstance()->value(SettingsConstants::profile).toString();
   getInstance()->remove(SettingsConstants::profile);
+  if (!activeProfile.isEmpty()) {
+    getInstance()->setValue(SettingsConstants::profile, activeProfile);
+  }
   getInstance()->beginGroup(SettingsConstants::profile);
 
   QHash<QString, QHash<QString, QString>>::const_iterator i = profiles.begin();

--- a/tests/auto/configdialog/tst_configdialog.cpp
+++ b/tests/auto/configdialog/tst_configdialog.cpp
@@ -319,8 +319,13 @@ void tst_configdialog::customCharsetPreservedWhenBuiltinSelected() {
  * the new one. The new row must be located by item pointer.
  */
 void tst_configdialog::addProfileSelectsNewRowAfterSort() {
-  const QHash<QString, QHash<QString, QString>> previous =
-      QtPassSettings::getProfiles();
+  // Restore the real profile state even if an assertion fails early (QVERIFY/
+  // QCOMPARE return immediately), so this test never leaks its synthetic
+  // profiles into later tests in the run.
+  struct ProfileRestorer {
+    QHash<QString, QHash<QString, QString>> saved;
+    ~ProfileRestorer() { QtPassSettings::setProfiles(saved); }
+  } restorer{QtPassSettings::getProfiles()};
 
   QHash<QString, QHash<QString, QString>> profiles;
   for (const QString &name :
@@ -350,9 +355,6 @@ void tst_configdialog::addProfileSelectsNewRowAfterSort() {
     QVERIFY(nameItem != nullptr);
     QCOMPARE(nameItem->text(), QStringLiteral("New Profile"));
   }
-
-  // Restore whatever profile state existed before the test.
-  QtPassSettings::setProfiles(previous);
 }
 
 QTEST_MAIN(tst_configdialog)

--- a/tests/auto/configdialog/tst_configdialog.cpp
+++ b/tests/auto/configdialog/tst_configdialog.cpp
@@ -5,10 +5,12 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QSystemTrayIcon>
+#include <QTableWidget>
 #include <QtTest>
 
 #include "../../../src/configdialog.h"
 #include "../../../src/passwordconfiguration.h"
+#include "../../../src/qtpasssettings.h"
 
 /**
  * @class tst_configdialog
@@ -47,6 +49,8 @@ private Q_SLOTS:
   void setPwgenPathEmptyDisablesPwgenCheckbox();
   void setAndGetPasswordConfigurationRoundTrip();
   void customCharsetRoundTrip();
+  void customCharsetPreservedWhenBuiltinSelected();
+  void addProfileSelectsNewRowAfterSort();
 };
 
 /**
@@ -276,6 +280,79 @@ void tst_configdialog::customCharsetRoundTrip() {
            static_cast<int>(PasswordConfiguration::CUSTOM));
   QCOMPARE(result.Characters[PasswordConfiguration::CUSTOM],
            QStringLiteral("abc123!@#"));
+}
+
+/**
+ * @brief The custom charset survives while a builtin set is selected.
+ *
+ * This is the branch the fix is actually about: with a builtin (non-CUSTOM)
+ * selection the line edit shows the builtin's characters, so
+ * getPasswordConfiguration() must fall back to the retained custom charset
+ * rather than reading the line edit and clobbering it with a builtin string.
+ */
+void tst_configdialog::customCharsetPreservedWhenBuiltinSelected() {
+  ConfigDialog dialog(nullptr);
+  PasswordConfiguration cfg;
+  cfg.selected = PasswordConfiguration::CUSTOM;
+  cfg.Characters[PasswordConfiguration::CUSTOM] = QStringLiteral("abc123!@#");
+  dialog.setPasswordConfiguration(cfg);
+
+  // Switch to a builtin selection while keeping the same custom charset.
+  PasswordConfiguration builtin = dialog.getPasswordConfiguration();
+  builtin.selected = PasswordConfiguration::ALPHANUMERIC;
+  dialog.setPasswordConfiguration(builtin);
+
+  PasswordConfiguration result = dialog.getPasswordConfiguration();
+  QCOMPARE(static_cast<int>(result.selected),
+           static_cast<int>(PasswordConfiguration::ALPHANUMERIC));
+  QCOMPARE(result.Characters[PasswordConfiguration::CUSTOM],
+           QStringLiteral("abc123!@#"));
+}
+
+/**
+ * @brief Adding a profile after the user sorted by name selects the new row.
+ *
+ * Regression for on_addButton_clicked(): after the user sorts the table by the
+ * name column, re-enabling sorting moves the freshly inserted row, so reading
+ * item(n, 0) by the stale insertion index returned an existing profile — the
+ * edit and selection then landed on (and would rename) that profile instead of
+ * the new one. The new row must be located by item pointer.
+ */
+void tst_configdialog::addProfileSelectsNewRowAfterSort() {
+  const QHash<QString, QHash<QString, QString>> previous =
+      QtPassSettings::getProfiles();
+
+  QHash<QString, QHash<QString, QString>> profiles;
+  for (const QString &name :
+       {QStringLiteral("alpha"), QStringLiteral("beta"),
+        QStringLiteral("gamma"), QStringLiteral("delta")}) {
+    QHash<QString, QString> profile;
+    profile.insert("path", "/store/" + name);
+    profiles.insert(name, profile);
+  }
+  QtPassSettings::setProfiles(profiles);
+
+  {
+    ConfigDialog dialog(nullptr);
+    auto *table =
+        dialog.findChild<QTableWidget *>(QStringLiteral("profileTable"));
+    QVERIFY2(table != nullptr, "profileTable widget must exist");
+
+    // Mimic the user sorting by the name column; this makes a later insert
+    // re-sort and move the new row away from its insertion index.
+    table->sortItems(0, Qt::DescendingOrder);
+
+    QVERIFY(QMetaObject::invokeMethod(&dialog, "on_addButton_clicked"));
+
+    const QList<QTableWidgetItem *> selected = table->selectedItems();
+    QVERIFY(!selected.isEmpty());
+    QTableWidgetItem *nameItem = table->item(selected.first()->row(), 0);
+    QVERIFY(nameItem != nullptr);
+    QCOMPARE(nameItem->text(), QStringLiteral("New Profile"));
+  }
+
+  // Restore whatever profile state existed before the test.
+  QtPassSettings::setProfiles(previous);
 }
 
 QTEST_MAIN(tst_configdialog)

--- a/tests/auto/configdialog/tst_configdialog.cpp
+++ b/tests/auto/configdialog/tst_configdialog.cpp
@@ -46,6 +46,7 @@ private Q_SLOTS:
   void setPwgenPathSetsLineEdit();
   void setPwgenPathEmptyDisablesPwgenCheckbox();
   void setAndGetPasswordConfigurationRoundTrip();
+  void customCharsetRoundTrip();
 };
 
 /**
@@ -255,6 +256,26 @@ void tst_configdialog::setAndGetPasswordConfigurationRoundTrip() {
   QCOMPARE(result.length, 32);
   QCOMPARE(static_cast<int>(result.selected),
            static_cast<int>(PasswordConfiguration::ALPHANUMERIC));
+}
+
+/**
+ * @brief A CUSTOM charset survives the set/get round-trip.
+ *
+ * getPasswordConfiguration() only reads the character line edit while CUSTOM is
+ * selected; this guards that path so a user-defined charset is not lost or
+ * replaced by a builtin string on save.
+ */
+void tst_configdialog::customCharsetRoundTrip() {
+  ConfigDialog dialog(nullptr);
+  PasswordConfiguration cfg;
+  cfg.selected = PasswordConfiguration::CUSTOM;
+  cfg.Characters[PasswordConfiguration::CUSTOM] = QStringLiteral("abc123!@#");
+  dialog.setPasswordConfiguration(cfg);
+  PasswordConfiguration result = dialog.getPasswordConfiguration();
+  QCOMPARE(static_cast<int>(result.selected),
+           static_cast<int>(PasswordConfiguration::CUSTOM));
+  QCOMPARE(result.Characters[PasswordConfiguration::CUSTOM],
+           QStringLiteral("abc123!@#"));
 }
 
 QTEST_MAIN(tst_configdialog)

--- a/tests/auto/settings/tst_settings.cpp
+++ b/tests/auto/settings/tst_settings.cpp
@@ -23,6 +23,7 @@ private Q_SLOTS:
   void setAndGetPasswordConfiguration();
   void getProfilesEmpty();
   void setAndGetProfiles();
+  void setProfilesPreservesActiveProfile();
   void setAndGetVersion();
   void setAndGetGeometry();
   void getPassStore();
@@ -168,6 +169,26 @@ void tst_settings::setAndGetProfiles() {
   QVERIFY(!readProfiles.isEmpty());
   QVERIFY(readProfiles.contains("profile1"));
   QCOMPARE(readProfiles["profile1"]["path"], QString("/test/path"));
+}
+
+void tst_settings::setProfilesPreservesActiveProfile() {
+  // The active-profile name (getProfile) is stored under the same "profile"
+  // key that setProfiles() clears before rewriting the profile group.
+  // Regression: setProfiles() used to wipe the scalar, silently switching the
+  // active password store on every config-dialog OK.
+  AppSettings s = QtPassSettings::load();
+  s.activeProfile = QStringLiteral("work");
+  QtPassSettings::save(s);
+  QCOMPARE(QtPassSettings::getProfile(), QStringLiteral("work"));
+
+  QHash<QString, QHash<QString, QString>> profiles;
+  QHash<QString, QString> profile;
+  profile.insert("path", "/store/work");
+  profiles.insert("work", profile);
+  QtPassSettings::setProfiles(profiles);
+
+  QCOMPARE(QtPassSettings::getProfile(), QStringLiteral("work"));
+  QVERIFY(QtPassSettings::getProfiles().contains("work"));
 }
 
 void tst_settings::setAndGetVersion() {


### PR DESCRIPTION
## Summary

Batch 2 of the full `src/` review (see the audit): the config dialog silently overwrote or destroyed persisted settings on a normal **OK** click — no crash needed. This fixes the confirmed data-loss/corruption findings, all in `configdialog.cpp` + `qtpasssettings.cpp`.

## Fixes

**Password-generation settings wiped every OK** (HIGH)
`applySettings()` never loaded the pwgen path or password configuration, so `readSettings()` wrote the `.ui` defaults back over the user's saved length / charset / custom chars / usePwgen. Now restored via `setPwgenPath()` / `setPasswordConfiguration()` before `usePwgen()`.

**Custom charset clobbered** (part of the same finding)
`getPasswordConfiguration()` read the character line edit unconditionally, replacing the saved custom charset with a builtin string when a builtin was selected. Now only reads the line edit while `CUSTOM` is selected; otherwise preserves the persisted custom value.

**Profile table corruption + data loss** (HIGH)
`setProfiles()` populated the table with sorting enabled, so writing the sort column moved rows between `setItem()` calls — path/signing-key cells landed in the wrong profile's row and were destroyed on save (with a randomized `QHash` order, any user with 2+ profiles hit it intermittently). Now disables sorting during population and locates the current row by item pointer.

**Add-profile renames an existing profile** (MED)
`on_addButton_clicked()` re-enabled sorting then read `item(n, 0)`, which after the re-sort could be an existing profile — the edit/selection landed on the wrong row. Now tracks the new item by pointer.

**Null deref on double-click** (MED)
`on_profileTable_cellDoubleClicked()` dereferenced the path cell with no null check.

**OK enabled with empty required fields** (LOW)
`validate()` derived the button state from a single changed item, re-enabling OK while another row still had an empty name — allowing an empty-named profile to be saved and then silently dropped.

**Active profile wiped on save** (HIGH)
`QtPassSettings::setProfiles()` `remove()`d the overloaded `"profile"` key, which also stores the active-profile name (`getProfile`), silently switching the active password store on every save. Now preserves and restores the active-profile scalar.

## Tests

- `tst_settings::setProfilesPreservesActiveProfile` — active profile survives `setProfiles()`.
- `tst_configdialog::customCharsetRoundTrip` — CUSTOM charset survives set/get.
- Full suite: 22 binaries, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored saved pwgen path and password-generation settings when reopening the configuration dialog.
  * Improved profile-table behavior with sorting—new profiles are selected correctly after insertion and loaded for the right profile.
  * Made required-field validation more consistent, including OK button enablement across the whole table.
  * Prevented issues when double-clicking empty profile directory cells.
  * Preserved custom password character sets correctly when switching between custom and built-in options.
  * Ensured the active profile remains unchanged when updating saved profile settings.
* **Tests**
  * Added Qt coverage for custom charset round-trips and for adding/selecting new profiles when the table is sorted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->