### PR TITLE
test: add unit tests for PassBackendFactory backend selection

### DIFF
--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow userinfo profileinit grepsearchcontroller passworddisplaypanel
+SUBDIRS += util ui model settings passwordconfig filecontent simpletransaction gpgkeystate exportpublickeydialog importkeydialog keygendialog trayicon configdialog locale mainwindow userinfo profileinit grepsearchcontroller passworddisplaypanel passbackendfactory
 win32: SUBDIRS -= executor
 !win32: SUBDIRS += executor
 !win32: SUBDIRS += integration

--- a/tests/auto/passbackendfactory/passbackendfactory.pro
+++ b/tests/auto/passbackendfactory/passbackendfactory.pro
@@ -1,0 +1,18 @@
+!include(../auto.pri) { error("Couldn't find the auto.pri file!") }
+
+SOURCES += tst_passbackendfactory.cpp
+
+LIBS = -L"$$OUT_PWD/../../../src/$(OBJECTS_DIR)" -lqtpass $$LIBS
+clang|gcc:PRE_TARGETDEPS += "$$OUT_PWD/../../../src/$(OBJECTS_DIR)/libqtpass.a"
+
+HEADERS   += ../../../src/passbackendfactory.h
+
+OBJ_PATH += ../../../src/$(OBJECTS_DIR)
+
+VPATH += ../../../src
+INCLUDEPATH += ../../../src
+
+win32 {
+    RC_FILE = ../../../windows.rc
+    QMAKE_LINK_OBJECT_MAX = 24
+}

--- a/tests/auto/passbackendfactory/tst_passbackendfactory.cpp
+++ b/tests/auto/passbackendfactory/tst_passbackendfactory.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Anne Jan Brouwer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @brief Unit tests for PassBackendFactory backend selection.
+ *
+ * PassBackendFactory decides whether QtPass talks to the real `pass` CLI
+ * (RealPass) or drives gpg/git directly (ImitatePass), caches the choice, and
+ * exposes invalidate() so a settings change can force a rebuild. These tests
+ * exercise that routing without needing gpg/pass installed — they only check
+ * which backend type is returned and the caching/rebuild lifecycle.
+ */
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include "../../../src/appsettings.h"
+#include "../../../src/imitatepass.h"
+#include "../../../src/passbackendfactory.h"
+#include "../../../src/qtpasssettings.h"
+#include "../../../src/realpass.h"
+
+class tst_passbackendfactory : public QObject {
+  Q_OBJECT
+
+  QTemporaryDir m_storeDir;
+  bool m_savedUsePass{};
+  QString m_savedPassStore;
+
+private Q_SLOTS:
+  void initTestCase();
+  void cleanup();
+  void cleanupTestCase();
+
+  void imitateModeReturnsImitatePass();
+  void passModeReturnsRealPass();
+  void getPassCachesInstance();
+  void switchingModeRebuildsBackend();
+  void createsMissingStoreDirectory();
+};
+
+void tst_passbackendfactory::initTestCase() {
+  QVERIFY2(m_storeDir.isValid(), "temp store dir must be created");
+  const AppSettings s = QtPassSettings::load();
+  m_savedUsePass = s.usePass;
+  m_savedPassStore = QtPassSettings::getPassStore();
+}
+
+void tst_passbackendfactory::cleanup() {
+  // Drop the cached backend so each test starts from a clean selection.
+  PassBackendFactory::invalidate();
+}
+
+void tst_passbackendfactory::cleanupTestCase() {
+  QtPassSettings::setUsePass(m_savedUsePass);
+  QtPassSettings::setPassStore(m_savedPassStore);
+  PassBackendFactory::invalidate();
+}
+
+void tst_passbackendfactory::imitateModeReturnsImitatePass() {
+  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setUsePass(false);
+  PassBackendFactory::invalidate();
+
+  Pass *p = PassBackendFactory::getPass();
+  QVERIFY2(dynamic_cast<ImitatePass *>(p) != nullptr,
+           "usePass=false must yield an ImitatePass backend");
+}
+
+void tst_passbackendfactory::passModeReturnsRealPass() {
+  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setUsePass(true);
+  PassBackendFactory::invalidate();
+
+  Pass *p = PassBackendFactory::getPass();
+  QVERIFY2(dynamic_cast<RealPass *>(p) != nullptr,
+           "usePass=true must yield a RealPass backend");
+}
+
+void tst_passbackendfactory::getPassCachesInstance() {
+  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setUsePass(false);
+  PassBackendFactory::invalidate();
+
+  Pass *first = PassBackendFactory::getPass();
+  Pass *second = PassBackendFactory::getPass();
+  QCOMPARE(first, second);
+}
+
+void tst_passbackendfactory::switchingModeRebuildsBackend() {
+  QtPassSettings::setPassStore(m_storeDir.path());
+  QtPassSettings::setUsePass(false);
+  QVERIFY2(dynamic_cast<ImitatePass *>(PassBackendFactory::getPass()) !=
+               nullptr,
+           "usePass=false yields ImitatePass");
+
+  // setUsePass() invalidates the cached backend, so the next getPass() reflects
+  // the new mode without a manual invalidate().
+  QtPassSettings::setUsePass(true);
+  QVERIFY2(dynamic_cast<RealPass *>(PassBackendFactory::getPass()) != nullptr,
+           "switching to usePass=true rebuilds the backend as RealPass");
+
+  QtPassSettings::setUsePass(false);
+  QVERIFY2(dynamic_cast<ImitatePass *>(PassBackendFactory::getPass()) !=
+               nullptr,
+           "switching back to usePass=false rebuilds as ImitatePass");
+}
+
+void tst_passbackendfactory::createsMissingStoreDirectory() {
+  const QString sub =
+      QDir::cleanPath(m_storeDir.path() + "/newly/created/store");
+  QVERIFY2(!QDir(sub).exists(),
+           "precondition: nested store dir must not exist");
+
+  QtPassSettings::setPassStore(sub);
+  QtPassSettings::setUsePass(false);
+  PassBackendFactory::invalidate();
+  PassBackendFactory::getPass();
+
+  QVERIFY2(QDir(sub).exists(),
+           "getPass() must create the store directory when it is missing");
+}
+
+QTEST_MAIN(tst_passbackendfactory)
+#include "tst_passbackendfactory.moc"


### PR DESCRIPTION
## Summary

`PassBackendFactory` is the core router that decides whether QtPass drives the real `pass` CLI (`RealPass`) or gpg/git directly (`ImitatePass`), caches that choice, and exposes `invalidate()` so a settings change forces a rebuild. It had **no dedicated tests** — this adds a `tst_passbackendfactory` binary.

## Coverage (no gpg/pass needed — pure routing/lifecycle)

- `usePass=false` selects `ImitatePass`; `usePass=true` selects `RealPass`
- `getPass()` caches the instance across calls (same pointer)
- switching `usePass` rebuilds the backend for the new mode — documents that `setUsePass()` calls `PassBackendFactory::invalidate()` (the same invalidation the ConfigDialog profile flow relies on)
- `getPass()` creates the store directory when it does not yet exist

All assertions check the returned backend **type** (`dynamic_cast`) and lifecycle, so the tests run on plain offscreen CI without a keyring.

Runs green locally alongside the full suite; settings are saved/restored around the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage for password and key management flows, including backend selection, configuration changes, and directory creation behavior.
  * Added new test setup to better validate app behavior across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->