### PR TITLE
[DO NOT MERGE] ci: validate Qt 6.11.1 build pin

### DIFF
--- a/qtpass.pro
+++ b/qtpass.pro
@@ -1,5 +1,6 @@
 # QtPass - GUI for pass
 # SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
+# CI validation: exercise the Qt 6.11.1 build pin from #1627 (do not merge).
 
 !include(qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 


### PR DESCRIPTION
Throwaway PR to prove #1627's Qt 6.11.1 pin actually builds. It touches a build-filtered file so the QMake workflow runs the 6.11 matrix (ubuntu + macOS) and installs **6.11.1** instead of the unavailable 6.11.2.

**Do not merge** — close once the `build (ubuntu-latest, 6.11)` and `build (macos-latest, 6.11)` checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note documenting CI validation for the Qt 6.11.1 build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->