### PR TITLE
fix: prevent PasswordDialog content duplication and premature-save data loss

### DIFF
--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -116,11 +116,15 @@ void PasswordDialog::on_createPasswordButton_clicked() {
  * @brief PasswordDialog::on_accepted handle Ok click for QDialog
  */
 void PasswordDialog::on_accepted() {
-  QString newValue = getPassword();
-  if (newValue.isEmpty()) {
+  // For an existing entry, refuse to save until its decrypted content has
+  // loaded (Show is asynchronous). getPassword() always returns at least a
+  // newline, so the previous isEmpty() check never fired and clicking OK early
+  // overwrote the entry with the empty dialog fields.
+  if (!m_isNew && !m_contentLoaded) {
     return;
   }
 
+  QString newValue = getPassword();
   if (newValue.right(1) != "\n") {
     newValue += "\n";
   }
@@ -167,7 +171,10 @@ void PasswordDialog::setPassword(const QString &password) {
     previous = line;
   }
 
-  ui->plainTextEdit->insertPlainText(fileContent.getRemainingData());
+  // setPlainText (not insertPlainText) so re-populating replaces the body
+  // instead of appending a second copy, which would be saved back as
+  // duplicated content.
+  ui->plainTextEdit->setPlainText(fileContent.getRemainingData());
 }
 
 /**
@@ -315,5 +322,9 @@ void PasswordDialog::cycleTemplate() {
  */
 void PasswordDialog::setPass(const QString &output) {
   setPassword(output);
-  // UI is enabled by default when password is set - no additional action needed
+  m_contentLoaded = true;
+  // Only the first Show result — the one for this dialog's entry — is ours.
+  // Stop listening so a later Show of a different entry (finishedShow is a
+  // shared Pass signal) cannot overwrite or duplicate these fields.
+  disconnect(m_pass, &Pass::finishedShow, this, &PasswordDialog::setPass);
 }

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -321,10 +321,12 @@ void PasswordDialog::cycleTemplate() {
  * @param output Output from pass show command
  */
 void PasswordDialog::setPass(const QString &output) {
+  // setPassword() replaces (not appends) every field, so if more than one
+  // finishedShow arrives the last one wins rather than duplicating content.
+  // We deliberately keep listening: the dialog is modal and always edits the
+  // selected entry, so its own Show is the result that matters, and we cannot
+  // safely disconnect on the first signal because finishedShow carries no
+  // request identity — a stale queued Show could otherwise be consumed as ours.
   setPassword(output);
   m_contentLoaded = true;
-  // Only the first Show result — the one for this dialog's entry — is ours.
-  // Stop listening so a later Show of a different entry (finishedShow is a
-  // shared Pass signal) cannot overwrite or duplicate these fields.
-  disconnect(m_pass, &Pass::finishedShow, this, &PasswordDialog::setPass);
 }

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -118,6 +118,10 @@ private:
   QString m_file;
   bool m_templating{};
   bool m_isNew{};
+  /// True once the existing entry's decrypted content has been loaded, so
+  /// on_accepted() can refuse to overwrite it with empty fields before the
+  /// asynchronous Show completes.
+  bool m_contentLoaded{};
   QList<QLineEdit *> m_templateLines;
   QList<QLineEdit *> m_otherLines;
   QHash<QString, QStringList> m_availableTemplates;


### PR DESCRIPTION
## Summary

Two data-integrity bugs in `PasswordDialog` when editing an existing entry (from the full `src/` review).

### 1. Free-text body duplicated on save
`setPassword()` filled the body with `insertPlainText()`, which **appends**. `PasswordDialog` connects to the shared `Pass::finishedShow` signal, so if more than one result arrives (e.g. a stale queued `Show`), the body got a second copy appended and `getPassword()` wrote the **duplicated** content back, corrupting the file.

Fix: use `setPlainText()` so every field is **replaced** (last result wins, no duplication). The dialog deliberately keeps listening — it is modal (`d.exec()`) and always edits the selected entry, and `finishedShow` carries no request identity, so disconnecting on the first signal could consume a stale queued result and never load this dialog's own entry.

### 2. Premature save wipes the entry
`on_accepted()` guarded with `if (newValue.isEmpty()) return;`, but `getPassword()` always returns at least a trailing newline, so the guard was **dead code**. Clicking **OK before the asynchronous `Show()` finished decrypting** overwrote the existing entry with the empty dialog fields — silent data loss.

Fix: track an `m_contentLoaded` flag (set when the entry's decrypted content arrives) and refuse to save an existing entry until it has loaded. New entries are unaffected.

## Testing
No `PasswordDialog` unit-test harness exists, and constructing one needs a live `Pass` singleton plus async `Show` mocking (and dialog + offscreen teardown is fragile on Qt 5.15). Verified by construction and by the related suites (ui/filecontent/model/passwordconfig) staying green; zero doxygen warnings.

## Scope
First of the review's "misc HIGH" batch. Deferred pending per-caller analysis:
- `realpass.cpp:162` — the no-force overwrite guard: the drag-drop caller passes real `.gpg` paths and already confirms overwrite in the UI, so the guard works for that path; needs checking for any caller that passes a non-`.gpg` dest.
- `qtpass.cpp:419` (clipboard autoclear after navigation) and `pass.cpp:109` (transaction bookkeeping when a command is discarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed saving of existing password entries so it won’t occur until decrypted details have finished loading.
  * Prevented duplicated or accumulated dialog text when repopulating the password dialog.
  * Improved handling of displayed entry contents to avoid showing or overwriting with stale/incorrect information during rapid item changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->