### PR TITLE
Fix/weblate 1614 translation bugs

### DIFF
--- a/localization/localization_nl_NL.ts
+++ b/localization/localization_nl_NL.ts
@@ -647,7 +647,7 @@ e-mail</translation>
     <message>
         <location filename="../src/executor.cpp" line="106"/>
         <source>Failed to start %1</source>
-        <translation>Beginnen met %1 mislukt</translation>
+        <translation>Kon %1 niet starten</translation>
     </message>
 </context>
 <context>
@@ -853,7 +853,7 @@ Je kan nieuw toegevoegde wachtwoorden niet uitlezen!</translation>
     <message>
         <location filename="../src/imitatepass.cpp" line="933"/>
         <source>Could not copy %1 to %2.</source>
-        <translation>Kon %1 niet kopiëren naar % 2.</translation>
+        <translation>Kon %1 niet kopiëren naar %2.</translation>
     </message>
 </context>
 <context>
@@ -1767,7 +1767,7 @@ Doorgaan?</translation>
     <message>
         <location filename="../src/pass.cpp" line="452"/>
         <source>No GPG executable configured</source>
-        <translation>Geen GPG toepassing geconfigureerd</translation>
+        <translation>Geen GPG-programma geconfigureerd</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="557"/>

--- a/localization/localization_sv.ts
+++ b/localization/localization_sv.ts
@@ -811,7 +811,7 @@ Du kommer inte att kunna avkryptera några nyligen tillagda lösenord!</translat
     <message>
         <location filename="../src/imitatepass.cpp" line="932"/>
         <source>Copy failed</source>
-        <translation>Kopering misslyckades</translation>
+        <translation>Kopiering misslyckades</translation>
     </message>
     <message>
         <location filename="../src/imitatepass.cpp" line="933"/>
@@ -1642,7 +1642,7 @@ Fortsätta?</translation>
     <message>
         <location filename="../src/pass.cpp" line="452"/>
         <source>No GPG executable configured</source>
-        <translation>Ingen GPG exekverbar fil konfigurerad</translation>
+        <translation>Ingen körbar GPG-fil har konfigurerats.</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="557"/>

--- a/localization/localization_sv.ts
+++ b/localization/localization_sv.ts
@@ -1642,7 +1642,7 @@ Fortsätta?</translation>
     <message>
         <location filename="../src/pass.cpp" line="452"/>
         <source>No GPG executable configured</source>
-        <translation>Ingen körbar GPG-fil har konfigurerats.</translation>
+        <translation>Ingen körbar GPG-fil har konfigurerats</translation>
     </message>
     <message>
         <location filename="../src/pass.cpp" line="557"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Dutch translations for executor startup errors, file-copy failures, and missing GPG executable messages.
  * Corrected Swedish translations for copy failures and missing GPG executable configuration messages.
  * Fixed spacing in a Dutch placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->