### PR TITLE
fix: keep clipboard autoclear tracking when navigating between entries

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -574,8 +574,6 @@ void MainWindow::on_treeView_clicked(const QModelIndex &index) {
   bool cleared = ui->treeView->currentIndex().flags() == Qt::NoItemFlags;
   m_currentDir = Util::getDir(ui->treeView->currentIndex(), false, model,
                               proxyModel, QtPassSettings::getPassStore());
-  // Clear any previously cached clipped text before showing new password
-  m_qtPass->clearClippedText();
   QString file = getFile(index, true);
   ui->passwordName->setText(file);
   if (!file.isEmpty() && !cleared) {

--- a/src/qtpass.cpp
+++ b/src/qtpass.cpp
@@ -415,17 +415,16 @@ void QtPass::doGitPush() {
  */
 void QtPass::setClippedText(const QString &password, const QString &p_output) {
   const AppSettings s = QtPassSettings::load();
-  if (s.clipBoardType != Enums::CLIPBOARD_NEVER && !p_output.isEmpty()) {
-    clippedText = password;
-    if (s.clipBoardType == Enums::CLIPBOARD_ALWAYS) {
-      copyTextToClipboard(password);
-    }
+  // Only "always copy" mode actually places text on the clipboard here; in
+  // on-demand mode the copy happens later from the field's copy button.
+  // Crucially, do not touch clippedText otherwise — it tracks what is currently
+  // on the clipboard so the autoclear timer knows what to clear. Overwriting it
+  // when merely showing another entry left a previously copied password on the
+  // clipboard past its autoclear window (copyTextToClipboard sets it).
+  if (s.clipBoardType == Enums::CLIPBOARD_ALWAYS && !p_output.isEmpty()) {
+    copyTextToClipboard(password);
   }
 }
-/**
- * @brief Clears the stored clipped text.
- */
-void QtPass::clearClippedText() { clippedText = ""; }
 
 /**
  * @brief Sets the clipboard clear timer based on autoclear settings.

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -56,10 +56,14 @@ public:
   auto init() -> bool;
 
   /**
-   * @brief Update the tracked clipped text value.
-   * @param text Primary text to store.
-   * @param p_output Optional additional output used when determining the final
-   *        clipped text value.
+   * @brief Handle clipboard copying for a shown entry.
+   *
+   * In "always copy" mode (and only then) this copies @p text to the clipboard
+   * via copyTextToClipboard(), which also arms the autoclear timer and records
+   * the clipboard contents. In other modes it does nothing, leaving any pending
+   * autoclear tracking intact.
+   * @param text Password (or value) of the entry being shown.
+   * @param p_output Full decrypted output; copying is skipped when it is empty.
    */
   void setClippedText(const QString &text, const QString &p_output = QString());
 

--- a/src/qtpass.h
+++ b/src/qtpass.h
@@ -64,11 +64,6 @@ public:
   void setClippedText(const QString &text, const QString &p_output = QString());
 
   /**
-   * @brief Remove any stored clipped text value.
-   */
-  void clearClippedText();
-
-  /**
    * @brief Configure and start the clipboard-clear timer.
    */
   void setClipboardTimer();


### PR DESCRIPTION
## Summary

A HIGH-severity clipboard-security bug from the full `src/` review: a copied password could stay on the clipboard **past its autoclear window** if the user selected another entry before it cleared.

## The bug

`clippedText` records what `copyTextToClipboard()` put on the clipboard, so the autoclear timer can verify and clear it:

```cpp
void QtPass::clearClipboard() {
  ...
  if (this->clippedText == clipboard->text(QClipboard::Clipboard)) {
    clipboard->clear(QClipboard::Clipboard);
    ...
  }
}
```

But two navigation paths overwrote that tracker before the timer fired:
- `setClippedText()` is called on **every** entry show and did `clippedText = password;`
- `clearClippedText()` was called on **every** tree click and did `clippedText = "";`

So: copy password A (timer armed) → click another entry → `clippedText` becomes B's password (or empty) while the clipboard still holds A → the timer sees `clippedText != clipboard` → **does not clear** → A stays on the clipboard indefinitely.

## The fix

The staged value was never consumed anywhere — on-demand copy uses the field's own value via `copyTextToClipboard()` — so `setClippedText`/`clearClippedText` only corrupted the autoclear tracker. Make `clippedText` a pure record of the current clipboard contents:
- `setClippedText()` now only copies in "always copy" mode (through `copyTextToClipboard()`, which sets the tracker) and no longer overwrites it otherwise.
- The vestigial `clearClippedText()` and its per-navigation call are removed.

Now selecting another entry no longer disarms a pending autoclear (always-copy mode simply re-copies and re-arms for the new entry).

## Testing
No `QtPass`-level clipboard test harness exists (needs a QApplication clipboard + timer). Verified by construction and by mainwindow/ui suites staying green; zero doxygen warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard handling: passwords are now only tracked when they are actually copied to the system clipboard, reducing unintended clipboard-related state changes in non-“always copy” modes.
  * Fixed password selection behavior: switching between entries no longer clears any previously stored “clipped text” unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->