### PR TITLE
ci: fix Qt 6.11 install and super-linter status 403

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -110,7 +110,12 @@ jobs:
         if: steps.need_build.outputs.run_build == 'true'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: ${{ matrix.qt }}
+          # Pin the 6.11 series to 6.11.1: the bare "6.11" spec resolves to the
+          # newest patch (6.11.2), whose archives download.qt.io fails to serve
+          # ("Failed to download checksum ... from mirrors"), breaking every
+          # build. 6.11.1 is the known-good patch (also the first with the macOS
+          # __yield fix). Drop this override once 6.11.2 mirrors propagate.
+          version: ${{ matrix.qt == '6.11' && '6.11.1' || matrix.qt }}
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && steps.need_build.outputs.run_build == 'true'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -134,3 +134,8 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The job runs with a read-only token (no statuses: write), so
+          # super-linter's per-linter commit-status POSTs return HTTP 403 and
+          # fail the job even when every linter passes. Disable the status
+          # writes; the job's own check result already reports pass/fail.
+          MULTI_STATUS: false


### PR DESCRIPTION
## Summary
Two unrelated **CI infrastructure** failures, both hitting every PR that builds code or runs the linters (surfaced on #1625, but not caused by it):

### 1. Qt 6.11 builds fail in "Install Qt"
`aqtinstall` resolves the bare `"6.11"` spec to the newest patch **6.11.2** (published 2026-08-13), whose archives `download.qt.io` currently fails to serve:
```
ERROR: Failed to download checksum for the file '6.11.2-...qtsvg-...7z' from mirrors '['https://download.qt.io']
```
Pinned the 6.11 matrix entries to the known-good **6.11.1** (also the first patch with the macOS `__yield` fix). The check names stay `build (…, 6.11)` via a matrix expression, so required-status-check config is unaffected. Revert once 6.11.2 mirrors propagate.

### 2. `Lint Code Base` fails despite `Failed checks: 0`
super-linter (v8.7.0, bumped in #1595) POSTs a per-linter commit status for each tool, but the job runs with a read-only token (no `statuses: write`):
```
[ERROR] Failed to call GitHub API (.../statuses/...) with POST HTTP method: curl: (22) ... error: 403
```
Each 403 fails the job even though every linter passed. Set `MULTI_STATUS=false` to disable the status writes — the job's own check result already reports pass/fail. Keeps the token least-privilege (no new `statuses: write` grant, no status-check spam on PRs).

## Validation
- Both files pass `prettier --check`.
- 5.15 / 6.8 / Windows builds were already green and are untouched.
- The fix validates itself when this PR's own CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build configuration to use the intended Qt 6.11.1 version.
  * Reduced redundant status updates from automated linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->