### PR TITLE
[DO NOT MERGE] ci: validate release macOS Qt 6.11.1 pin

### DIFF
--- a/qtpass.pro
+++ b/qtpass.pro
@@ -1,5 +1,6 @@
 # QtPass - GUI for pass
 # SPDX-FileCopyrightText: 2014 Anne Jan Brouwer
+# CI validation: exercise the release build-macos Qt 6.11.1 pin (do not merge).
 
 !include(qtpass.pri) { error("Couldn't find the qtpass.pri file!") }
 


### PR DESCRIPTION
Throwaway to prove #1629 — trips the `qt` filter so the Release Build `build-macos` job runs and installs Qt **6.11.1**. Do not merge; close once `build-macos` is green. 🤖