### PR TITLE
fix: check process start for stdin-less commands so the Executor queue can't stall

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -69,52 +69,56 @@ void Executor::startProcessBlocking(QProcess &internal, const QString &app,
  * @brief Executor::executeNext consumes executable tasks from the queue
  */
 void Executor::executeNext() {
-  if (!running) {
-    if (!m_execQueue.isEmpty()) {
-      const execQueueItem &i = m_execQueue.head();
-      running = true;
-      if (!i.workingDir.isEmpty()) {
-        m_process.setWorkingDirectory(i.workingDir);
-      }
-      startProcess(i.app, i.args);
-      if (!i.input.isEmpty()) {
-        if (!m_process.waitForStarted(-1)) {
+  if (running || m_execQueue.isEmpty()) {
+    return;
+  }
+  const execQueueItem &i = m_execQueue.head();
+  running = true;
+  if (!i.workingDir.isEmpty()) {
+    m_process.setWorkingDirectory(i.workingDir);
+  }
+  startProcess(i.app, i.args);
+
+  // Confirm the process actually started, regardless of whether it takes stdin.
+  // A process that fails to start emits errorOccurred(FailedToStart) but never
+  // finished(), so without this check `running` would stay true forever and
+  // stall the whole queue (and, for stdin commands, the input would be dropped
+  // silently). Surface the failure so callers waiting on a finished/error
+  // signal (e.g. the GPG keygen dialog) do not hang. Defer the emit via a
+  // queued call so we do not re-enter a caller still on the stack —
+  // KeygenDialog::done() drives key generation synchronously — which mirrors
+  // the normal asynchronous QProcess::finished path. A -1 exit code routes
+  // through Pass::finished's non-zero error gate.
+  if (!m_process.waitForStarted(-1)) {
 #ifdef QT_DEBUG
-          dbg() << "Process failed to start:" << i.id << " " << i.app;
+    dbg() << "Process failed to start:" << i.id << " " << i.app;
 #endif
-          // Capture before dequeue() invalidates the head reference.
-          const int failedId = i.id;
-          const QString failedApp = i.app;
-          m_process.closeWriteChannel();
-          running = false;
-          m_execQueue.dequeue();
-          // Surface the failure instead of silently dropping the command:
-          // otherwise callers waiting on a finished/error signal (e.g. the GPG
-          // keygen dialog) hang forever with no feedback. Defer the emit via a
-          // queued call so we do not re-enter a caller still on the stack —
-          // KeygenDialog::done() drives key generation synchronously — which
-          // mirrors the normal asynchronous QProcess::finished path. A -1 exit
-          // code routes through Pass::finished's non-zero error gate.
-          QMetaObject::invokeMethod(
-              this,
-              [this, failedId, failedApp]() {
-                emit error(failedId, -1, QString(),
-                           tr("Failed to start %1").arg(failedApp));
-              },
-              Qt::QueuedConnection);
-          executeNext();
-          return;
-        }
-        QByteArray data = i.input.toUtf8();
-        if (m_process.write(data) != data.length()) {
+    // Capture before dequeue() invalidates the head reference.
+    const int failedId = i.id;
+    const QString failedApp = i.app;
+    m_process.closeWriteChannel();
+    running = false;
+    m_execQueue.dequeue();
+    QMetaObject::invokeMethod(
+        this,
+        [this, failedId, failedApp]() {
+          emit error(failedId, -1, QString(),
+                     tr("Failed to start %1").arg(failedApp));
+        },
+        Qt::QueuedConnection);
+    executeNext();
+    return;
+  }
+
+  if (!i.input.isEmpty()) {
+    QByteArray data = i.input.toUtf8();
+    if (m_process.write(data) != data.length()) {
 #ifdef QT_DEBUG
-          dbg() << "Not all data written to process:" << i.id << " " << i.app;
+      dbg() << "Not all data written to process:" << i.id << " " << i.app;
 #endif
-        }
-      }
-      m_process.closeWriteChannel();
     }
   }
+  m_process.closeWriteChannel();
 }
 
 /**

--- a/tests/auto/executor/tst_executor.cpp
+++ b/tests/auto/executor/tst_executor.cpp
@@ -34,6 +34,7 @@ private Q_SLOTS:
   void executeAsyncMultipleSequential();
   void executeAsyncWithWorkDir();
   void executeAsyncFailedToStartEmitsError();
+  void executeAsyncFailedToStartNoInputDoesNotStall();
   void executeAsyncCrashExitReportsNonZeroCode();
   void cancelNextWhileRunningReturnsMinusOne();
 #endif
@@ -403,6 +404,39 @@ void tst_executor::executeAsyncFailedToStartEmitsError() {
   QCOMPARE(errorSpy.first().at(0).toInt(), 1);
   QVERIFY2(errorSpy.first().at(1).toInt() != 0,
            "a failed-to-start process must report a non-zero exit code");
+}
+
+void tst_executor::executeAsyncFailedToStartNoInputDoesNotStall() {
+  // A command WITHOUT stdin that fails to start used to leave `running` true
+  // forever: QProcess emits errorOccurred(FailedToStart) but never finished(),
+  // and the no-input path skipped waitForStarted(), so the whole queue stalled.
+  // It must now surface an error and let queued commands proceed.
+  const QString sh = QStandardPaths::findExecutable("sh");
+  if (sh.isEmpty())
+    QSKIP("sh not found in PATH");
+  Executor exec;
+  QSignalSpy errorSpy(&exec, &Executor::error);
+  QSignalSpy finishedSpy(&exec,
+                         qOverload<int, int, const QString &, const QString &>(
+                             &Executor::finished));
+  QVERIFY2(errorSpy.isValid(), "spy must connect to Executor::error signal");
+  QVERIFY2(finishedSpy.isValid(),
+           "spy must connect to Executor::finished signal");
+
+  // No input -> the path that previously skipped the start check and stalled.
+  exec.execute(1, "/nonexistent/definitely-not-a-real-binary", {"status"},
+               false, false);
+  // A valid command queued behind the failure must still run.
+  exec.execute(2, sh, {"-c", "echo after-failure"}, true, false);
+
+  QTRY_COMPARE_WITH_TIMEOUT(errorSpy.count(), 1, 5000);
+  QCOMPARE(errorSpy.first().at(0).toInt(), 1);
+  QVERIFY2(errorSpy.first().at(1).toInt() != 0,
+           "failed-to-start must report a non-zero exit code");
+
+  // The queue did not stall: the second command completed.
+  QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 5000);
+  QCOMPARE(finishedSpy.first().at(0).toInt(), 2);
 }
 
 void tst_executor::executeAsyncCrashExitReportsNonZeroCode() {


### PR DESCRIPTION
## Summary

From the full `src/` review — a HIGH-severity queue stall in `Executor`.

## The bug

`Executor::executeNext()` only called `waitForStarted()` for commands that carry stdin input:

```cpp
startProcess(i.app, i.args);
if (!i.input.isEmpty()) {
  if (!m_process.waitForStarted(-1)) { /* handle failure */ }
  ...write input...
}
```

A command **without** stdin — which is most `git` / `gpg` / `pass` invocations — that fails to start (missing binary, bad path, permissions) emits `QProcess::errorOccurred(FailedToStart)` but **never** `finished()`. The Executor advances its FIFO queue from the `finished` handler (which clears `running`), so that handler never ran: `running` stayed `true` forever and **the entire queue stalled**, freezing all subsequent password-store operations with no user feedback.

(The stdin case was already handled — see #1598.)

## The fix

Run the start check for **every** command regardless of stdin. On failure, emit an error (deferred via a queued call so we don't re-enter a caller still on the stack), dequeue, clear `running`, and continue to the next item. The stdin-write path is unchanged.

## Test

`tst_executor::executeAsyncFailedToStartNoInputDoesNotStall` queues a failing no-input command followed by a valid one and asserts the error is surfaced **and** the second command still completes. Verified to fail without the fix (the second command never runs — the queue stalls until the test times out).

Full executor suite (35) and integration suite (22) pass; zero doxygen warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a queued command that failed to start could leave the executor stuck and prevent later tasks from running.
  * Improved handling of failed process starts so the queue continues processing remaining items.
  * Ensured process input is handled consistently and the write channel is closed after each attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->