### PR TITLE
ci: pin release macOS build to Qt 6.11.1

### DIFF
--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -178,7 +178,9 @@ jobs:
           # its Xcode 26.x clang rejects the ARM __yield intrinsic used by
           # Qt 6.8.x's qyieldcpu.h. 6.11 reordered that header to prefer
           # __builtin_arm_yield, so it compiles cleanly.
-          version: "6.11"
+          # Pinned to 6.11.1: the bare "6.11" spec resolves to 6.11.2, whose
+          # archives download.qt.io fails to serve. Drop once mirrors catch up.
+          version: "6.11.1"
 
       - name: Install dmg helper
         if: steps.need_build.outputs.run_build == 'true'


### PR DESCRIPTION
## Summary
Follow-up to #1627. That PR fixed the `6.11` → 6.11.2 download breakage in `ccpp.yml`, but the **Release Build** workflow (`release-installers.yml`) has its own `install-qt-action` step that was missed — its `build-macos` job still pins the bare `"6.11"` spec and fails at **Install Qt**:
```
X Run jurplel/install-qt-action@v4.3.1
Error: The process '.../python3' failed with exit code 1
```
(Run: https://github.com/IJHack/QtPass/actions/runs/31850215012)

Pinned that job to the known-good **6.11.1**. This is the 4th and last of the red checks on code PRs (e.g. #1625): `build-macos`.

## Scope
- `release-installers.yml` **windows** job → Qt 6.8, untouched.
- `codeql.yml` / `docs.yml` `install-qt-action` steps specify no `version:` (non-6.11 default) and are green — untouched.

## Validation
- `prettier --check` clean.
- The `build-macos` check runs on this PR (its `.github/**` change trips the docs/build filters), so this PR validates its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS installer build configuration to use a fixed Qt version, improving build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->