### PR TITLE
fix: correct ImitatePass git re-encryption recipients, CWD, and broken copy

### DIFF
--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -920,14 +920,19 @@ void ImitatePass::Copy(const QString src, const QString dest,
                        const bool force) {
   QFileInfo destFileInfo(dest);
   transactionHelper trans(this, PASS_COPY);
-  QDir qDir;
   if (force) {
-    qDir.remove(dest);
+    QFile::remove(dest);
   }
   // git has no "cp" subcommand, so copy on the filesystem in both modes and,
   // when using git, stage the new path afterwards. QFile::copy is synchronous,
-  // so the destination exists before the re-encryption below runs.
-  QFile::copy(src, dest);
+  // so the destination exists before the re-encryption below runs. It fails
+  // (without overwriting) when dest already exists, so surface that instead of
+  // committing a copy that never happened.
+  if (!QFile::copy(src, dest)) {
+    emit critical(tr("Copy failed"),
+                  tr("Could not copy %1 to %2.").arg(src, dest));
+    return;
+  }
   if (m_settings.useGit) {
     executeGit(GIT_COPY, {"add", pgit(dest)});
     QString message = QString("Copied from %1 to %2 using QtPass.");

--- a/src/imitatepass.cpp
+++ b/src/imitatepass.cpp
@@ -476,15 +476,18 @@ auto ImitatePass::verifyGpgIdForDir(const QString &file,
                                     QStringList &gpgIdFilesVerified,
                                     QStringList &gpgId) -> bool {
   QString gpgIdPath = Pass::getGpgIdPath(file, m_settings.passStore);
-  if (gpgIdFilesVerified.contains(gpgIdPath)) {
-    return true;
+  // Verify each .gpg-id signature only once, but always refresh the recipient
+  // list for the current file: a cache hit means the signature was already
+  // checked, not that gpgId still holds this directory's recipients — it may
+  // carry a different directory's list, which would re-encrypt to wrong keys.
+  if (!gpgIdFilesVerified.contains(gpgIdPath)) {
+    if (!verifyGpgIdFile(gpgIdPath)) {
+      emit critical(tr("Check .gpg-id file signature!"),
+                    tr("Signature for %1 is invalid.").arg(gpgIdPath));
+      return false;
+    }
+    gpgIdFilesVerified.append(gpgIdPath);
   }
-  if (!verifyGpgIdFile(gpgIdPath)) {
-    emit critical(tr("Check .gpg-id file signature!"),
-                  tr("Signature for %1 is invalid.").arg(gpgIdPath));
-    return false;
-  }
-  gpgIdFilesVerified.append(gpgIdPath);
   gpgId = getRecipientList(file, m_settings.passStore);
   gpgId.sort();
   return true;
@@ -645,12 +648,15 @@ auto ImitatePass::reencryptSingleFile(const QString &fileName,
   QFile::remove(backupPath);
 
   if (!m_settings.useWebDav && m_settings.useGit) {
+    // -C the store so git runs there rather than in QtPass's launch directory
+    // (executeBlocking sets no working directory).
+    const QString store = pgit(m_settings.passStore);
     Executor::executeBlocking(m_settings.gitExecutable,
-                              {"add", pgit(fileName)});
+                              {"-C", store, "add", pgit(fileName)});
     QString path = QDir(m_settings.passStore).relativeFilePath(fileName);
     path.replace(Util::endsWithGpg(), "");
     Executor::executeBlocking(m_settings.gitExecutable,
-                              {"commit", pgit(fileName), "-m",
+                              {"-C", store, "commit", pgit(fileName), "-m",
                                "Re-encrypt for " + path + " using QtPass."});
   }
 
@@ -667,18 +673,22 @@ auto ImitatePass::createBackupCommit() -> bool {
   }
   emit statusMsg(tr("Creating backup commit"), 2000);
   const QString git = m_settings.gitExecutable;
+  // Run git in the password store: executeBlocking does not set a working
+  // directory, so without -C these commands would run in QtPass's launch
+  // directory and either fail or operate on an unrelated repository.
+  const QString store = pgit(m_settings.passStore);
   QString statusOut;
-  if (Executor::executeBlocking(git, {"status", "--porcelain"}, &statusOut) !=
-      0) {
+  if (Executor::executeBlocking(git, {"-C", store, "status", "--porcelain"},
+                                &statusOut) != 0) {
     emit critical(
         tr("Backup commit failed"),
         tr("Could not inspect git status. Re-encryption was aborted."));
     return false;
   }
   if (!statusOut.trimmed().isEmpty()) {
-    if (Executor::executeBlocking(git, {"add", "-A"}) != 0 ||
-        Executor::executeBlocking(
-            git, {"commit", "-m", "Backup before re-encryption"}) != 0) {
+    if (Executor::executeBlocking(git, {"-C", store, "add", "-A"}) != 0 ||
+        Executor::executeBlocking(git, {"-C", store, "commit", "-m",
+                                        "Backup before re-encryption"}) != 0) {
       emit critical(tr("Backup commit failed"),
                     tr("Re-encryption was aborted because a git backup could "
                        "not be created."));
@@ -910,25 +920,19 @@ void ImitatePass::Copy(const QString src, const QString dest,
                        const bool force) {
   QFileInfo destFileInfo(dest);
   transactionHelper trans(this, PASS_COPY);
+  QDir qDir;
+  if (force) {
+    qDir.remove(dest);
+  }
+  // git has no "cp" subcommand, so copy on the filesystem in both modes and,
+  // when using git, stage the new path afterwards. QFile::copy is synchronous,
+  // so the destination exists before the re-encryption below runs.
+  QFile::copy(src, dest);
   if (m_settings.useGit) {
-    QStringList args;
-    args << "cp";
-    if (force) {
-      args << "-f";
-    }
-    args << pgit(src);
-    args << pgit(dest);
-    executeGit(GIT_COPY, args);
-
+    executeGit(GIT_COPY, {"add", pgit(dest)});
     QString message = QString("Copied from %1 to %2 using QtPass.");
     message = message.arg(src, dest);
     gitCommit("", message);
-  } else {
-    QDir qDir;
-    if (force) {
-      qDir.remove(dest);
-    }
-    QFile::copy(src, dest);
   }
   // reecrypt all files under the new folder
   if (destFileInfo.isDir()) {

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -205,6 +205,32 @@ class tst_integration : public QObject {
     return true;
   }
 
+  // Initialize a git repo with local identity and disabled commit signing so
+  // ImitatePass git operations succeed in tests. Returns true on success.
+  static auto initGitRepo(const QString &storePath, const QString &gitExe)
+      -> bool {
+    QProcess gitInit;
+    gitInit.setWorkingDirectory(storePath);
+    gitInit.start(gitExe, {"init"});
+    if (!gitInit.waitForFinished() || gitInit.exitCode() != 0) {
+      return false;
+    }
+    QProcess cfgName;
+    cfgName.setWorkingDirectory(storePath);
+    if (!runGitConfig(cfgName, gitExe, {"config", "user.name", "Test User"})) {
+      return false;
+    }
+    QProcess cfgEmail;
+    cfgEmail.setWorkingDirectory(storePath);
+    if (!runGitConfig(cfgEmail, gitExe,
+                      {"config", "user.email", "test@example.com"})) {
+      return false;
+    }
+    QProcess cfgSign;
+    cfgSign.setWorkingDirectory(storePath);
+    return runGitConfig(cfgSign, gitExe, {"config", "commit.gpgsign", "false"});
+  }
+
 private Q_SLOTS:
   void initTestCase();
   void cleanupTestCase();
@@ -665,36 +691,8 @@ void tst_integration::imitatePass_gitInitAndCommit() {
   ImitatePass pass;
   INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
-  QProcess gitInit;
-  gitInit.setWorkingDirectory(storeDir.path());
-  gitInit.start(gitExe, {"init"});
-  QVERIFY2(gitInit.waitForFinished(), "git init should complete");
-  QVERIFY2(gitInit.exitCode() == 0, "git init should succeed");
-
-  // Configure local git identity so ImitatePass commits succeed
-  QProcess gitConfig;
-  gitConfig.setWorkingDirectory(storeDir.path());
-  QVERIFY2(
-      runGitConfig(gitConfig, gitExe, {"config", "user.name", "Test User"}),
-      qPrintable(
-          QString("git config user.name failed: %1")
-              .arg(QString::fromUtf8(gitConfig.readAllStandardError()))));
-
-  QProcess gitConfigEmail;
-  gitConfigEmail.setWorkingDirectory(storeDir.path());
-  QVERIFY2(runGitConfig(gitConfigEmail, gitExe,
-                        {"config", "user.email", "test@example.com"}),
-           qPrintable(QString("git config user.email failed: %1")
-                          .arg(QString::fromUtf8(
-                              gitConfigEmail.readAllStandardError()))));
-
-  QProcess gitConfigSign;
-  gitConfigSign.setWorkingDirectory(storeDir.path());
-  QVERIFY2(runGitConfig(gitConfigSign, gitExe,
-                        {"config", "commit.gpgsign", "false"}),
-           qPrintable(QString("git config commit.gpgsign failed: %1")
-                          .arg(QString::fromUtf8(
-                              gitConfigSign.readAllStandardError()))));
+  QVERIFY2(initGitRepo(storeDir.path(), gitExe),
+           "git repo setup (init + identity/signing config) should succeed");
 
   const QString entryName = QStringLiteral("gitentry");
   const QString entryContent = QStringLiteral("secret\nurl: example.com\n");
@@ -733,22 +731,8 @@ void tst_integration::imitatePass_gitCopyAndShow() {
   ImitatePass pass;
   INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
 
-  QProcess gitInit;
-  gitInit.setWorkingDirectory(storeDir.path());
-  gitInit.start(gitExe, {"init"});
-  QVERIFY2(gitInit.waitForFinished(), "git init should complete");
-  QVERIFY2(gitInit.exitCode() == 0, "git init should succeed");
-
-  QProcess cfgName;
-  cfgName.setWorkingDirectory(storeDir.path());
-  QVERIFY(runGitConfig(cfgName, gitExe, {"config", "user.name", "Test User"}));
-  QProcess cfgEmail;
-  cfgEmail.setWorkingDirectory(storeDir.path());
-  QVERIFY(runGitConfig(cfgEmail, gitExe,
-                       {"config", "user.email", "test@example.com"}));
-  QProcess cfgSign;
-  cfgSign.setWorkingDirectory(storeDir.path());
-  QVERIFY(runGitConfig(cfgSign, gitExe, {"config", "commit.gpgsign", "false"}));
+  QVERIFY2(initGitRepo(storeDir.path(), gitExe),
+           "git repo setup should succeed");
 
   QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
   QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
@@ -771,6 +755,21 @@ void tst_integration::imitatePass_gitCopyAndShow() {
   QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted after copy");
   QVERIFY2(showSpy[0][0].toString().contains("copyme"),
            "decrypted git-mode copy should contain the original content");
+
+  // Confirm the copy was staged/committed into the repository, not just written
+  // to disk — a git command run in the wrong directory would leave it
+  // untracked. (The copy's re-encryption commit is synchronous, so by now the
+  // file is in the repo; the async "Copied" commit message may not have landed
+  // yet, hence checking tracked state rather than a specific commit subject.)
+  QProcess gitLs;
+  gitLs.setWorkingDirectory(storeDir.path());
+  gitLs.start(gitExe, {"ls-files"});
+  QVERIFY2(gitLs.waitForFinished(), "git ls-files should complete");
+  const QString tracked = QString::fromUtf8(gitLs.readAll());
+  QVERIFY2(
+      tracked.contains("copy.gpg"),
+      qPrintable(
+          QString("copied entry should be tracked in git: %1").arg(tracked)));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -223,6 +223,7 @@ private Q_SLOTS:
   void imitatePass_specialCharactersInPassword();
   void imitatePass_emptyPassword();
   void imitatePass_gitInitAndCommit();
+  void imitatePass_gitCopyAndShow();
 
   // UTF-8 and unicode handling
   void imitatePass_utf8Characters();
@@ -713,6 +714,63 @@ void tst_integration::imitatePass_gitInitAndCommit() {
   QVERIFY2(commitMsg.contains("gitentry"),
            qPrintable(QString("commit message should mention gitentry: %1")
                           .arg(commitMsg)));
+}
+
+void tst_integration::imitatePass_gitCopyAndShow() {
+  const QString gitExe = QStandardPaths::findExecutable("git");
+  if (gitExe.isEmpty())
+    QSKIP("git not installed – skipping Git copy test");
+
+  RestoreUseGit restoreUseGit;
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gitExecutable = gitExe;
+    s.useGit = true;
+    QtPassSettings::save(s);
+  }
+
+  QTemporaryDir storeDir;
+  ImitatePass pass;
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
+
+  QProcess gitInit;
+  gitInit.setWorkingDirectory(storeDir.path());
+  gitInit.start(gitExe, {"init"});
+  QVERIFY2(gitInit.waitForFinished(), "git init should complete");
+  QVERIFY2(gitInit.exitCode() == 0, "git init should succeed");
+
+  QProcess cfgName;
+  cfgName.setWorkingDirectory(storeDir.path());
+  QVERIFY(runGitConfig(cfgName, gitExe, {"config", "user.name", "Test User"}));
+  QProcess cfgEmail;
+  cfgEmail.setWorkingDirectory(storeDir.path());
+  QVERIFY(runGitConfig(cfgEmail, gitExe,
+                       {"config", "user.email", "test@example.com"}));
+  QProcess cfgSign;
+  cfgSign.setWorkingDirectory(storeDir.path());
+  QVERIFY(runGitConfig(cfgSign, gitExe, {"config", "commit.gpgsign", "false"}));
+
+  QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+  QSignalSpy insertErrorSpy(&pass, &Pass::processErrorExit);
+  pass.Insert(QStringLiteral("original"), QStringLiteral("copyme\n"), false);
+  QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(insertErrorSpy));
+
+  const QString src = QDir::cleanPath(storeDir.path() + "/original.gpg");
+  const QString dst = QDir::cleanPath(storeDir.path() + "/copy.gpg");
+  QVERIFY2(QFile::exists(src), "source must exist before copy");
+
+  // Regression: git-mode Copy used a non-existent `git cp` subcommand, so the
+  // destination was silently never created. It must now produce a decryptable
+  // copy.
+  pass.Copy(src, dst, false);
+  QVERIFY2(QFile::exists(src), "source should still exist after copy");
+  QVERIFY2(QFile::exists(dst), "destination should exist after git-mode copy");
+
+  QSignalSpy showSpy(&pass, &Pass::finishedShow);
+  pass.Show(QStringLiteral("copy"));
+  QVERIFY2(waitForSignal(showSpy), "finishedShow not emitted after copy");
+  QVERIFY2(showSpy[0][0].toString().contains("copyme"),
+           "decrypted git-mode copy should contain the original content");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Batch 3 of the full `src/` review — three defects in the `ImitatePass` git/gpg re-encryption path (native `gpg2`/`git` mode, no `pass` CLI).

## Fixes

### 1. Re-encryption to the wrong recipients (`verifyGpgIdForDir`)
On a `.gpg-id` **cache hit** the function returned early **without recomputing `gpgId`**, leaving it set to the previously processed directory's recipient list. When `reencryptPath()` walks into a directory whose `.gpg-id` was already verified, files there could be re-encrypted to the **wrong keys**. Now the signature is verified once per `.gpg-id`, but the recipient list is always refreshed for the current file.

### 2. git commands run in the wrong directory (`createBackupCommit`, `reencryptSingleFile`)
Both used `Executor::executeBlocking()`, which sets **no working directory**, so `git status` / `git add` / `git commit` ran in QtPass's **launch directory** rather than the store. Depending on where QtPass was started this either aborted all re-encryption (`fatal: not a git repository`) or operated on an **unrelated repository**. Fixed with `git -C <store>`.

### 3. Broken git-mode copy (`Copy`)
Git mode invoked `git cp`, which is **not a git subcommand**, so drag-and-drop copy silently produced nothing (and the follow-up re-encryption ran against a destination that never existed). Copy now does a filesystem copy (synchronous, so the destination exists before re-encryption) and stages the new path with `git add`.

## Test

`tst_integration::imitatePass_gitCopyAndShow` sets up a real git store, copies an entry in git mode, and verifies the destination exists and decrypts to the original content. Confirmed to fail without the copy fix (`QFile::exists(dst)` is false — `git cp` created nothing).

Full suite: 22 integration tests pass, all unit suites green, zero doxygen warnings.

## Deferred to follow-ups
- **Move** does not re-encrypt for the destination folder's `.gpg-id` (unlike `pass mv` / `Copy`) — the git path uses async `git mv`, so re-encryption needs completion ordering.
- The `actualKeys != gpgId` comparison compares 16-char key IDs against raw `.gpg-id` entries (often fingerprints/emails), so the "skip already-correct files" optimization never matches — a performance issue, not a correctness one.

Related: #1598 (keygen error handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `.gpg-id` verification caching to ensure signature checks aren’t incorrectly reused across directories, while recipients continue to refresh as expected.
  * Improved Git-backed operations so staging/committing (re-encryption, backup commits) execute in the password-store repo and use porcelain status checks to determine when to commit.
  * Updated Git-mode copy to always write the encrypted result to disk first, then stage and commit it.

* **Tests**
  * Added a regression integration test covering Git-mode copy and confirming the copied file is tracked and can be shown/decrypted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->