### PR TITLE
fix(l10n): correct sv/nl translation bugs flagged on #1614

### DIFF
--- a/localization/localization_nl_NL.ts
+++ b/localization/localization_nl_NL.ts
@@ -647,7 +647,7 @@ e-mail</translation>
     <message>
         <location filename="../src/executor.cpp" line="106"/>
         <source>Failed to start %1</source>
-        <translation>Beginnen met %1 mislukt</translation>
+        <translation>Kon %1 niet starten</translation>
     </message>
 </context>
 <context>
@@ -853,7 +853,7 @@ Je kan nieuw toegevoegde wachtwoorden niet uitlezen!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="933"/>
         <source>Could not copy %1 to %2.</source>
-        <translation>Kon %1 niet kopiëren naar % 2.</translation>
+        <translation>Kon %1 niet kopiëren naar %2.</translation>
     </message>
 </context>
 <context>
@@ -1767,7 +1767,7 @@ Doorgaan?</translation>
     <message>
         <location filename="../src/pass.cpp" line="452"/>
         <source>No GPG executable configured</source>
-        <translation>Geen GPG toepassing geconfigureerd</translation>
+        <translation>Geen GPG-programma geconfigureerd</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="557"/>

--- a/localization/localization_sv.ts
+++ b/localization/localization_sv.ts
@@ -811,7 +811,7 @@ Du kommer inte att kunna avkryptera några nyligen tillagda lösenord!</translat
     <message>
         <location filename="../src/imitatepass.cpp" line="932"/>
         <source>Copy failed</source>
-        <translation>Kopering misslyckades</translation>
+        <translation>Kopiering misslyckades</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="933"/>
@@ -1642,7 +1642,7 @@ Fortsätta?</translation>
     <message>
         <location filename="../src/pass.cpp" line="452"/>
         <source>No GPG executable configured</source>
-        <translation>Ingen GPG exekverbar fil konfigurerad</translation>
+        <translation>Ingen körbar GPG-fil har konfigurerats.</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="557"/>


### PR DESCRIPTION
## Summary
- Fixes the 5 translation bugs CodeRabbit flagged on the merged Weblate PR #1614 (translations landed in `main`, so this is a follow-up branch).

## Fixes
**Swedish (`sv`)**
- `Kopering misslyckades` → `Kopiering misslyckades` (typo)
- `No GPG executable configured`: `Ingen GPG exekverbar fil konfigurerad` → `Ingen körbar GPG-fil har konfigurerats.` (natural wording)

**Dutch (`nl_NL`)**
- `Failed to start %1`: `Beginnen met %1 mislukt` → `Kon %1 niet starten` (launch-specific)
- `Could not copy %1 to %2.`: fixed broken Qt placeholder `% 2` → `%2`
- `No GPG executable configured`: `Geen GPG toepassing geconfigureerd` → `Geen GPG-programma geconfigureerd` (executable, not "application")

## Validation
- `lrelease6` on both files: no placeholder-mismatch warnings.
- All 5 findings verified still present in current `main` before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved Dutch translations for executor, copy, and GPG configuration messages.
  * Corrected Swedish translations for copy failures and missing GPG configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->