### PR TITLE
test: GUI end-to-end — selecting a tree entry decrypts into the panel

### DIFF
--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -1016,13 +1016,27 @@ void tst_integration::mainWindow_selectingEntryShowsDecryptedContent() {
     QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(errSpy));
   }
 
+  // Restore every globally-mutated setting on any exit path (including early
+  // QVERIFY returns): this test changes passStore/usePass/gpgExecutable/
+  // hideContent, all of which live in AppSettings.
+  const AppSettings savedSettings = QtPassSettings::load();
+  struct SettingsRestorer {
+    AppSettings s;
+    ~SettingsRestorer() {
+      QtPassSettings::save(s);
+      PassBackendFactory::invalidate();
+    }
+  } restorer{savedSettings};
+
   // Point QtPassSettings at the store in gpg mode and pre-set the gpg path so
-  // the constructor does not open the blocking config dialog.
+  // the constructor does not open the blocking config dialog. hideContent (not
+  // hidePassword) is what passShowHandler() checks before rendering the panel.
   QtPassSettings::setPassStore(storeDir.path());
   QtPassSettings::setUsePass(false);
   {
     AppSettings s = QtPassSettings::load();
     s.gpgExecutable = m_gpgExe;
+    s.hideContent = false;
     s.hidePassword = false;
     QtPassSettings::save(s);
   }
@@ -1030,6 +1044,8 @@ void tst_integration::mainWindow_selectingEntryShowsDecryptedContent() {
 
   MainWindow w;
   w.show();
+  QVERIFY2(QTest::qWaitForWindowExposed(&w),
+           "MainWindow should become exposed");
 
   auto *tree = w.findChild<QTreeView *>(QStringLiteral("treeView"));
   QVERIFY2(tree != nullptr, "treeView must exist");

--- a/tests/auto/integration/tst_integration.cpp
+++ b/tests/auto/integration/tst_integration.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 
+#include <QAbstractItemModel>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -26,11 +27,15 @@
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
+#include <QTextBrowser>
+#include <QTreeView>
 #include <QtTest>
 
 #include "../../../src/enums.h"
 #include "../../../src/imitatepass.h"
+#include "../../../src/mainwindow.h"
 #include "../../../src/pass.h"
+#include "../../../src/passbackendfactory.h"
 #include "../../../src/qtpasssettings.h"
 #include "../../../src/realpass.h"
 #include "../../../src/userinfo.h"
@@ -301,6 +306,7 @@ private Q_SLOTS:
   void imitatePass_usersDialogListsAndFilters();
   void imitatePass_multiRecipientReencryptChangesRecipients();
   void imitatePass_reencryptPreservesPerFolderRecipients();
+  void mainWindow_selectingEntryShowsDecryptedContent();
 
   // UTF-8 and unicode handling
   void imitatePass_utf8Characters();
@@ -993,6 +999,78 @@ void tst_integration::imitatePass_reencryptPreservesPerFolderRecipients() {
       teamIds.contains(sub2) && !teamIds.contains(sub1),
       qPrintable(QStringLiteral("team entry must target key2 only, got: %1")
                      .arg(teamIds.join(','))));
+}
+
+void tst_integration::mainWindow_selectingEntryShowsDecryptedContent() {
+  // Full GUI end-to-end: build a store with one real entry, construct the
+  // MainWindow over it, click the entry in the tree, and verify the panel shows
+  // the decrypted content — driving the real UI through real gpg.
+  QTemporaryDir storeDir;
+  ImitatePass pass;
+  INIT_IMITATE_STORE_OR_FAIL(storeDir, pass);
+  {
+    QSignalSpy insertSpy(&pass, &Pass::finishedInsert);
+    QSignalSpy errSpy(&pass, &Pass::processErrorExit);
+    pass.Insert(QStringLiteral("guitest"),
+                QStringLiteral("topsecret\nurl: gui.example.com\n"), false);
+    QVERIFY2(waitForSignal(insertSpy), gpgInsertErrorMsg(errSpy));
+  }
+
+  // Point QtPassSettings at the store in gpg mode and pre-set the gpg path so
+  // the constructor does not open the blocking config dialog.
+  QtPassSettings::setPassStore(storeDir.path());
+  QtPassSettings::setUsePass(false);
+  {
+    AppSettings s = QtPassSettings::load();
+    s.gpgExecutable = m_gpgExe;
+    s.hidePassword = false;
+    QtPassSettings::save(s);
+  }
+  PassBackendFactory::invalidate();
+
+  MainWindow w;
+  w.show();
+
+  auto *tree = w.findChild<QTreeView *>(QStringLiteral("treeView"));
+  QVERIFY2(tree != nullptr, "treeView must exist");
+
+  // QFileSystemModel loads asynchronously; wait until our entry appears, then
+  // capture its index.
+  QModelIndex entryIdx;
+  auto findEntry = [&]() -> bool {
+    QAbstractItemModel *m = tree->model();
+    const QModelIndex root = tree->rootIndex();
+    for (int r = 0; r < m->rowCount(root); ++r) {
+      const QModelIndex idx = m->index(r, 0, root);
+      if (m->data(idx).toString() == QStringLiteral("guitest")) {
+        entryIdx = idx;
+        return true;
+      }
+    }
+    return false;
+  };
+  QTRY_VERIFY_WITH_TIMEOUT(findEntry(), 10000);
+  QVERIFY(entryIdx.isValid());
+
+  // Click the entry in the tree.
+  tree->scrollTo(entryIdx);
+  const QRect rect = tree->visualRect(entryIdx);
+  QVERIFY2(rect.isValid() && !rect.isEmpty(), "entry must have a visible rect");
+  QTest::mouseClick(tree->viewport(), Qt::LeftButton, Qt::NoModifier,
+                    rect.center());
+
+  // The decrypted "url" field should render in the display panel (a
+  // QTextBrowser); the show is asynchronous so poll for it.
+  auto panelHasUrl = [&]() -> bool {
+    const auto browsers = w.findChildren<QTextBrowser *>();
+    for (auto *b : browsers) {
+      if (b->toPlainText().contains(QStringLiteral("gui.example.com"))) {
+        return true;
+      }
+    }
+    return false;
+  };
+  QTRY_VERIFY_WITH_TIMEOUT(panelHasUrl(), 15000);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The **first test that drives the real QtPass GUI** — step 2 of the e2e effort. Everything so far tested backends or constructed widgets in isolation; this one simulates an actual user action through the full stack.

## What it does
1. Inserts a real entry (`guitest` with a `url` field) into a temp store via real gpg.
2. Constructs `MainWindow` over that store (gpg mode, gpg path pre-set so no config dialog).
3. Waits for the asynchronous `QFileSystemModel` to expose the entry in the tree, then captures its index.
4. Clicks it with `QTest::mouseClick` on the tree viewport.
5. Polls (`QTRY_VERIFY_WITH_TIMEOUT`) until the display panel's `QTextBrowser` renders the decrypted field content.

So it exercises the full **tree-click → `Show` → gpg decrypt → panel-render** path.

## Reliability
The two async gaps (model load, decryption) are absorbed by `QTRY_VERIFY_WITH_TIMEOUT`. Verified stable over repeated local runs. Uses the offscreen platform like the other widget tests.

This is the non-modal user flow; modal Add/Edit dialogs (driven via a `QTimer` poker) would be a follow-up if this proves stable on CI.

Integration suite: 26 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end GUI integration coverage for selecting an entry and verifying its decrypted content is displayed correctly.
  * Improved reliability of the integration test by handling asynchronous loading and polling the UI until the expected decrypted value appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->